### PR TITLE
Ensure that non-virtual C++ instance methods without a body have an inserted parameter for pThis

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -3406,6 +3406,26 @@ namespace ClangSharp
 
                 case CX_StmtClass.CX_StmtClass_CallExpr:
                 {
+                    var callExpr = (CallExpr)initExpr;
+
+                    if (callExpr.DirectCallee.IsInlined)
+                    {
+                        var evaluateResult = callExpr.Handle.Evaluate;
+
+                        switch (evaluateResult.Kind)
+                        {
+                            case CXEvalResultKind.CXEval_Int:
+                            {
+                                return true;
+                            }
+
+                            case CXEvalResultKind.CXEval_Float:
+                            {
+                                return true;
+                            }
+                        }
+                    }
+
                     return false;
                 }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -185,7 +185,7 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
-        public static extern void MyVoidMethod();
+        public static extern void MyVoidMethod(MyStruct* pThis);
 
         public int MyInt32Method()
         {{

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -185,7 +185,7 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
-        public static extern void MyVoidMethod();
+        public static extern void MyVoidMethod(MyStruct* pThis);
 
         public int MyInt32Method()
         {{

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
@@ -185,7 +185,7 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
-        public static extern void MyVoidMethod();
+        public static extern void MyVoidMethod(MyStruct* pThis);
 
         public int MyInt32Method()
         {{

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -185,7 +185,7 @@ namespace ClangSharp.Test
     public partial struct MyStruct
     {{
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
-        public static extern void MyVoidMethod();
+        public static extern void MyVoidMethod(MyStruct* pThis);
 
         public int MyInt32Method()
         {{

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -226,6 +226,9 @@ namespace ClangSharp.UnitTests
     <struct name=""MyStruct"" access=""public"">
       <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
         <type>void</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
       </function>
       <function name=""MyInt32Method"" access=""public"">
         <type>int</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -226,6 +226,9 @@ namespace ClangSharp.UnitTests
     <struct name=""MyStruct"" access=""public"">
       <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
         <type>void</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
       </function>
       <function name=""MyInt32Method"" access=""public"">
         <type>int</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
@@ -226,6 +226,9 @@ namespace ClangSharp.UnitTests
     <struct name=""MyStruct"" access=""public"">
       <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
         <type>void</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
       </function>
       <function name=""MyInt32Method"" access=""public"">
         <type>int</type>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
@@ -226,6 +226,9 @@ namespace ClangSharp.UnitTests
     <struct name=""MyStruct"" access=""public"">
       <function name=""MyVoidMethod"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"">
         <type>void</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
       </function>
       <function name=""MyInt32Method"" access=""public"">
         <type>int</type>


### PR DESCRIPTION
This resolves https://github.com/dotnet/ClangSharp/issues/302