### PR TITLE
Greatly improve the understanding of the `log-potential-typedef-remappings` feature

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -2440,7 +2440,7 @@ namespace ClangSharp
             outputBuilder.Write("Marshal.OffsetOf<");
             outputBuilder.Write(GetRemappedTypeName(offsetOfExpr, context: null, offsetOfExpr.TypeSourceInfoType, out var _, skipUsing: false));
             outputBuilder.Write(">(\"");
-            Visit(offsetOfExpr.Referenced);
+            Visit(offsetOfExpr.Referenced ?? offsetOfExpr.CursorChildren[1]);
             outputBuilder.Write("\")");
 
             StopCSharpCode();


### PR DESCRIPTION
As per the title, this improves the `log-potential-typedef-remappings` feature. In particular we now actually track found typedefs and compare that against given remappings; suggesting a "preferred" remapping using the existing heuristics if one exists and always listing the alternative remappings that were found.

Users can still override this behavior by prefixing the remapped name with `@`. For example `IID_XMLDSOControl=@CLSID_XMLDSOControl`. This allows you to override the naming without worrying about warnings still being raised.