### PR TITLE
Fix imported constructors and instance methods

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/FunctionOrDelegateDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/FunctionOrDelegateDesc.cs
@@ -214,6 +214,14 @@ namespace ClangSharp.Abstractions
                 : Flags & ~FunctionOrDelegateFlags.IsCxxConstructor;
         }
 
+        public bool NeedsThisParameter
+        {
+            get => (Flags & FunctionOrDelegateFlags.NeedsThisParameter) != 0;
+            set => Flags = value
+                ? Flags | FunctionOrDelegateFlags.NeedsThisParameter
+                : Flags & ~FunctionOrDelegateFlags.NeedsThisParameter;
+        }
+
         public Action<TCustomAttrGeneratorData> WriteCustomAttrs { get; set; }
         public TCustomAttrGeneratorData CustomAttrGeneratorData { get; set; }
     }

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -285,6 +285,10 @@ namespace ClangSharp.CSharp
                 Write(desc.ReturnType);
                 Write(' ');
             }
+            else if (desc.IsDllImport)
+            {
+                Write("void ");
+            }
         }
 
         private void WriteSourceLocation(CXSourceLocation location, bool inline)

--- a/sources/ClangSharp.PInvokeGenerator/FunctionOrDelegateFlags.cs
+++ b/sources/ClangSharp.PInvokeGenerator/FunctionOrDelegateFlags.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace ClangSharp
 {
@@ -20,5 +20,6 @@ namespace ClangSharp
         IsNotStatic = 1 << 12,
         NeedsReturnFixup = 1 << 13,
         IsCxxConstructor = 1 << 14,
+        NeedsThisParameter = 1 << 15
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -463,7 +463,7 @@ namespace ClangSharp
             }
 
             var needsReturnFixup = isVirtual && NeedsReturnFixup(cxxMethodDecl);
-            var needsThisParameter = isVirtual || (isDllImport && cxxMethodDecl != null && cxxMethodDecl.IsInstance);
+            var needsThisParameter = cxxMethodDecl != null && NeedsThisParameter(cxxMethodDecl);
 
             var desc = new FunctionOrDelegateDesc<(string Name, PInvokeGenerator This)>
             {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -540,11 +540,11 @@ namespace ClangSharp
                     _outputBuilder.BeginParameter(in parameterDesc);
                     _outputBuilder.EndParameter();
                 }
+            }
 
-                if (functionDecl.Parameters.Any())
-                {
-                    _outputBuilder.WriteParameterSeparator();
-                }
+            if (functionDecl.Parameters.Any() && (needsThisParameter || isVirtual))
+            {
+                _outputBuilder.WriteParameterSeparator();
             }
 
             Visit(functionDecl.Parameters);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -463,7 +463,7 @@ namespace ClangSharp
             }
 
             var needsReturnFixup = isVirtual && NeedsReturnFixup(cxxMethodDecl);
-            var needsThisParameter = isVirtual || (isDllImport && functionDecl is CXXConstructorDecl);
+            var needsThisParameter = isVirtual || (isDllImport && cxxMethodDecl != null && cxxMethodDecl.IsInstance);
 
             var desc = new FunctionOrDelegateDesc<(string Name, PInvokeGenerator This)>
             {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1273,6 +1273,12 @@ namespace ClangSharp
                 return AddUsingDirectiveIfNeeded(_outputBuilder, remappedName, skipUsing);
             }
 
+            if (cursor is CXXConstructorDecl constructorDecl && !constructorDecl.HasBody)
+            {
+                wasRemapped = true;
+                return AddUsingDirectiveIfNeeded(_outputBuilder, "Constructor", skipUsing);
+            }
+
             wasRemapped = false;
             return AddUsingDirectiveIfNeeded(_outputBuilder, remappedName, skipUsing);
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationTest.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft and Contributors. All rights reserved. Licensed under the University of Illinois/NCSA Open Source License. See LICENSE.txt in the project root for license information.
 
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -12,6 +13,9 @@ namespace ClangSharp.UnitTests
 
         [Fact]
         public abstract Task ConstructorWithInitializeTest();
+
+        [Fact]
+        public abstract Task ConstructorImportTest();
 
         [Fact]
         public abstract Task ConversionTest();

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationTest.cs
@@ -18,6 +18,9 @@ namespace ClangSharp.UnitTests
         public abstract Task ConstructorImportTest();
 
         [Fact]
+        public abstract Task CopyAndMoveConstructor();
+
+        [Fact]
         public abstract Task ConversionTest();
 
         [Fact]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -93,6 +93,36 @@ namespace ClangSharp.UnitTests
             return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task ConstructorImportTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct();
+};
+";
+
+            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint = $"_{entryPoint}";
+            }
+
+            var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        public static extern void Constructor(MyStruct* pThis);
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -225,7 +225,7 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
-        public static extern void MyVoidMethod();
+        public static extern void MyVoidMethod(MyStruct* pThis);
 
         public int MyInt32Method()
         {{

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -133,6 +133,46 @@ namespace ClangSharp.Test
             return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveConstructor()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct(const MyStruct& other);
+    MyStruct(MyStruct&& other);
+};
+";
+
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
+                : "_ZN8MyStructC2ERKS_";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
+                : "_ZN8MyStructC2EOS_";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
+            }
+
+            var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint1}"", ExactSpelling = true)]
+        public static extern unsafe void CopyConstructor(MyStruct* pThis, [NativeTypeName(""const MyStruct &"")] MyStruct* other);
+
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint2}"", ExactSpelling = true)]
+        public static extern unsafe void MoveConstructor(MyStruct* pThis, [NativeTypeName(""MyStruct &&"")] MyStruct* other);
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -98,14 +98,17 @@ namespace ClangSharp.UnitTests
             var inputContents = @"struct MyStruct
 {
     MyStruct();
+    MyStruct(int a);
 };
 ";
 
-            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                entryPoint = $"_{entryPoint}";
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
             }
 
             var expectedOutputContents = $@"using System.Runtime.InteropServices;
@@ -114,8 +117,11 @@ namespace ClangSharp.Test
 {{
     public partial struct MyStruct
     {{
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint1}"", ExactSpelling = true)]
         public static extern void Constructor(MyStruct* pThis);
+
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint2}"", ExactSpelling = true)]
+        public static extern void Constructor(MyStruct* pThis, int a);
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -144,10 +144,10 @@ namespace ClangSharp.Test
 
             var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
-                : "_ZN8MyStructC2ERKS_";
+                : "_ZN8MyStructC1ERKS_";
             var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
-                : "_ZN8MyStructC2EOS_";
+                : "_ZN8MyStructC1EOS_";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -102,8 +102,12 @@ namespace ClangSharp.UnitTests
 };
 ";
 
-            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
-            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@XZ" : "??0MyStruct@@QAE@XZ")
+                : "_ZN8MyStructC1Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@H@Z" : "??0MyStruct@@QAE@H@Z")
+                : "_ZN8MyStructC1Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -122,10 +122,10 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint1}"", ExactSpelling = true)]
-        public static extern void Constructor(MyStruct* pThis);
+        public static extern unsafe void Constructor(MyStruct* pThis);
 
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint2}"", ExactSpelling = true)]
-        public static extern void Constructor(MyStruct* pThis, int a);
+        public static extern unsafe void Constructor(MyStruct* pThis, int a);
     }}
 }}
 ";
@@ -265,7 +265,7 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
-        public static extern void MyVoidMethod(MyStruct* pThis);
+        public static extern unsafe void MyVoidMethod(MyStruct* pThis);
 
         public int MyInt32Method()
         {{

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -93,6 +93,36 @@ namespace ClangSharp.UnitTests
             return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task ConstructorImportTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct();
+};
+";
+
+            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint = $"_{entryPoint}";
+            }
+
+            var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        public static extern void Constructor(MyStruct* pThis);
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -225,7 +225,7 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
-        public static extern void MyVoidMethod();
+        public static extern void MyVoidMethod(MyStruct* pThis);
 
         public int MyInt32Method()
         {{

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -98,14 +98,17 @@ namespace ClangSharp.UnitTests
             var inputContents = @"struct MyStruct
 {
     MyStruct();
+    MyStruct(int a);
 };
 ";
 
-            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                entryPoint = $"_{entryPoint}";
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
             }
 
             var expectedOutputContents = $@"using System.Runtime.InteropServices;
@@ -114,8 +117,11 @@ namespace ClangSharp.Test
 {{
     public partial struct MyStruct
     {{
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint1}"", ExactSpelling = true)]
         public static extern void Constructor(MyStruct* pThis);
+
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint2}"", ExactSpelling = true)]
+        public static extern void Constructor(MyStruct* pThis, int a);
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -144,10 +144,10 @@ namespace ClangSharp.Test
 
             var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
-                : "_ZN8MyStructC2ERKS_";
+                : "_ZN8MyStructC1ERKS_";
             var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
-                : "_ZN8MyStructC2EOS_";
+                : "_ZN8MyStructC1EOS_";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -102,8 +102,12 @@ namespace ClangSharp.UnitTests
 };
 ";
 
-            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
-            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@XZ" : "??0MyStruct@@QAE@XZ")
+                : "_ZN8MyStructC1Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@H@Z" : "??0MyStruct@@QAE@H@Z")
+                : "_ZN8MyStructC1Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -122,10 +122,10 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint1}"", ExactSpelling = true)]
-        public static extern void Constructor(MyStruct* pThis);
+        public static extern unsafe void Constructor(MyStruct* pThis);
 
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint2}"", ExactSpelling = true)]
-        public static extern void Constructor(MyStruct* pThis, int a);
+        public static extern unsafe void Constructor(MyStruct* pThis, int a);
     }}
 }}
 ";
@@ -265,7 +265,7 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
-        public static extern void MyVoidMethod(MyStruct* pThis);
+        public static extern unsafe void MyVoidMethod(MyStruct* pThis);
 
         public int MyInt32Method()
         {{

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
@@ -225,7 +225,7 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
-        public static extern void MyVoidMethod();
+        public static extern void MyVoidMethod(MyStruct* pThis);
 
         public int MyInt32Method()
         {{

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
@@ -133,6 +133,46 @@ namespace ClangSharp.Test
             return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveConstructor()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct(const MyStruct& other);
+    MyStruct(MyStruct&& other);
+};
+";
+
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
+                : "_ZN8MyStructC2ERKS_";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
+                : "_ZN8MyStructC2EOS_";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
+            }
+
+            var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint1}"", ExactSpelling = true)]
+        public static extern unsafe void CopyConstructor(MyStruct* pThis, [NativeTypeName(""const MyStruct &"")] MyStruct* other);
+
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint2}"", ExactSpelling = true)]
+        public static extern unsafe void MoveConstructor(MyStruct* pThis, [NativeTypeName(""MyStruct &&"")] MyStruct* other);
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
@@ -98,14 +98,17 @@ namespace ClangSharp.UnitTests
             var inputContents = @"struct MyStruct
 {
     MyStruct();
+    MyStruct(int a);
 };
 ";
 
-            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                entryPoint = $"_{entryPoint}";
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
             }
 
             var expectedOutputContents = $@"using System.Runtime.InteropServices;
@@ -114,8 +117,11 @@ namespace ClangSharp.Test
 {{
     public partial struct MyStruct
     {{
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint1}"", ExactSpelling = true)]
         public static extern void Constructor(MyStruct* pThis);
+
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint2}"", ExactSpelling = true)]
+        public static extern void Constructor(MyStruct* pThis, int a);
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
@@ -93,6 +93,36 @@ namespace ClangSharp.UnitTests
             return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task ConstructorImportTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct();
+};
+";
+
+            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint = $"_{entryPoint}";
+            }
+
+            var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        public static extern void Constructor(MyStruct* pThis);
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
@@ -144,10 +144,10 @@ namespace ClangSharp.Test
 
             var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
-                : "_ZN8MyStructC2ERKS_";
+                : "_ZN8MyStructC1ERKS_";
             var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
-                : "_ZN8MyStructC2EOS_";
+                : "_ZN8MyStructC1EOS_";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
@@ -102,8 +102,12 @@ namespace ClangSharp.UnitTests
 };
 ";
 
-            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
-            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@XZ" : "??0MyStruct@@QAE@XZ")
+                : "_ZN8MyStructC1Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@H@Z" : "??0MyStruct@@QAE@H@Z")
+                : "_ZN8MyStructC1Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
@@ -122,10 +122,10 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint1}"", ExactSpelling = true)]
-        public static extern void Constructor(MyStruct* pThis);
+        public static extern unsafe void Constructor(MyStruct* pThis);
 
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint2}"", ExactSpelling = true)]
-        public static extern void Constructor(MyStruct* pThis, int a);
+        public static extern unsafe void Constructor(MyStruct* pThis, int a);
     }}
 }}
 ";
@@ -265,7 +265,7 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
-        public static extern void MyVoidMethod(MyStruct* pThis);
+        public static extern unsafe void MyVoidMethod(MyStruct* pThis);
 
         public int MyInt32Method()
         {{

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -93,6 +93,36 @@ namespace ClangSharp.UnitTests
             return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task ConstructorImportTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct();
+};
+";
+
+            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint = $"_{entryPoint}";
+            }
+
+            var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        public static extern void Constructor(MyStruct* pThis);
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -225,7 +225,7 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
-        public static extern void MyVoidMethod();
+        public static extern void MyVoidMethod(MyStruct* pThis);
 
         public int MyInt32Method()
         {{

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -133,6 +133,46 @@ namespace ClangSharp.Test
             return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveConstructor()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct(const MyStruct& other);
+    MyStruct(MyStruct&& other);
+};
+";
+
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
+                : "_ZN8MyStructC2ERKS_";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
+                : "_ZN8MyStructC2EOS_";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
+            }
+
+            var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public partial struct MyStruct
+    {{
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint1}"", ExactSpelling = true)]
+        public static extern unsafe void CopyConstructor(MyStruct* pThis, [NativeTypeName(""const MyStruct &"")] MyStruct* other);
+
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint2}"", ExactSpelling = true)]
+        public static extern unsafe void MoveConstructor(MyStruct* pThis, [NativeTypeName(""MyStruct &&"")] MyStruct* other);
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -98,14 +98,17 @@ namespace ClangSharp.UnitTests
             var inputContents = @"struct MyStruct
 {
     MyStruct();
+    MyStruct(int a);
 };
 ";
 
-            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                entryPoint = $"_{entryPoint}";
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
             }
 
             var expectedOutputContents = $@"using System.Runtime.InteropServices;
@@ -114,8 +117,11 @@ namespace ClangSharp.Test
 {{
     public partial struct MyStruct
     {{
-        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint1}"", ExactSpelling = true)]
         public static extern void Constructor(MyStruct* pThis);
+
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint2}"", ExactSpelling = true)]
+        public static extern void Constructor(MyStruct* pThis, int a);
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -144,10 +144,10 @@ namespace ClangSharp.Test
 
             var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
-                : "_ZN8MyStructC2ERKS_";
+                : "_ZN8MyStructC1ERKS_";
             var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
-                : "_ZN8MyStructC2EOS_";
+                : "_ZN8MyStructC1EOS_";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -102,8 +102,12 @@ namespace ClangSharp.UnitTests
 };
 ";
 
-            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
-            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@XZ" : "??0MyStruct@@QAE@XZ")
+                : "_ZN8MyStructC1Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@H@Z" : "??0MyStruct@@QAE@H@Z")
+                : "_ZN8MyStructC1Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -122,10 +122,10 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint1}"", ExactSpelling = true)]
-        public static extern void Constructor(MyStruct* pThis);
+        public static extern unsafe void Constructor(MyStruct* pThis);
 
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint2}"", ExactSpelling = true)]
-        public static extern void Constructor(MyStruct* pThis, int a);
+        public static extern unsafe void Constructor(MyStruct* pThis, int a);
     }}
 }}
 ";
@@ -265,7 +265,7 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
-        public static extern void MyVoidMethod(MyStruct* pThis);
+        public static extern unsafe void MyVoidMethod(MyStruct* pThis);
 
         public int MyInt32Method()
         {{

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -275,6 +275,9 @@ namespace ClangSharp.UnitTests
     <struct name=""MyStruct"" access=""public"">
       <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
         <type>void</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
       </function>
       <function name=""MyInt32Method"" access=""public"">
         <type>int</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -136,24 +136,36 @@ namespace ClangSharp.UnitTests
             var inputContents = @"struct MyStruct
 {
     MyStruct();
+    MyStruct(int a);
 };
 ";
 
-            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                entryPoint = $"_{entryPoint}";
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
             }
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"">
         <type>Constructor</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
+        </param>
+      </function>
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"">
+        <type>Constructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""a"">
+          <type>int</type>
         </param>
       </function>
     </struct>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -157,13 +157,13 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"" unsafe=""true"">
         <type>Constructor</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </function>
-      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"" unsafe=""true"">
         <type>Constructor</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -325,7 +325,7 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
+      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"" unsafe=""true"">
         <type>void</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -1073,7 +1073,7 @@ extern ""C"" void MyFunction();";
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""ThisCall"" unsafe=""true"">
+      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""ThisCall"">
         <type>void*</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -1165,7 +1165,7 @@ extern ""C"" void MyFunction();";
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""ThisCall"" unsafe=""true"">
+      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""ThisCall"">
         <type>void*</type>
         <param name=""pThis"">
           <type>MyStruct*</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -131,6 +131,39 @@ namespace ClangSharp.UnitTests
             return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task ConstructorImportTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct();
+};
+";
+
+            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint = $"_{entryPoint}";
+            }
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
+        <type>Constructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -180,6 +180,58 @@ namespace ClangSharp.UnitTests
             return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveConstructor()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct(const MyStruct& other);
+    MyStruct(MyStruct&& other);
+};
+";
+
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
+                : "_ZN8MyStructC2ERKS_";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
+                : "_ZN8MyStructC2EOS_";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
+            }
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <function name=""CopyConstructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"" unsafe=""true"">
+        <type>CopyConstructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+      </function>
+      <function name=""MoveConstructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"" unsafe=""true"">
+        <type>MoveConstructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -140,8 +140,12 @@ namespace ClangSharp.UnitTests
 };
 ";
 
-            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
-            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@XZ" : "??0MyStruct@@QAE@XZ")
+                : "_ZN8MyStructC1Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@H@Z" : "??0MyStruct@@QAE@H@Z")
+                : "_ZN8MyStructC1Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -191,10 +191,10 @@ namespace ClangSharp.UnitTests
 
             var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
-                : "_ZN8MyStructC2ERKS_";
+                : "_ZN8MyStructC1ERKS_";
             var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
-                : "_ZN8MyStructC2EOS_";
+                : "_ZN8MyStructC1EOS_";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -275,6 +275,9 @@ namespace ClangSharp.UnitTests
     <struct name=""MyStruct"" access=""public"">
       <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
         <type>void</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
       </function>
       <function name=""MyInt32Method"" access=""public"">
         <type>int</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -136,24 +136,36 @@ namespace ClangSharp.UnitTests
             var inputContents = @"struct MyStruct
 {
     MyStruct();
+    MyStruct(int a);
 };
 ";
 
-            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                entryPoint = $"_{entryPoint}";
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
             }
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"">
         <type>Constructor</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
+        </param>
+      </function>
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"">
+        <type>Constructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""a"">
+          <type>int</type>
         </param>
       </function>
     </struct>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -157,13 +157,13 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"" unsafe=""true"">
         <type>Constructor</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </function>
-      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"" unsafe=""true"">
         <type>Constructor</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -325,7 +325,7 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
+      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"" unsafe=""true"">
         <type>void</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -1073,7 +1073,7 @@ extern ""C"" void MyFunction();";
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""ThisCall"" unsafe=""true"">
+      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""ThisCall"">
         <type>void*</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -1165,7 +1165,7 @@ extern ""C"" void MyFunction();";
           <type>MyStruct*</type>
         </param>
       </delegate>
-      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""ThisCall"" unsafe=""true"">
+      <delegate name=""_MyVoidStarMethod"" access=""public"" convention=""ThisCall"">
         <type>void*</type>
         <param name=""pThis"">
           <type>MyStruct*</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -180,6 +180,58 @@ namespace ClangSharp.UnitTests
             return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveConstructor()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct(const MyStruct& other);
+    MyStruct(MyStruct&& other);
+};
+";
+
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
+                : "_ZN8MyStructC2ERKS_";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
+                : "_ZN8MyStructC2EOS_";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
+            }
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <function name=""CopyConstructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"" unsafe=""true"">
+        <type>CopyConstructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+      </function>
+      <function name=""MoveConstructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"" unsafe=""true"">
+        <type>MoveConstructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -140,8 +140,12 @@ namespace ClangSharp.UnitTests
 };
 ";
 
-            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
-            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@XZ" : "??0MyStruct@@QAE@XZ")
+                : "_ZN8MyStructC1Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@H@Z" : "??0MyStruct@@QAE@H@Z")
+                : "_ZN8MyStructC1Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -131,6 +131,39 @@ namespace ClangSharp.UnitTests
             return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task ConstructorImportTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct();
+};
+";
+
+            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint = $"_{entryPoint}";
+            }
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
+        <type>Constructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -191,10 +191,10 @@ namespace ClangSharp.UnitTests
 
             var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
-                : "_ZN8MyStructC2ERKS_";
+                : "_ZN8MyStructC1ERKS_";
             var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
-                : "_ZN8MyStructC2EOS_";
+                : "_ZN8MyStructC1EOS_";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
@@ -275,6 +275,9 @@ namespace ClangSharp.UnitTests
     <struct name=""MyStruct"" access=""public"">
       <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
         <type>void</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
       </function>
       <function name=""MyInt32Method"" access=""public"">
         <type>int</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
@@ -180,6 +180,58 @@ namespace ClangSharp.UnitTests
             return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveConstructor()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct(const MyStruct& other);
+    MyStruct(MyStruct&& other);
+};
+";
+
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
+                : "_ZN8MyStructC2ERKS_";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
+                : "_ZN8MyStructC2EOS_";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
+            }
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <function name=""CopyConstructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"" unsafe=""true"">
+        <type>CopyConstructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+      </function>
+      <function name=""MoveConstructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"" unsafe=""true"">
+        <type>MoveConstructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
@@ -136,24 +136,36 @@ namespace ClangSharp.UnitTests
             var inputContents = @"struct MyStruct
 {
     MyStruct();
+    MyStruct(int a);
 };
 ";
 
-            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                entryPoint = $"_{entryPoint}";
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
             }
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"">
         <type>Constructor</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
+        </param>
+      </function>
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"">
+        <type>Constructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""a"">
+          <type>int</type>
         </param>
       </function>
     </struct>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
@@ -131,6 +131,39 @@ namespace ClangSharp.UnitTests
             return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task ConstructorImportTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct();
+};
+";
+
+            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint = $"_{entryPoint}";
+            }
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
+        <type>Constructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
@@ -140,8 +140,12 @@ namespace ClangSharp.UnitTests
 };
 ";
 
-            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
-            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@XZ" : "??0MyStruct@@QAE@XZ")
+                : "_ZN8MyStructC1Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@H@Z" : "??0MyStruct@@QAE@H@Z")
+                : "_ZN8MyStructC1Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
@@ -157,13 +157,13 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"" unsafe=""true"">
         <type>Constructor</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </function>
-      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"" unsafe=""true"">
         <type>Constructor</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -325,7 +325,7 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
+      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"" unsafe=""true"">
         <type>void</type>
         <param name=""pThis"">
           <type>MyStruct*</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
@@ -191,10 +191,10 @@ namespace ClangSharp.UnitTests
 
             var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
-                : "_ZN8MyStructC2ERKS_";
+                : "_ZN8MyStructC1ERKS_";
             var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
-                : "_ZN8MyStructC2EOS_";
+                : "_ZN8MyStructC1EOS_";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
@@ -190,10 +190,10 @@ namespace ClangSharp.UnitTests
 
             var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
-                : "_ZN8MyStructC2ERKS_";
+                : "_ZN8MyStructC1ERKS_";
             var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
-                : "_ZN8MyStructC2EOS_";
+                : "_ZN8MyStructC1EOS_";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
@@ -179,6 +179,58 @@ namespace ClangSharp.UnitTests
             return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task CopyAndMoveConstructor()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct(const MyStruct& other);
+    MyStruct(MyStruct&& other);
+};
+";
+
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@AEBU0@@Z" : "??0MyStruct@@QAE@ABU0@@Z")
+                : "_ZN8MyStructC2ERKS_";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@$$QEAU0@@Z" : "??0MyStruct@@QAE@$$QAU0@@Z")
+                : "_ZN8MyStructC2EOS_";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
+            }
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <function name=""CopyConstructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"" unsafe=""true"">
+        <type>CopyConstructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+      </function>
+      <function name=""MoveConstructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"" unsafe=""true"">
+        <type>MoveConstructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""other"">
+          <type>MyStruct*</type>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
@@ -136,31 +136,42 @@ namespace ClangSharp.UnitTests
             var inputContents = @"struct MyStruct
 {
     MyStruct();
+    MyStruct(int a);
 };
 ";
 
-            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                entryPoint = $"_{entryPoint}";
+                entryPoint1 = $"_{entryPoint1}";
+                entryPoint2 = $"_{entryPoint2}";
             }
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"">
         <type>Constructor</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
+        </param>
+      </function>
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"">
+        <type>Constructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""a"">
+          <type>int</type>
         </param>
       </function>
     </struct>
   </namespace>
 </bindings>
 ";
-
             return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
@@ -140,8 +140,12 @@ namespace ClangSharp.UnitTests
 };
 ";
 
-            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
-            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@H@Z" : "_ZN8MyStructC2Ei";
+            var entryPoint1 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@XZ" : "??0MyStruct@@QAE@XZ")
+                : "_ZN8MyStructC1Ev";
+            var entryPoint2 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? (Environment.Is64BitProcess ? "??0MyStruct@@QEAA@H@Z" : "??0MyStruct@@QAE@H@Z")
+                : "_ZN8MyStructC1Ei";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
@@ -157,13 +157,13 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint1}"" static=""true"" unsafe=""true"">
         <type>Constructor</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
         </param>
       </function>
-      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint2}"" static=""true"" unsafe=""true"">
         <type>Constructor</type>
         <param name=""pThis"">
           <type>MyStruct*</type>
@@ -324,7 +324,7 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"">
-      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
+      <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"" unsafe=""true"">
         <type>void</type>
         <param name=""pThis"">
           <type>MyStruct*</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
@@ -274,6 +274,9 @@ namespace ClangSharp.UnitTests
     <struct name=""MyStruct"" access=""public"">
       <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
         <type>void</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
       </function>
       <function name=""MyInt32Method"" access=""public"">
         <type>int</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
@@ -131,6 +131,39 @@ namespace ClangSharp.UnitTests
             return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        public override Task ConstructorImportTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    MyStruct();
+};
+";
+
+            var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "??0MyStruct@@QEAA@XZ" : "_ZN8MyStructC2Ev";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                entryPoint = $"_{entryPoint}";
+            }
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"">
+      <function name=""Constructor"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
+        <type>Constructor</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         public override Task ConversionTest()
         {
             var inputContents = @"struct MyStruct


### PR DESCRIPTION
Constructors were supported when they had bodies and were generated as actual C# constructors, but trying to import them produced invalid C#, e.g:

```csharp
    public partial struct MyStruct
    {
        [DllImport("", CallingConvention = CallingConvention.ThisCall, EntryPoint = "...", ExactSpelling = true)]
        public static extern MyStruct();
    }
```

So three things had to be fixed:

  - The name has to be remapped to not conflict with C# constructors (static or not) <br/> Also copy/move constructors will conflict with each other thus they get different names
  - A return type has to be added (Clang said `void` although it *might* also be a pointer to the struct?)
  - A `pThis` parameter has to be added. <br/> This point applied to all imported instance methods.

Here is an example of the result of this PR:

```csharp
    public partial struct MyStruct
    {
        [DllImport("", CallingConvention = CallingConvention.ThisCall, EntryPoint = "...", ExactSpelling = true)]
        public static extern unsafe void Constructor(MyStruct* pThis);

        [DllImport("", CallingConvention = CallingConvention.ThisCall, EntryPoint = "...", ExactSpelling = true)]
        public static extern unsafe void CopyConstructor(MyStruct* pThis, [NativeTypeName("const MyStruct &")] MyStruct* other);

        [DllImport("", CallingConvention = CallingConvention.ThisCall, EntryPoint = "...", ExactSpelling=true)]
        public static extern unsafe void MoveConstructor(MyStruct* pThis, [NativeTypeName("MyStruct &&")] MyStruct* other);

        [DllImport("", CallingConvention = CallingConvention.ThisCall, EntryPoint = "...", ExactSpelling = true)]
        public static extern unsafe void MyMethod(MyStruct* pThis);
    }
```