### PR TITLE
Rewrite P/Invoke generator using Roslyn

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -30,6 +30,8 @@
     <PackageReference Update="libClang" Version="10.0.0" />
     <PackageReference Update="libClangSharp" Version="10.0.0-beta1" />
     <PackageReference Update="Microsoft.Bcl.HashCode" Version="1.1.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="3.5.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.5.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Update="System.CommandLine" Version="2.0.0-beta1.20158.1" />

--- a/sources/ClangSharp.PInvokeGenerator/Builders/PInvokeBuilder.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Builders/PInvokeBuilder.cs
@@ -1,0 +1,43 @@
+using System;
+using ClangSharp.Interop;
+using Microsoft.CodeAnalysis;
+
+using NativeType = ClangSharp.Type;
+using ManagedType = System.Type;
+
+namespace ClangSharp
+{
+    public sealed class PInvokeBuilder : IDisposable
+    {
+        private readonly PInvokeGeneratorConfiguration _config;
+        private readonly Index _index;
+        private readonly Workspace _workspace;
+
+        public string LibraryName { get; set; }
+
+        public CXIndex IndexHandle => _index.Handle;
+        public Workspace Workspace => _workspace;
+
+        public PInvokeBuilder(PInvokeGeneratorConfiguration configuration)
+        {
+            _config = configuration;
+            _index = Index.Create();
+            _workspace = new AdhocWorkspace();
+        }
+
+        /*public PInvokeDocumentBuilder AddFile(string path)
+        {
+            var error = CXTranslationUnit.TryParse(IndexHandle, path, )
+            TranslationUnit.GetOrCreate
+
+
+            return this;
+        }*/
+
+        public void Dispose()
+        {
+            _workspace?.Dispose();
+            _index?.Dispose();
+        }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Builders/PInvokeMethodBuilder.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Builders/PInvokeMethodBuilder.cs
@@ -1,0 +1,368 @@
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using ClangSharp.Interop;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+using NativeType = ClangSharp.Type;
+using ManagedType = System.Type;
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    public sealed class PInvokeMethodBuilder
+    {
+        private readonly PInvokeBuilder _builder;
+
+        public FunctionDecl NativeMethod { get; }
+
+        public PInvokeMethodBuilder(PInvokeBuilder builder,
+            FunctionDecl nativeMethod)
+        {
+            _builder = builder;
+            NativeMethod = nativeMethod;
+        }
+
+        public MethodDeclarationSyntax Build()
+        {
+            return MethodDeclaration(
+                attributeLists: new SyntaxList<AttributeListSyntax>(
+                    BuildAttributes()),
+                modifiers: new SyntaxTokenList(GetMethodModifiers(NativeMethod)),
+                returnType: BuildManagedType(NativeMethod.ReturnType),
+                explicitInterfaceSpecifier: null,
+                identifier: Identifier(NativeMethod.Name),
+                typeParameterList: null,
+                parameterList: ParameterList(SeparatedList(
+                    BuildParameters())),
+                constraintClauses: default,
+                body: null,
+                expressionBody: null,
+                semicolonToken: Token(SyntaxKind.SemicolonToken)
+            ).WithLeadingTrivia(
+                TriviaList(BuildComments(NativeMethod)));
+
+            static IEnumerable<SyntaxToken> GetMethodModifiers(FunctionDecl method)
+            {
+                yield return Token(SyntaxKind.PublicKeyword);
+
+                if (method.ReturnType.Kind == CXTypeKind.CXType_Pointer)
+                    yield return Token(SyntaxKind.UnsafeKeyword);
+
+                yield return Token(SyntaxKind.StaticKeyword);
+                yield return Token(SyntaxKind.ExternKeyword);
+            }
+        }
+
+        private IEnumerable<AttributeListSyntax> BuildAttributes()
+        {
+            if (NativeMethod.ReturnType != NativeMethod.ReturnType.CanonicalType)
+                yield return AttributeList(
+                    AttributeTargetSpecifier(
+                        Identifier("return")),
+                    SingletonSeparatedList(
+                        Attribute(
+                            IdentifierName("NativeTypeName"),
+                            AttributeArgumentList(
+                                SingletonSeparatedList(
+                                    AttributeArgument(
+                                        LiteralExpression(SyntaxKind.StringLiteralExpression,
+                                            Literal(NativeMethod.ReturnType.AsString))
+                                    )
+                                )
+                            ))
+                    ));
+
+            yield return AttributeList(
+                SingletonSeparatedList(
+                    Attribute(
+                        QualifiedName(
+                            QualifiedName(
+                                QualifiedName(
+                                    IdentifierName("System"),
+                                    IdentifierName("Runtime")
+                                ),
+                                IdentifierName("InteropServices")
+                            ),
+                            IdentifierName("DllImport")
+                        ),
+                        AttributeArgumentList(
+                            SeparatedList(GenerateDllImportArguments(NativeMethod, _builder))
+                        ))
+                ));
+
+            static IEnumerable<AttributeArgumentSyntax> GenerateDllImportArguments(
+                FunctionDecl decl, PInvokeBuilder builder)
+            {
+                yield return AttributeArgument(
+                        LiteralExpression(SyntaxKind.StringLiteralExpression,
+                            Literal(builder.LibraryName)));
+
+                var callingConvention = CallingConvention.Cdecl;
+
+                if (decl.HasAttrs)
+                {
+                    foreach (var attr in decl.Attrs)
+                    {
+                        if (attr.Kind == CX_AttrKind.CX_AttrKind_CDecl)
+                        {
+                            callingConvention = CallingConvention.Cdecl;
+                        }
+                    }
+                }
+
+                yield return AttributeArgument(
+                    AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
+                        IdentifierName("CallingConvention"),
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                                        IdentifierName("System"),
+                                        IdentifierName("Runtime")
+                                    ),
+                                    IdentifierName("InteropServices")
+                                ),
+                                IdentifierName("CallingConvention")
+                            ),
+                            IdentifierName(callingConvention.ToString())
+                        )
+                    )
+                );
+            }
+        }
+
+        private IEnumerable<ParameterSyntax> BuildParameters()
+        {
+            foreach (var parameter in NativeMethod.Parameters)
+            {
+                var builder = new PInvokeParameterBuilder(_builder, parameter);
+
+                yield return builder.Build();
+            }
+        }
+
+        private static IEnumerable<SyntaxTrivia> BuildComments(FunctionDecl method)
+        {
+            method.Location.GetPresumedLocation(out var fileName, out var line, out var col);
+
+            yield return Comment($"// Defined in: {fileName} ({line}:{col})");
+
+            var comment = method.Handle.ParsedComment;
+
+            if (comment.Kind == CXCommentKind.CXComment_Null)
+                yield break;
+
+
+
+            yield return Trivia(
+                DocumentationCommentTrivia(
+                    SyntaxKind.SingleLineDocumentationCommentTrivia,
+                    List(GetComments(comment)),
+                    Token(SyntaxKind.EndOfDocumentationCommentToken)
+                )
+            );
+
+            static IEnumerable<XmlNodeSyntax> GetComments(CXComment comment,
+                bool isFirstParagraph = true)
+            {
+                if (comment.Kind == CXCommentKind.CXComment_FullComment)
+                {
+                    yield return XmlText(" ")
+                        .WithLeadingTrivia(TriviaList(
+                            DocumentationCommentExterior("///")
+                        ));
+                }
+
+                for (uint x = 0; x < comment.NumChildren; x++)
+                {
+                    var child = comment.GetChild(x);
+
+                    switch (child.Kind)
+                    {
+                        case CXCommentKind.CXComment_Text:
+                            var text = child.TextComment_Text.CString.Trim();
+
+                            if (text.Length > 0)
+                            {
+                                yield return XmlText(TokenList(
+                                    XmlTextLiteral($" {text}"),
+                                    XmlTextNewLine("\r\n"),
+                                    XmlTextLiteral(" "))
+                                )
+                                .WithLeadingTrivia(TriviaList(
+                                    DocumentationCommentExterior("///")
+                                ));
+                            }
+                            break;
+                        case CXCommentKind.CXComment_InlineCommand:
+                            //break;
+                        case CXCommentKind.CXComment_HTMLStartTag:
+                            //break;
+                        case CXCommentKind.CXComment_HTMLEndTag:
+                            goto default;
+                            //break;
+                        case CXCommentKind.CXComment_Paragraph:
+                            if (isFirstParagraph)
+                            {
+                                var summary = XmlSummaryElement(
+                                    List(
+                                        GetComments(child, false)
+                                    )
+                                );
+
+                                if (!summary.Content.Any(SyntaxKind.XmlText))
+                                    break;
+
+                                yield return summary;
+                                isFirstParagraph = false;
+                            }
+                            else
+                            {
+                                foreach (var elem in GetComments(child, isFirstParagraph))
+                                    yield return elem;
+                            }
+                            break;
+                        case CXCommentKind.CXComment_BlockCommand:
+                            foreach (var elem in GetBlockComment(child))
+                                yield return elem;
+
+                            break;
+                        case CXCommentKind.CXComment_ParamCommand:
+                            yield return XmlText(" ")
+                                .WithLeadingTrivia(TriviaList(
+                                    DocumentationCommentExterior("///")
+                                ));
+
+                            yield return XmlParamElement(
+                                child.ParamCommandComment_ParamName.CString.Trim(),
+                                List(
+                                    GetComments(child, false)
+                                )
+                            );
+
+                            yield return XmlText(
+                                XmlTextNewLine("\r\n")
+                                    .WithoutTrivia());
+                            break;
+                        case CXCommentKind.CXComment_TParamCommand:
+                            //break;
+                        case CXCommentKind.CXComment_VerbatimBlockCommand:
+                            //break;
+                        case CXCommentKind.CXComment_VerbatimBlockLine:
+                            //break;
+                        case CXCommentKind.CXComment_VerbatimLine:
+                            //break;
+                        case CXCommentKind.CXComment_FullComment:
+                            //break;
+
+                        default:
+                            foreach (var elem in GetComments(child, isFirstParagraph))
+                                yield return elem;
+                            break;
+                    }
+                }
+
+                if (comment.Kind == CXCommentKind.CXComment_FullComment)
+                {
+                    yield return XmlText(
+                        XmlTextNewLine("\r\n")
+                            .WithoutTrivia());
+                }
+
+                static IEnumerable<XmlNodeSyntax> GetBlockComment(CXComment comment)
+                {
+                    switch (comment.BlockCommandComment_CommandName.CString)
+                    {
+                        case "see":
+                        case "sa":
+                            var cref = comment.BlockCommandComment_Paragraph.GetChild(0);
+                            yield return XmlText(" ")
+                                .WithLeadingTrivia(TriviaList(
+                                    DocumentationCommentExterior("///")
+                                ));
+                            yield return XmlEmptyElement(
+                                XmlName("seealso"),
+                                SingletonList<XmlAttributeSyntax>(
+                                    XmlCrefAttribute(
+                                        NameMemberCref(
+                                            ParseName(
+                                                cref.TextComment_Text.CString.Trim(),
+                                                consumeFullText: false)
+                                        )
+                                    )
+                                )
+                            );
+
+                            break;
+                        case "brief":
+                            yield return XmlSummaryElement(
+                                List(
+                                    GetComments(comment, false)
+                                )
+                            );
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
+
+        private static TypeSyntax BuildManagedType(NativeType nativeType)
+        {
+            // Ensure we're dealing with the canonical type for this, rather
+            // than an alias.
+            nativeType = nativeType.CanonicalType;
+
+            return GetManagedType(nativeType.Handle);
+
+            static TypeSyntax GetManagedType(CXType type)
+            {
+                switch (type.kind)
+                {
+                    case CXTypeKind.CXType_Pointer:
+                        return Pointer(type);
+                    case CXTypeKind.CXType_SChar:
+                        return PredefinedType(
+                            Token(SyntaxKind.SByteKeyword));
+                    case CXTypeKind.CXType_UChar:
+                        return PredefinedType(
+                            Token(SyntaxKind.ByteKeyword));
+                    case CXTypeKind.CXType_Short:
+                        return PredefinedType(
+                            Token(SyntaxKind.ShortKeyword));
+                    case CXTypeKind.CXType_UShort:
+                        return PredefinedType(
+                            Token(SyntaxKind.UShortKeyword));
+                    case CXTypeKind.CXType_Int:
+                        return PredefinedType(
+                            Token(SyntaxKind.IntKeyword));
+                    case CXTypeKind.CXType_UInt:
+                        return PredefinedType(
+                            Token(SyntaxKind.UIntKeyword));
+                    case CXTypeKind.CXType_Long:
+                    case CXTypeKind.CXType_ULong:
+                        Debug.Fail("No .NET type correctly maps to long/unsigned long");
+                        return null;
+                    case CXTypeKind.CXType_LongLong:
+                        return PredefinedType(
+                            Token(SyntaxKind.LongKeyword));
+                    case CXTypeKind.CXType_ULongLong:
+                        return PredefinedType(
+                            Token(SyntaxKind.ULongKeyword));
+                }
+
+                Debug.Fail($"Unsupported type: {type.kind} ({type.Spelling.CString})");
+                return null;
+            }
+
+            static TypeSyntax Pointer(CXType type)
+            {
+                return PointerType(GetManagedType(type.PointeeType));
+            }
+        }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/Builders/PInvokeParameterBuilder.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Builders/PInvokeParameterBuilder.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using ClangSharp.Interop;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+using NativeType = ClangSharp.Type;
+using ManagedType = System.Type;
+using System.Diagnostics;
+
+namespace ClangSharp
+{
+    public sealed class PInvokeParameterBuilder
+    {
+        private readonly PInvokeBuilder _builder;
+
+        public ParmVarDecl NativeParam { get; }
+
+        public PInvokeParameterBuilder(PInvokeBuilder builder,
+            ParmVarDecl nativeParam)
+        {
+            _builder = builder;
+            NativeParam = nativeParam;
+        }
+
+        public ParameterSyntax Build()
+        {
+            return Parameter(
+                List(BuildAttributes()),
+                TokenList(),
+                type: BuildManagedType(NativeParam.Type),
+                identifier: Identifier(NativeParam.Name),
+                @default: null
+            );
+        }
+
+        private IEnumerable<AttributeListSyntax> BuildAttributes()
+        {
+            if (NativeParam.Type != NativeParam.Type.CanonicalType)
+                yield return AttributeList(
+                    AttributeTargetSpecifier(
+                        Identifier("return")),
+                    SingletonSeparatedList(
+                        Attribute(
+                            IdentifierName("NativeTypeName"),
+                            AttributeArgumentList(
+                                SingletonSeparatedList(
+                                    AttributeArgument(
+                                        LiteralExpression(SyntaxKind.StringLiteralExpression,
+                                            Literal(NativeParam.Type.AsString))
+                                    )
+                                )
+                            ))
+                    ));
+        }
+
+        private static TypeSyntax BuildManagedType(NativeType nativeType)
+        {
+            // Ensure we're dealing with the canonical type for this, rather
+            // than an alias.
+            nativeType = nativeType.CanonicalType;
+
+            return GetManagedType(nativeType.Handle);
+
+            static TypeSyntax GetManagedType(CXType type)
+            {
+                switch (type.kind)
+                {
+                    case CXTypeKind.CXType_Pointer:
+                        return Pointer(type);
+
+                    case CXTypeKind.CXType_Char_S:
+                        return PredefinedType(
+                            Token(SyntaxKind.CharKeyword));
+
+                    case CXTypeKind.CXType_SChar:
+                        return PredefinedType(
+                            Token(SyntaxKind.SByteKeyword));
+                    case CXTypeKind.CXType_UChar:
+                        return PredefinedType(
+                            Token(SyntaxKind.ByteKeyword));
+                    case CXTypeKind.CXType_Short:
+                        return PredefinedType(
+                            Token(SyntaxKind.ShortKeyword));
+                    case CXTypeKind.CXType_UShort:
+                        return PredefinedType(
+                            Token(SyntaxKind.UShortKeyword));
+                    case CXTypeKind.CXType_Int:
+                        return PredefinedType(
+                            Token(SyntaxKind.IntKeyword));
+                    case CXTypeKind.CXType_UInt:
+                        return PredefinedType(
+                            Token(SyntaxKind.UIntKeyword));
+                    case CXTypeKind.CXType_Long:
+                    case CXTypeKind.CXType_ULong:
+                        Debug.Fail("No .NET type correctly maps to long/unsigned long");
+                        return null;
+                    case CXTypeKind.CXType_LongLong:
+                        return PredefinedType(
+                            Token(SyntaxKind.LongKeyword));
+                    case CXTypeKind.CXType_ULongLong:
+                        return PredefinedType(
+                            Token(SyntaxKind.ULongKeyword));
+                }
+
+                Debug.Fail($"Unsupported type: {type.kind} ({type.Spelling.CString})");
+                return null;
+            }
+
+            static TypeSyntax Pointer(CXType type)
+            {
+                return PointerType(GetManagedType(type.PointeeType));
+            }
+        }
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/ClangSharp.PInvokeGenerator.csproj
+++ b/sources/ClangSharp.PInvokeGenerator/ClangSharp.PInvokeGenerator.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ClangSharp\ClangSharp.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
**NOTE:** This is super *super* alpha; all I did was get a small sample application working before pushing these commits for now.

Rewriting the P/Invoke generator using Roslyn should allow us in the future to modify it to work with new features like source generators, which could make generating P/Invoke signatures *really* easy. (See #127)

However, no current public API has been properly designed or considered; what is here is currently the "bare minimum" in order to get something working. I do hope that this minimal example can solicit some dialogue, and hopefully eventually a final design.