### PR TITLE
Add note about libclang/libClangSharp runtime and restore discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ A nuget package for the project is provided here: https://www.nuget.org/packages
 A .NET tool for the P/Invoke generator project is provided here: https://www.nuget.org/packages/ClangSharpPInvokeGenerator
 
 A convenience package which provides the native libClang library for several platforms is provided here: https://www.nuget.org/packages/libclang
+
 A helper package which exposes many Clang APIs missing from libClang is provided here: https://www.nuget.org/packages/libClangSharp
+
+NOTE: libclang and libClangSharp are meta-packages which point to the platform-specific runtime packages ([e.g.](https://www.nuget.org/packages/libClangSharp.runtime.win-x64/13.0.0-beta1); see others owned by [tannergooding](https://www.nuget.org/profiles/tannergooding)). Several manual steps may be required to use them, see discussion in [#46](https://github.com/dotnet/ClangSharp/issues/46) and [#118](https://github.com/dotnet/ClangSharp/issues/118).
 
 Nightly packages are available via the NuGet Feed URL: https://pkgs.clangsharp.dev/index.json
 


### PR DESCRIPTION
Adds a note pointing to the issues where installation of platform-specific library runtimes is discussed.