### PR TITLE
Allow private access specifiers on functions

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -445,7 +445,7 @@ namespace ClangSharp.CSharp
             }
             else
             {
-                WriteIndented(GetAccessSpecifierString(desc.AccessSpecifier, isNested: false));
+                WriteIndented(GetAccessSpecifierString(desc.AccessSpecifier, isNested: true));
                 Write(' ');
             }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -491,7 +491,7 @@ namespace ClangSharp
                 return;
             }
 
-            var accessSppecifier = GetAccessSpecifier(functionDecl);
+            var accessSpecifier = GetAccessSpecifier(functionDecl);
 
             var body = functionDecl.Body;
             var hasBody = body is not null;
@@ -530,7 +530,7 @@ namespace ClangSharp
             var needsReturnFixup = isCxxMethodDecl && NeedsReturnFixup(cxxMethodDecl);
 
             var desc = new FunctionOrDelegateDesc {
-                AccessSpecifier = accessSppecifier,
+                AccessSpecifier = accessSpecifier,
                 NativeTypeName = nativeTypeName,
                 EscapedName = escapedName,
                 ParentName = parentName,
@@ -3677,7 +3677,7 @@ namespace ClangSharp
             {
                 return IsPrimitiveValue(autoType.CanonicalType);
             }
-            else if (type is BuiltinType builtinType)
+            else if (type is BuiltinType)
             {
                 switch (type.Kind)
                 {


### PR DESCRIPTION
`private` access specifier on a function identifier is getting overridden to `internal` by the check meant to prevent `private` on non-nested types.

The XML generator is already doing the right thing.