### PR TITLE
Add remaps for copy, move and deref operators

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -3808,6 +3808,15 @@ namespace ClangSharp
                     return true;
                 }
 
+                case "operator=":
+                {
+                    var sourceParameterIndex = functionDecl.IsInstance ? 0 : 1;
+                    name = numArgs > 1 && functionDecl.Parameters[sourceParameterIndex].Type.TypeClass == CX_TypeClass.CX_TypeClass_RValueReference
+                           ? "MoveFrom"
+                           : "CopyFrom";
+                    return true;
+                }
+
                 default:
                 {
                     return false;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -3726,7 +3726,7 @@ namespace ClangSharp
 
                 case "operator*":
                 {
-                    name = "Multiply";
+                    name = (numArgs == 1) ? "Dereference" : "Multiply";
                     return true;
                 }
 
@@ -3814,6 +3814,12 @@ namespace ClangSharp
                     name = numArgs > 1 && functionDecl.Parameters[sourceParameterIndex].Type.TypeClass == CX_TypeClass.CX_TypeClass_RValueReference
                            ? "MoveFrom"
                            : "CopyFrom";
+                    return true;
+                }
+
+                case "operator->":
+                {
+                    name = "Access";
                     return true;
                 }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationTest.cs
@@ -41,6 +41,9 @@ namespace ClangSharp.UnitTests
         public abstract Task OperatorTest();
 
         [Fact]
+        public abstract Task CopyAndMoveOperatorTest();
+
+        [Fact]
         public abstract Task OperatorCallTest();
 
         [Fact]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -591,6 +591,65 @@ MyStruct operator-(MyStruct lhs, MyStruct rhs)
             return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveOperatorTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    MyStruct(int value) : value(value)
+    {
+    }
+
+    MyStruct operator+(MyStruct rhs)
+    {
+        return MyStruct(value + rhs.value);
+    }
+
+    void operator=(const MyStruct& other)
+    {
+        value = other.value;
+    }
+
+    void operator=(MyStruct&& other)
+    {
+        value = other.value;
+    }
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int value;
+
+        public MyStruct(int value)
+        {
+            this.value = value;
+        }
+
+        public MyStruct Add(MyStruct rhs)
+        {
+            return new MyStruct(value + rhs.value);
+        }
+
+        public unsafe void CopyFrom([NativeTypeName(""const MyStruct &"")] MyStruct* other)
+        {
+            value = other->value;
+        }
+
+        public unsafe void MoveFrom([NativeTypeName(""MyStruct &&"")] MyStruct* other)
+        {
+            value = other->value;
+        }
+    }
+}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task OperatorCallTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -591,6 +591,65 @@ MyStruct operator-(MyStruct lhs, MyStruct rhs)
             return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveOperatorTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    MyStruct(int value) : value(value)
+    {
+    }
+
+    MyStruct operator+(MyStruct rhs)
+    {
+        return MyStruct(value + rhs.value);
+    }
+
+    void operator=(const MyStruct& other)
+    {
+        value = other.value;
+    }
+
+    void operator=(MyStruct&& other)
+    {
+        value = other.value;
+    }
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int value;
+
+        public MyStruct(int value)
+        {
+            this.value = value;
+        }
+
+        public MyStruct Add(MyStruct rhs)
+        {
+            return new MyStruct(value + rhs.value);
+        }
+
+        public unsafe void CopyFrom([NativeTypeName(""const MyStruct &"")] MyStruct* other)
+        {
+            value = other->value;
+        }
+
+        public unsafe void MoveFrom([NativeTypeName(""MyStruct &&"")] MyStruct* other)
+        {
+            value = other->value;
+        }
+    }
+}
+";
+
+            return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task OperatorCallTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
@@ -553,6 +553,65 @@ MyStruct operator-(MyStruct lhs, MyStruct rhs)
             return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveOperatorTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    MyStruct(int value) : value(value)
+    {
+    }
+
+    MyStruct operator+(MyStruct rhs)
+    {
+        return MyStruct(value + rhs.value);
+    }
+
+    void operator=(const MyStruct& other)
+    {
+        value = other.value;
+    }
+
+    void operator=(MyStruct&& other)
+    {
+        value = other.value;
+    }
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int value;
+
+        public MyStruct(int value)
+        {
+            this.value = value;
+        }
+
+        public MyStruct Add(MyStruct rhs)
+        {
+            return new MyStruct(value + rhs.value);
+        }
+
+        public unsafe void CopyFrom([NativeTypeName(""const MyStruct &"")] MyStruct* other)
+        {
+            value = other->value;
+        }
+
+        public unsafe void MoveFrom([NativeTypeName(""MyStruct &&"")] MyStruct* other)
+        {
+            value = other->value;
+        }
+    }
+}
+";
+
+            return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task OperatorCallTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -553,6 +553,65 @@ MyStruct operator-(MyStruct lhs, MyStruct rhs)
             return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveOperatorTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    MyStruct(int value) : value(value)
+    {
+    }
+
+    MyStruct operator+(MyStruct rhs)
+    {
+        return MyStruct(value + rhs.value);
+    }
+
+    void operator=(const MyStruct& other)
+    {
+        value = other.value;
+    }
+
+    void operator=(MyStruct&& other)
+    {
+        value = other.value;
+    }
+};
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int value;
+
+        public MyStruct(int value)
+        {
+            this.value = value;
+        }
+
+        public MyStruct Add(MyStruct rhs)
+        {
+            return new MyStruct(value + rhs.value);
+        }
+
+        public unsafe void CopyFrom([NativeTypeName(""const MyStruct &"")] MyStruct* other)
+        {
+            value = other->value;
+        }
+
+        public unsafe void MoveFrom([NativeTypeName(""MyStruct &&"")] MyStruct* other)
+        {
+            value = other->value;
+        }
+    }
+}
+";
+
+            return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task OperatorCallTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -718,6 +718,79 @@ MyStruct operator-(MyStruct lhs, MyStruct rhs)
             return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveOperatorTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    MyStruct(int value) : value(value)
+    {
+    }
+
+    MyStruct operator+(MyStruct rhs)
+    {
+        return MyStruct(value + rhs.value);
+    }
+
+    void operator=(const MyStruct& other)
+    {
+        value = other.value;
+    }
+
+    void operator=(MyStruct&& other)
+    {
+        value = other.value;
+    }
+};
+";
+
+            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <field name=""value"" access=""public"">
+        <type>int</type>
+      </field>
+      <function name=""MyStruct"" access=""public"">
+        <type>void</type>
+        <param name=""value"">
+          <type>int</type>
+        </param>
+        <init field=""value"" hint=""value"">
+          <code>value</code>
+        </init>
+        <code></code>
+      </function>
+      <function name=""Add"" access=""public"">
+        <type>MyStruct</type>
+        <param name=""rhs"">
+          <type>MyStruct</type>
+        </param>
+        <code>return new MyStruct(value + rhs.value);</code>
+      </function>
+      <function name=""CopyFrom"" access=""public"" unsafe=""true"">
+        <type>void</type>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+        <code>value = other-&gt;value;</code>
+      </function>
+      <function name=""MoveFrom"" access=""public"" unsafe=""true"">
+        <type>void</type>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+        <code>value = other-&gt;value;</code>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task OperatorCallTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -718,6 +718,79 @@ MyStruct operator-(MyStruct lhs, MyStruct rhs)
             return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveOperatorTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    MyStruct(int value) : value(value)
+    {
+    }
+
+    MyStruct operator+(MyStruct rhs)
+    {
+        return MyStruct(value + rhs.value);
+    }
+
+    void operator=(const MyStruct& other)
+    {
+        value = other.value;
+    }
+
+    void operator=(MyStruct&& other)
+    {
+        value = other.value;
+    }
+};
+";
+
+            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <field name=""value"" access=""public"">
+        <type>int</type>
+      </field>
+      <function name=""MyStruct"" access=""public"">
+        <type>void</type>
+        <param name=""value"">
+          <type>int</type>
+        </param>
+        <init field=""value"" hint=""value"">
+          <code>value</code>
+        </init>
+        <code></code>
+      </function>
+      <function name=""Add"" access=""public"">
+        <type>MyStruct</type>
+        <param name=""rhs"">
+          <type>MyStruct</type>
+        </param>
+        <code>return new MyStruct(value + rhs.value);</code>
+      </function>
+      <function name=""CopyFrom"" access=""public"" unsafe=""true"">
+        <type>void</type>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+        <code>value = other-&gt;value;</code>
+      </function>
+      <function name=""MoveFrom"" access=""public"" unsafe=""true"">
+        <type>void</type>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+        <code>value = other-&gt;value;</code>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task OperatorCallTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
@@ -646,6 +646,79 @@ MyStruct operator-(MyStruct lhs, MyStruct rhs)
             return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveOperatorTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    MyStruct(int value) : value(value)
+    {
+    }
+
+    MyStruct operator+(MyStruct rhs)
+    {
+        return MyStruct(value + rhs.value);
+    }
+
+    void operator=(const MyStruct& other)
+    {
+        value = other.value;
+    }
+
+    void operator=(MyStruct&& other)
+    {
+        value = other.value;
+    }
+};
+";
+
+            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <field name=""value"" access=""public"">
+        <type>int</type>
+      </field>
+      <function name=""MyStruct"" access=""public"">
+        <type>void</type>
+        <param name=""value"">
+          <type>int</type>
+        </param>
+        <init field=""value"" hint=""value"">
+          <code>value</code>
+        </init>
+        <code></code>
+      </function>
+      <function name=""Add"" access=""public"">
+        <type>MyStruct</type>
+        <param name=""rhs"">
+          <type>MyStruct</type>
+        </param>
+        <code>return new MyStruct(value + rhs.value);</code>
+      </function>
+      <function name=""CopyFrom"" access=""public"" unsafe=""true"">
+        <type>void</type>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+        <code>value = other-&gt;value;</code>
+      </function>
+      <function name=""MoveFrom"" access=""public"" unsafe=""true"">
+        <type>void</type>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+        <code>value = other-&gt;value;</code>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task OperatorCallTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
@@ -646,6 +646,79 @@ MyStruct operator-(MyStruct lhs, MyStruct rhs)
             return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveOperatorTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    int value;
+
+    MyStruct(int value) : value(value)
+    {
+    }
+
+    MyStruct operator+(MyStruct rhs)
+    {
+        return MyStruct(value + rhs.value);
+    }
+
+    void operator=(const MyStruct& other)
+    {
+        value = other.value;
+    }
+
+    void operator=(MyStruct&& other)
+    {
+        value = other.value;
+    }
+};
+";
+
+            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <field name=""value"" access=""public"">
+        <type>int</type>
+      </field>
+      <function name=""MyStruct"" access=""public"">
+        <type>void</type>
+        <param name=""value"">
+          <type>int</type>
+        </param>
+        <init field=""value"" hint=""value"">
+          <code>value</code>
+        </init>
+        <code></code>
+      </function>
+      <function name=""Add"" access=""public"">
+        <type>MyStruct</type>
+        <param name=""rhs"">
+          <type>MyStruct</type>
+        </param>
+        <code>return new MyStruct(value + rhs.value);</code>
+      </function>
+      <function name=""CopyFrom"" access=""public"" unsafe=""true"">
+        <type>void</type>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+        <code>value = other-&gt;value;</code>
+      </function>
+      <function name=""MoveFrom"" access=""public"" unsafe=""true"">
+        <type>void</type>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+        <code>value = other-&gt;value;</code>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task OperatorCallTest()
         {
             var inputContents = @"struct MyStruct


### PR DESCRIPTION
This PR adds remapped operator names for the copy, move and dereference operators. Previously this would have produced invalid C# code (e.g. `public unsafe void operator=(`. Unfortunately I could not find much guidance for "canonical C#" names, so "MoveFrom", "CopyFrom" and "Access" (for `->`) might not be the best choice.

Note that I did not use return types for the tests as this seems to be its own bug with returning references (e.g. C++ `MyStruct& abc() { return *this; }` would produce C# `MyStruct* abc() { return *this; }`.