### PR TITLE
Translate temporary object expressions as constructor invocations

### DIFF
--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CXXMethodDeclarationTest.cs
@@ -128,6 +128,48 @@ namespace ClangSharp.UnitTests
         }
 
         [Fact]
+        public async Task ConstructorInvocationTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    MyStruct(int val)
+    {
+        value = val;
+    }
+
+    static MyStruct get()
+    {
+        return MyStruct(10);
+    }
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int value;
+
+        public MyStruct(int val)
+        {
+            value = val;
+        }
+
+        public static MyStruct get()
+        {
+            return new MyStruct(10);
+        }
+    }
+}
+";
+
+            await ValidateGeneratedBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+
+        [Fact]
         public async Task DestructorTest()
         {
             var inputContents = @"struct MyStruct


### PR DESCRIPTION
Translate 
```cpp
X create_X() 
{
    return X(1, 3.14f);
}
```
 as 
```cs
X create_X() 
{
    return new X(1, 3.14f);
}
