### PR TITLE
Fix linking to Clang libraries on Linux

### DIFF
--- a/sources/libClangSharp/CMakeLists.txt
+++ b/sources/libClangSharp/CMakeLists.txt
@@ -33,13 +33,20 @@ set(LLVM_SEARCH_PATHS
   ${PATH_TO_LLVM}/share/llvm/cmake/
 )
 
+option(LLVM_USE_STATIC "Link to static versions of LLVM/Clang libraries" ON)
+
 find_package(Clang REQUIRED CONFIG
              PATHS ${LLVM_SEARCH_PATHS}
              NO_DEFAULT_PATH)
 
 add_library(ClangSharp SHARED ${SOURCES})
 
-target_link_libraries(ClangSharp PRIVATE clangAST clangFrontend libclang)
+if (LLVM_USE_STATIC)
+    target_link_libraries(ClangSharp PRIVATE clangAST clangFrontend)
+else()
+    target_link_libraries(ClangSharp PRIVATE clang-cpp)
+endif()
+target_link_libraries(ClangSharp PRIVATE libclang)
 
 target_include_directories(ClangSharp PRIVATE ${CLANG_INCLUDE_DIRS})
 


### PR DESCRIPTION
Linux distributions prefer dynamic libraries but we'd like to link to
Clang statically. Therefore we return the test for clang targets but
extend it to prefer static Clang libraries and fall back to the
clang-cpp library when the static ones are unavailable.

Fixes #336.