### PR TITLE
Replace generation of protected entries

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -692,7 +692,8 @@ namespace ClangSharp
 
                 case CX_CXXAccessSpecifier.CX_CXXProtected:
                 {
-                    name = AccessSpecifier.Protected;
+                    // neither in C# structs nor in namespaces are protected entries allowed
+                    name = AccessSpecifier.Public;
                     break;
                 }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/StructDeclarationTest.cs
@@ -205,5 +205,8 @@ namespace ClangSharp.UnitTests
 
         [Fact]
         public abstract Task SourceLocationAttributeTest();
+
+        [Fact]
+        public abstract Task AccessModifierTest();
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
@@ -1646,5 +1646,71 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        public override Task AccessModifierTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    protected: virtual ~MyStruct() = default;
+    public: void PublicMethod() {}
+    protected: void ProtectedMethod() {}
+    private: void PrivateMethod() {}
+
+    public: int publicField;
+    protected: int protectedField;
+    private: int privateField;
+};
+";
+
+            var expectedOutputContents = @"using System;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct MyStruct
+    {
+        public Vtbl* lpVtbl;
+
+        public int publicField;
+
+        public int protectedField;
+
+        private int privateField;
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate void _Dispose(MyStruct* pThis);
+
+        public void PublicMethod()
+        {
+        }
+
+        public void ProtectedMethod()
+        {
+        }
+
+        private void PrivateMethod()
+        {
+        }
+
+        public void Dispose()
+        {
+            fixed (MyStruct* pThis = &this)
+            {
+                Marshal.GetDelegateForFunctionPointer<_Dispose>(lpVtbl->Dispose)(pThis);
+            }
+        }
+
+        public partial struct Vtbl
+        {
+            [NativeTypeName(""void ()"")]
+            public IntPtr Dispose;
+        }
+    }
+}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents,
+                PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls | PInvokeGeneratorConfigurationOptions.ExcludeFnptrCodegen);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
@@ -1662,6 +1662,12 @@ struct MyStruct1B : MyStruct1A
 };
 ";
 
+            var nativeCallConv = "";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
+            {
+                nativeCallConv = " __attribute__((thiscall))";
+            }
+
             var expectedOutputContents = @"using System;
 using System.Runtime.InteropServices;
 
@@ -1702,7 +1708,7 @@ namespace ClangSharp.Test
 
         public partial struct Vtbl
         {
-            [NativeTypeName(""void ()"")]
+            [NativeTypeName(""void ()" + nativeCallConv + @""")]
             public IntPtr Dispose;
         }
     }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
@@ -1666,6 +1666,12 @@ struct MyStruct1B : MyStruct1A
 };
 ";
 
+            var nativeCallConv = "";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
+            {
+                nativeCallConv = " __attribute__((thiscall))";
+            }
+
             var expectedOutputContents = @"using System;
 using System.Runtime.InteropServices;
 
@@ -1706,7 +1712,7 @@ namespace ClangSharp.Test
 
         public partial struct Vtbl
         {
-            [NativeTypeName(""void ()"")]
+            [NativeTypeName(""void ()" + nativeCallConv + @""")]
             public IntPtr Dispose;
         }
     }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
@@ -1640,6 +1640,8 @@ struct MyStruct1B : MyStruct1A
 };
 ";
 
+            var vtblIndex = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : 1;
+
             var expectedOutputContents = @"using System.Runtime.CompilerServices;
 
 namespace ClangSharp.Test
@@ -1668,7 +1670,7 @@ namespace ClangSharp.Test
 
         public void Dispose()
         {
-            ((delegate* unmanaged[Thiscall]<MyStruct*, void>)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this));
+            ((delegate* unmanaged[Thiscall]<MyStruct*, void>)(lpVtbl[" + vtblIndex + @"]))((MyStruct*)Unsafe.AsPointer(ref this));
         }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
@@ -1624,5 +1624,57 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedCSharpLatestUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        public override Task AccessModifierTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    protected: virtual ~MyStruct() = default;
+    public: void PublicMethod() {}
+    protected: void ProtectedMethod() {}
+    private: void PrivateMethod() {}
+
+    public: int publicField;
+    protected: int protectedField;
+    private: int privateField;
+};
+";
+
+            var expectedOutputContents = @"using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct MyStruct
+    {
+        public void** lpVtbl;
+
+        public int publicField;
+
+        public int protectedField;
+
+        private int privateField;
+
+        public void PublicMethod()
+        {
+        }
+
+        public void ProtectedMethod()
+        {
+        }
+
+        private void PrivateMethod()
+        {
+        }
+
+        public void Dispose()
+        {
+            ((delegate* unmanaged[Thiscall]<MyStruct*, void>)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this));
+        }
+    }
+}
+";
+
+            return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
@@ -1644,6 +1644,8 @@ struct MyStruct1B : MyStruct1A
 };
 ";
 
+            var vtblIndex = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : 1;
+
             var expectedOutputContents = @"using System.Runtime.CompilerServices;
 
 namespace ClangSharp.Test
@@ -1672,7 +1674,7 @@ namespace ClangSharp.Test
 
         public void Dispose()
         {
-            ((delegate* unmanaged[Thiscall]<MyStruct*, void>)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this));
+            ((delegate* unmanaged[Thiscall]<MyStruct*, void>)(lpVtbl[" + vtblIndex + @"]))((MyStruct*)Unsafe.AsPointer(ref this));
         }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
@@ -1628,5 +1628,57 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedCSharpLatestWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        public override Task AccessModifierTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    protected: virtual ~MyStruct() = default;
+    public: void PublicMethod() {}
+    protected: void ProtectedMethod() {}
+    private: void PrivateMethod() {}
+
+    public: int publicField;
+    protected: int protectedField;
+    private: int privateField;
+};
+";
+
+            var expectedOutputContents = @"using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct MyStruct
+    {
+        public void** lpVtbl;
+
+        public int publicField;
+
+        public int protectedField;
+
+        private int privateField;
+
+        public void PublicMethod()
+        {
+        }
+
+        public void ProtectedMethod()
+        {
+        }
+
+        private void PrivateMethod()
+        {
+        }
+
+        public void Dispose()
+        {
+            ((delegate* unmanaged[Thiscall]<MyStruct*, void>)(lpVtbl[0]))((MyStruct*)Unsafe.AsPointer(ref this));
+        }
+    }
+}
+";
+
+            return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
@@ -1657,6 +1657,12 @@ struct MyStruct1B : MyStruct1A
 };
 ";
 
+            var nativeCallConv = "";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
+            {
+                nativeCallConv = " __attribute__((thiscall))";
+            }
+
             var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -1702,7 +1708,7 @@ struct MyStruct1B : MyStruct1A
       </function>
       <vtbl>
         <field name=""Dispose"" access=""public"">
-          <type native=""void ()"">IntPtr</type>
+          <type native=""void ()" + nativeCallConv + @""">IntPtr</type>
         </field>
       </vtbl>
     </struct>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
@@ -1641,5 +1641,76 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedXmlCompatibleUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        public override Task AccessModifierTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    protected: virtual ~MyStruct() = default;
+    public: void PublicMethod() {}
+    protected: void ProtectedMethod() {}
+    private: void PrivateMethod() {}
+
+    public: int publicField;
+    protected: int protectedField;
+    private: int privateField;
+};
+";
+
+            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" vtbl=""true"" unsafe=""true"">
+      <field name=""lpVtbl"" access=""public"">
+        <type>Vtbl*</type>
+      </field>
+      <field name=""publicField"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""protectedField"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""privateField"" access=""private"">
+        <type>int</type>
+      </field>
+      <delegate name=""_Dispose"" access=""public"" convention=""ThisCall"">
+        <type>void</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+      </delegate>
+      <function name=""PublicMethod"" access=""public"">
+        <type>void</type>
+        <code></code>
+      </function>
+      <function name=""ProtectedMethod"" access=""public"">
+        <type>void</type>
+        <code></code>
+      </function>
+      <function name=""PrivateMethod"" access=""private"">
+        <type>void</type>
+        <code></code>
+      </function>
+      <function name=""Dispose"" access=""public"" unsafe=""true"">
+        <type>void</type>
+        <body>
+          <code>fixed (MyStruct* pThis = &amp;this)
+    {
+        Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Dispose</delegate>&gt;(lpVtbl-&gt;<vtbl explicit=""True"">Dispose</vtbl>)(<param special=""thisPtr"">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <vtbl>
+        <field name=""Dispose"" access=""public"">
+          <type native=""void ()"">IntPtr</type>
+        </field>
+      </vtbl>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
@@ -1646,5 +1646,76 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        public override Task AccessModifierTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    protected: virtual ~MyStruct() = default;
+    public: void PublicMethod() {}
+    protected: void ProtectedMethod() {}
+    private: void PrivateMethod() {}
+
+    public: int publicField;
+    protected: int protectedField;
+    private: int privateField;
+};
+";
+
+            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" vtbl=""true"" unsafe=""true"">
+      <field name=""lpVtbl"" access=""public"">
+        <type>Vtbl*</type>
+      </field>
+      <field name=""publicField"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""protectedField"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""privateField"" access=""private"">
+        <type>int</type>
+      </field>
+      <delegate name=""_Dispose"" access=""public"" convention=""ThisCall"">
+        <type>void</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+      </delegate>
+      <function name=""PublicMethod"" access=""public"">
+        <type>void</type>
+        <code></code>
+      </function>
+      <function name=""ProtectedMethod"" access=""public"">
+        <type>void</type>
+        <code></code>
+      </function>
+      <function name=""PrivateMethod"" access=""private"">
+        <type>void</type>
+        <code></code>
+      </function>
+      <function name=""Dispose"" access=""public"" unsafe=""true"">
+        <type>void</type>
+        <body>
+          <code>fixed (MyStruct* pThis = &amp;this)
+    {
+        Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Dispose</delegate>&gt;(lpVtbl-&gt;<vtbl explicit=""True"">Dispose</vtbl>)(<param special=""thisPtr"">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <vtbl>
+        <field name=""Dispose"" access=""public"">
+          <type native=""void ()"">IntPtr</type>
+        </field>
+      </vtbl>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
@@ -1662,6 +1662,12 @@ struct MyStruct1B : MyStruct1A
 };
 ";
 
+            var nativeCallConv = "";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
+            {
+                nativeCallConv = " __attribute__((thiscall))";
+            }
+
             var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
@@ -1707,7 +1713,7 @@ struct MyStruct1B : MyStruct1A
       </function>
       <vtbl>
         <field name=""Dispose"" access=""public"">
-          <type native=""void ()"">IntPtr</type>
+          <type native=""void ()" + nativeCallConv + @""">IntPtr</type>
         </field>
       </vtbl>
     </struct>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
@@ -1637,7 +1637,9 @@ struct MyStruct1B : MyStruct1A
 };
 ";
 
-            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+            var vtblIndex = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : 1;
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"" vtbl=""true"" unsafe=""true"">
@@ -1668,7 +1670,7 @@ struct MyStruct1B : MyStruct1A
       <function name=""Dispose"" access=""public"" unsafe=""true"">
         <type>void</type>
         <body>
-          <code>((delegate* unmanaged[Thiscall]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>((delegate* unmanaged[Thiscall]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">{vtblIndex}</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
     </struct>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
@@ -1621,5 +1621,62 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedXmlLatestUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        public override Task AccessModifierTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    protected: virtual ~MyStruct() = default;
+    public: void PublicMethod() {}
+    protected: void ProtectedMethod() {}
+    private: void PrivateMethod() {}
+
+    public: int publicField;
+    protected: int protectedField;
+    private: int privateField;
+};
+";
+
+            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" vtbl=""true"" unsafe=""true"">
+      <field name=""lpVtbl"" access=""public"">
+        <type>void**</type>
+      </field>
+      <field name=""publicField"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""protectedField"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""privateField"" access=""private"">
+        <type>int</type>
+      </field>
+      <function name=""PublicMethod"" access=""public"">
+        <type>void</type>
+        <code></code>
+      </function>
+      <function name=""ProtectedMethod"" access=""public"">
+        <type>void</type>
+        <code></code>
+      </function>
+      <function name=""PrivateMethod"" access=""private"">
+        <type>void</type>
+        <code></code>
+      </function>
+      <function name=""Dispose"" access=""public"" unsafe=""true"">
+        <type>void</type>
+        <body>
+          <code>((delegate* unmanaged[Thiscall]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
@@ -1643,7 +1643,9 @@ struct MyStruct1B : MyStruct1A
 };
 ";
 
-            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+            var vtblIndex = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : 1;
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"" vtbl=""true"" unsafe=""true"">
@@ -1674,7 +1676,7 @@ struct MyStruct1B : MyStruct1A
       <function name=""Dispose"" access=""public"" unsafe=""true"">
         <type>void</type>
         <body>
-          <code>((delegate* unmanaged[Thiscall]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+          <code>((delegate* unmanaged[Thiscall]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">{vtblIndex}</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
         </body>
       </function>
     </struct>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
@@ -1627,5 +1627,62 @@ struct MyStruct1B : MyStruct1A
 
             return ValidateGeneratedXmlLatestWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        public override Task AccessModifierTest()
+        {
+            var inputContents = @"struct MyStruct
+{
+    protected: virtual ~MyStruct() = default;
+    public: void PublicMethod() {}
+    protected: void ProtectedMethod() {}
+    private: void PrivateMethod() {}
+
+    public: int publicField;
+    protected: int protectedField;
+    private: int privateField;
+};
+";
+
+            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" vtbl=""true"" unsafe=""true"">
+      <field name=""lpVtbl"" access=""public"">
+        <type>void**</type>
+      </field>
+      <field name=""publicField"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""protectedField"" access=""public"">
+        <type>int</type>
+      </field>
+      <field name=""privateField"" access=""private"">
+        <type>int</type>
+      </field>
+      <function name=""PublicMethod"" access=""public"">
+        <type>void</type>
+        <code></code>
+      </function>
+      <function name=""ProtectedMethod"" access=""public"">
+        <type>void</type>
+        <code></code>
+      </function>
+      <function name=""PrivateMethod"" access=""private"">
+        <type>void</type>
+        <code></code>
+      </function>
+      <function name=""Dispose"" access=""public"" unsafe=""true"">
+        <type>void</type>
+        <body>
+          <code>((delegate* unmanaged[Thiscall]&lt;MyStruct*, void&gt;)(lpVtbl[<vtbl explicit=""False"">0</vtbl>]))(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
     }
 }


### PR DESCRIPTION
Protected C++ entries are also generated as protected C# entries. This is afaik always wrong as protected is not allowed in neither namespaces nor structs. This PR thus replaces this access modifier with `public` as my reasoning was that using applications might want to access those to e.g. implement new inheriting classes. But this could very well also be a config flag.
I deliberately included a virtual protected method with explicit vtables and without function pointers to test delegates and vtable fields.

During this feature there was an issue with delegates not being generated when the implementation is not user-provided (e.g. `virtual ~MyStruct() = default;`)