### PR TITLE
Updating to use the latest System.CommandLine

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -40,7 +40,7 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageReference Update="NUnit" Version="3.13.3" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Update="System.CommandLine" Version="2.0.0-beta1.21308.1" />
+    <PackageReference Update="System.CommandLine" Version="2.0.0-beta3.22114.1" />
     <PackageReference Update="System.Memory" Version="4.5.4" />
   </ItemGroup>
 

--- a/sources/ClangSharpPInvokeGenerator/CustomHelpBuilder.cs
+++ b/sources/ClangSharpPInvokeGenerator/CustomHelpBuilder.cs
@@ -11,12 +11,16 @@ namespace ClangSharp
 {
     internal sealed class CustomHelpBuilder : HelpBuilder
     {
-        public CustomHelpBuilder(IConsole console, int maxWidth = int.MaxValue)
-            : base(console, maxWidth)
+        private IConsole Console { get; }
+
+        public CustomHelpBuilder(IConsole console, LocalizationResources localizationResources,
+            int maxWidth = int.MaxValue)
+            : base(localizationResources, maxWidth)
         {
+            Console = console;
         }
 
-        public void Write(IOption option)
+        public void Write(Option option)
         {
             Write(string.Join(", ", option.Aliases));
             Write("\t");
@@ -26,15 +30,16 @@ namespace ClangSharp
 
         public void Write(string value) => Console.Out.Write(value);
 
-        public void Write(params HelpItem[] helpItems)
+        public void Write(params TwoColumnHelpRow[] helpItems)
         {
             WriteLine("Options:");
-            RenderAsColumns(helpItems);
+            var _ = new Command("unused");
+            WriteColumns(helpItems, new HelpContext(this, _, Console.Out.CreateTextWriter()));
             WriteLine();
         }
 
         public void WriteLine() => Console.Out.WriteLine();
-
+        
         public void WriteLine(string value) => Console.Out.WriteLine(value);
     }
 }


### PR DESCRIPTION
I tried to keep the structure similar to what was there previously.

Some notable differences.

1. Had to update to using the `CommandLineBuilder` directly because calling `Command.Invoke` with and option that matched the `--version` caused an error with a duplicate symbol.
2. The default value on the help output for most of the items is now showing as `[]` where before it was `[default: ]`
3. The two column rendering in the help builder required creating a `HelpContext` I believe this API could be improved in System.CommandLine to make this easier.