### PR TITLE
Fix clangsharp_Type_getTemplateArgument for record decl

### DIFF
--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -5403,6 +5403,14 @@ CX_TemplateArgument clangsharp_Type_getTemplateArgument(CXType CT, unsigned i) {
         }
     }
 
+    // Matching what clang_Type_getNumTemplateArguments/Type.GetTemplateArguments is doing here
+    if (const auto* RecordDecl = T->getAsCXXRecordDecl()) {
+        const auto* TemplateDecl = dyn_cast<ClassTemplateSpecializationDecl>(RecordDecl);
+        if (TemplateDecl && i < TemplateDecl->getTemplateArgs().size()) {
+            return MakeCXTemplateArgument(&TemplateDecl->getTemplateArgs()[i], GetTypeTU(CT));
+        }
+    }
+
     return MakeCXTemplateArgument(nullptr, GetTypeTU(CT));
 }
 


### PR DESCRIPTION
Hey,
While trying to upgrade CppAst to 14.0, I got into trouble with `clangsharp_Type_getTemplateArgument`  that was not able to recover template arguments for a record/struct:

```
template <typename T, typename U>
struct TemplateStruct
{
    T field0;
    U field1;
};

struct Struct2
{
};

TemplateStruct<int, Struct2> exposed;
```
This PR is trying to fix the issue by using the same code that is in `clang_Type_getNumTemplateArguments`/`Type.GetTemplateArguments`.