### PR TITLE
Add tests for anonymous enums

### DIFF
--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/EnumDeclarationTest.cs
@@ -63,6 +63,12 @@ public abstract class EnumDeclarationTest : PInvokeGeneratorTest
     [Test]
     public Task WithTypeStarOverrideTest() => WithTypeStarOverrideTestImpl();
 
+    [Test]
+    public Task WithAnonymousEnumTest() => WithAnonymousEnumTestImpl();
+
+    [Test]
+    public Task WithReferenceToAnonymousEnumEnumeratorTest() => WithReferenceToAnonymousEnumEnumeratorTestImpl();
+
     protected abstract Task BasicTestImpl();
 
     protected abstract Task BasicValueTestImpl();
@@ -72,6 +78,7 @@ public abstract class EnumDeclarationTest : PInvokeGeneratorTest
     protected abstract Task ExplicitTypedTestImpl(string nativeType, string expectedManagedType);
 
     protected abstract Task ExplicitTypedWithNativeTypeNameTestImpl(string nativeType, string expectedManagedType);
+
 
     protected abstract Task RemapTestImpl();
 
@@ -96,4 +103,8 @@ public abstract class EnumDeclarationTest : PInvokeGeneratorTest
     protected abstract Task WithTypeStarTestImpl();
 
     protected abstract Task WithTypeStarOverrideTestImpl();
+
+    protected abstract Task WithAnonymousEnumTestImpl();
+
+    protected abstract Task WithReferenceToAnonymousEnumEnumeratorTestImpl();
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/EnumDeclarationTest.cs
@@ -550,4 +550,61 @@ enum MyEnum2 : int
         };
         return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, withTypes: withTypes);
     }
+    protected override Task WithAnonymousEnumTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+enum MyEnum2 : int
+{
+    MyEnum2_Value1 = MyEnum1_Value1,
+};
+";
+
+        var expectedOutputContents = @"using static ClangSharp.Test.Methods;
+
+namespace ClangSharp.Test
+{
+    public enum MyEnum2
+    {
+        MyEnum2_Value1 = MyEnum1_Value1,
+    }
+
+    public static partial class Methods
+    {
+        public const int MyEnum1_Value1 = 1;
+    }
+}
+";
+
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
+
+    protected override Task WithReferenceToAnonymousEnumEnumeratorTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+const int MyEnum2_Value1 = MyEnum1_Value1 + 1;
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        public const int MyEnum1_Value1 = 1;
+
+        [NativeTypeName(""const int"")]
+        public const int MyEnum2_Value1 = (int)(MyEnum1_Value1) + 1;
+    }
+}
+";
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/EnumDeclarationTest.cs
@@ -550,4 +550,62 @@ enum MyEnum2 : int
         };
         return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, withTypes: withTypes);
     }
+
+    protected override Task WithAnonymousEnumTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+enum MyEnum2 : int
+{
+    MyEnum2_Value1 = MyEnum1_Value1,
+};
+";
+
+        var expectedOutputContents = @"using static ClangSharp.Test.Methods;
+
+namespace ClangSharp.Test
+{
+    public enum MyEnum2
+    {
+        MyEnum2_Value1 = MyEnum1_Value1,
+    }
+
+    public static partial class Methods
+    {
+        public const int MyEnum1_Value1 = 1;
+    }
+}
+";
+
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
+
+    protected override Task WithReferenceToAnonymousEnumEnumeratorTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+const int MyEnum2_Value1 = MyEnum1_Value1 + 1;
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        public const int MyEnum1_Value1 = 1;
+
+        [NativeTypeName(""const int"")]
+        public const int MyEnum2_Value1 = (int)(MyEnum1_Value1) + 1;
+    }
+}
+";
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/EnumDeclarationTest.cs
@@ -550,4 +550,62 @@ enum MyEnum2 : int
         };
         return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents, withTypes: withTypes);
     }
+
+    protected override Task WithAnonymousEnumTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+enum MyEnum2 : int
+{
+    MyEnum2_Value1 = MyEnum1_Value1,
+};
+";
+
+        var expectedOutputContents = @"using static ClangSharp.Test.Methods;
+
+namespace ClangSharp.Test
+{
+    public enum MyEnum2
+    {
+        MyEnum2_Value1 = MyEnum1_Value1,
+    }
+
+    public static partial class Methods
+    {
+        public const int MyEnum1_Value1 = 1;
+    }
+}
+";
+
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
+
+    protected override Task WithReferenceToAnonymousEnumEnumeratorTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+const int MyEnum2_Value1 = MyEnum1_Value1 + 1;
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        public const int MyEnum1_Value1 = 1;
+
+        [NativeTypeName(""const int"")]
+        public const int MyEnum2_Value1 = (int)(MyEnum1_Value1) + 1;
+    }
+}
+";
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/EnumDeclarationTest.cs
@@ -550,4 +550,61 @@ enum MyEnum2 : int
         };
         return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, withTypes: withTypes);
     }
+    protected override Task WithAnonymousEnumTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+enum MyEnum2 : int
+{
+    MyEnum2_Value1 = MyEnum1_Value1,
+};
+";
+
+        var expectedOutputContents = @"using static ClangSharp.Test.Methods;
+
+namespace ClangSharp.Test
+{
+    public enum MyEnum2
+    {
+        MyEnum2_Value1 = MyEnum1_Value1,
+    }
+
+    public static partial class Methods
+    {
+        public const int MyEnum1_Value1 = 1;
+    }
+}
+";
+
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
+
+    protected override Task WithReferenceToAnonymousEnumEnumeratorTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+const int MyEnum2_Value1 = MyEnum1_Value1 + 1;
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        public const int MyEnum1_Value1 = 1;
+
+        [NativeTypeName(""const int"")]
+        public const int MyEnum2_Value1 = (int)(MyEnum1_Value1) + 1;
+    }
+}
+";
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/EnumDeclarationTest.cs
@@ -224,7 +224,7 @@ namespace ClangSharp.Test
 ";
 
         var withAttributes = new Dictionary<string, IReadOnlyList<string>>
-        {
+        { 
             ["MyEnum1"] = new List<string>() { "Flags" }
         };
         return ValidateGeneratedCSharpPreviewUnixBindingsAsync(inputContents, expectedOutputContents, withAttributes: withAttributes);
@@ -549,5 +549,63 @@ enum MyEnum2 : int
             ["MyEnum1"] = "int",
         };
         return ValidateGeneratedCSharpPreviewUnixBindingsAsync(inputContents, expectedOutputContents, withTypes: withTypes);
+    }
+
+    protected override Task WithAnonymousEnumTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+enum MyEnum2 : int
+{
+    MyEnum2_Value1 = MyEnum1_Value1,
+};
+";
+
+        var expectedOutputContents = @"using static ClangSharp.Test.Methods;
+
+namespace ClangSharp.Test
+{
+    public enum MyEnum2
+    {
+        MyEnum2_Value1 = MyEnum1_Value1,
+    }
+
+    public static partial class Methods
+    {
+        public const int MyEnum1_Value1 = 1;
+    }
+}
+";
+
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedCSharpPreviewUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
+
+    protected override Task WithReferenceToAnonymousEnumEnumeratorTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+const int MyEnum2_Value1 = MyEnum1_Value1 + 1;
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        public const int MyEnum1_Value1 = 1;
+
+        [NativeTypeName(""const int"")]
+        public const int MyEnum2_Value1 = (int)(MyEnum1_Value1) + 1;
+    }
+}
+";
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedCSharpPreviewUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/EnumDeclarationTest.cs
@@ -550,4 +550,62 @@ enum MyEnum2 : int
         };
         return ValidateGeneratedCSharpPreviewWindowsBindingsAsync(inputContents, expectedOutputContents, withTypes: withTypes);
     }
+
+    protected override Task WithAnonymousEnumTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+enum MyEnum2 : int
+{
+    MyEnum2_Value1 = MyEnum1_Value1,
+};
+";
+
+        var expectedOutputContents = @"using static ClangSharp.Test.Methods;
+
+namespace ClangSharp.Test
+{
+    public enum MyEnum2
+    {
+        MyEnum2_Value1 = MyEnum1_Value1,
+    }
+
+    public static partial class Methods
+    {
+        public const int MyEnum1_Value1 = 1;
+    }
+}
+";
+
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedCSharpPreviewWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
+
+    protected override Task WithReferenceToAnonymousEnumEnumeratorTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+const int MyEnum2_Value1 = MyEnum1_Value1 + 1;
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        public const int MyEnum1_Value1 = 1;
+
+        [NativeTypeName(""const int"")]
+        public const int MyEnum2_Value1 = (int)(MyEnum1_Value1) + 1;
+    }
+}
+";
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedCSharpPreviewWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/EnumDeclarationTest.cs
@@ -652,4 +652,79 @@ enum MyEnum2 : int
         };
         return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, withTypes: withTypes);
     }
+
+    protected override Task WithAnonymousEnumTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+enum MyEnum2 : int
+{
+    MyEnum2_Value1 = MyEnum1_Value1,
+};
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <enumeration name=""MyEnum2"" access=""public"">
+      <type>int</type>
+      <enumerator name=""MyEnum2_Value1"" access=""public"">
+        <type primitive=""False"">int</type>
+        <value>
+          <code>MyEnum1_Value1</code>
+        </value>
+      </enumerator>
+    </enumeration>
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyEnum1_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>1</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
+
+    protected override Task WithReferenceToAnonymousEnumEnumeratorTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+const int MyEnum2_Value1 = MyEnum1_Value1 + 1;
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyEnum1_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>1</code>
+        </value>
+      </constant>
+      <constant name=""MyEnum2_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>(int)(<value>MyEnum1_Value1</value>) + 1</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/EnumDeclarationTest.cs
@@ -652,4 +652,79 @@ enum MyEnum2 : int
         };
         return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, withTypes: withTypes);
     }
+
+    protected override Task WithAnonymousEnumTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+enum MyEnum2 : int
+{
+    MyEnum2_Value1 = MyEnum1_Value1,
+};
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <enumeration name=""MyEnum2"" access=""public"">
+      <type>int</type>
+      <enumerator name=""MyEnum2_Value1"" access=""public"">
+        <type primitive=""False"">int</type>
+        <value>
+          <code>MyEnum1_Value1</code>
+        </value>
+      </enumerator>
+    </enumeration>
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyEnum1_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>1</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
+
+    protected override Task WithReferenceToAnonymousEnumEnumeratorTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+const int MyEnum2_Value1 = MyEnum1_Value1 + 1;
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyEnum1_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>1</code>
+        </value>
+      </constant>
+      <constant name=""MyEnum2_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>(int)(<value>MyEnum1_Value1</value>) + 1</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/EnumDeclarationTest.cs
@@ -652,4 +652,79 @@ enum MyEnum2 : int
         };
         return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents, withTypes: withTypes);
     }
+
+    protected override Task WithAnonymousEnumTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+enum MyEnum2 : int
+{
+    MyEnum2_Value1 = MyEnum1_Value1,
+};
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <enumeration name=""MyEnum2"" access=""public"">
+      <type>int</type>
+      <enumerator name=""MyEnum2_Value1"" access=""public"">
+        <type primitive=""False"">int</type>
+        <value>
+          <code>MyEnum1_Value1</code>
+        </value>
+      </enumerator>
+    </enumeration>
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyEnum1_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>1</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
+
+    protected override Task WithReferenceToAnonymousEnumEnumeratorTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+const int MyEnum2_Value1 = MyEnum1_Value1 + 1;
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyEnum1_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>1</code>
+        </value>
+      </constant>
+      <constant name=""MyEnum2_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>(int)(<value>MyEnum1_Value1</value>) + 1</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/EnumDeclarationTest.cs
@@ -652,4 +652,79 @@ enum MyEnum2 : int
         };
         return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents, withTypes: withTypes);
     }
+
+    protected override Task WithAnonymousEnumTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+enum MyEnum2 : int
+{
+    MyEnum2_Value1 = MyEnum1_Value1,
+};
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <enumeration name=""MyEnum2"" access=""public"">
+      <type>int</type>
+      <enumerator name=""MyEnum2_Value1"" access=""public"">
+        <type primitive=""False"">int</type>
+        <value>
+          <code>MyEnum1_Value1</code>
+        </value>
+      </enumerator>
+    </enumeration>
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyEnum1_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>1</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
+
+    protected override Task WithReferenceToAnonymousEnumEnumeratorTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+const int MyEnum2_Value1 = MyEnum1_Value1 + 1;
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyEnum1_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>1</code>
+        </value>
+      </constant>
+      <constant name=""MyEnum2_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>(int)(<value>MyEnum1_Value1</value>) + 1</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/EnumDeclarationTest.cs
@@ -652,4 +652,79 @@ enum MyEnum2 : int
         };
         return ValidateGeneratedXmlPreviewUnixBindingsAsync(inputContents, expectedOutputContents, withTypes: withTypes);
     }
+
+    protected override Task WithAnonymousEnumTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+enum MyEnum2 : int
+{
+    MyEnum2_Value1 = MyEnum1_Value1,
+};
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <enumeration name=""MyEnum2"" access=""public"">
+      <type>int</type>
+      <enumerator name=""MyEnum2_Value1"" access=""public"">
+        <type primitive=""False"">int</type>
+        <value>
+          <code>MyEnum1_Value1</code>
+        </value>
+      </enumerator>
+    </enumeration>
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyEnum1_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>1</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedXmlPreviewUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
+
+    protected override Task WithReferenceToAnonymousEnumEnumeratorTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+const int MyEnum2_Value1 = MyEnum1_Value1 + 1;
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyEnum1_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>1</code>
+        </value>
+      </constant>
+      <constant name=""MyEnum2_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>(int)(<value>MyEnum1_Value1</value>) + 1</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedXmlPreviewUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/EnumDeclarationTest.cs
@@ -652,4 +652,79 @@ enum MyEnum2 : int
         };
         return ValidateGeneratedXmlPreviewWindowsBindingsAsync(inputContents, expectedOutputContents, withTypes: withTypes);
     }
+
+    protected override Task WithAnonymousEnumTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+enum MyEnum2 : int
+{
+    MyEnum2_Value1 = MyEnum1_Value1,
+};
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <enumeration name=""MyEnum2"" access=""public"">
+      <type>int</type>
+      <enumerator name=""MyEnum2_Value1"" access=""public"">
+        <type primitive=""False"">int</type>
+        <value>
+          <code>MyEnum1_Value1</code>
+        </value>
+      </enumerator>
+    </enumeration>
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyEnum1_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>1</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedXmlPreviewWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
+
+    protected override Task WithReferenceToAnonymousEnumEnumeratorTestImpl()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+const int MyEnum2_Value1 = MyEnum1_Value1 + 1;
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyEnum1_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>1</code>
+        </value>
+      </constant>
+      <constant name=""MyEnum2_Value1"" access=""public"">
+        <type primitive=""True"">int</type>
+        <value>
+          <code>(int)(<value>MyEnum1_Value1</value>) + 1</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedXmlPreviewWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }


### PR DESCRIPTION
Do not use the mangled anonymous name in `using static` directives. Additionally, a `using static` directive should not be added when members of the enum are already available in context (for example, when inside the method class.)