### PR TITLE
Add support for varargs.

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -578,8 +578,11 @@ namespace ClangSharp.CSharp
                 _customAttrIsForParameter = false;
 
                 Write(info.Type);
-                Write(' ');
-                Write(info.Name);
+                if (info.Name.Length > 0)
+                {
+                    Write(' ');
+                    Write(info.Name);
+                }
             }
         }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1922,6 +1922,14 @@ namespace ClangSharp
 
         private CallingConvention GetCallingConvention(Cursor cursor, Cursor context, Type type)
         {
+            if (cursor is FunctionDecl functionDecl)
+            {
+                if (functionDecl.IsVariadic)
+                {
+                    return CallingConvention.Cdecl;
+                }
+            }
+
             if (cursor is NamedDecl namedDecl)
             {
                 if (TryGetRemappedValue(namedDecl, _config.WithCallConvs, out var callConv, matchStar: true))

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/FunctionDeclarationDllImportTest.cs
@@ -73,6 +73,9 @@ namespace ClangSharp.UnitTests
         [Test]
         public Task SourceLocationTest() => SourceLocationTestImpl();
 
+        [Test]
+        public Task VarargsTest() => VarargsTestImpl();
+
         protected abstract Task BasicTestImpl();
 
         protected abstract Task ArrayParameterTestImpl();
@@ -106,5 +109,7 @@ namespace ClangSharp.UnitTests
         protected abstract Task WithSetLastErrorStarTestImpl();
 
         protected abstract Task SourceLocationTestImpl();
+
+        protected abstract Task VarargsTestImpl();
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/FunctionDeclarationDllImportTest.cs
@@ -396,5 +396,7 @@ namespace ClangSharp.Test
 
             return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        protected override Task VarargsTestImpl() => Task.CompletedTask;
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/FunctionDeclarationDllImportTest.cs
@@ -407,7 +407,7 @@ namespace ClangSharp.Test
     public static partial class Methods
     {
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern void MyFunction(int value, __arglist );
+        public static extern void MyFunction(int value, __arglist);
     }
 }
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/FunctionDeclarationDllImportTest.cs
@@ -395,5 +395,24 @@ namespace ClangSharp.Test
 
             return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        protected override Task VarargsTestImpl()
+        {
+            const string InputContents = @"extern ""C"" void MyFunction(int value, ...);";
+
+            const string ExpectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void MyFunction(int value, __arglist );
+    }
+}
+";
+
+            return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(InputContents, ExpectedOutputContents);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/FunctionDeclarationDllImportTest.cs
@@ -394,5 +394,7 @@ namespace ClangSharp.Test
 
             return ValidateGeneratedCSharpLatestUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        protected override Task VarargsTestImpl() => Task.CompletedTask;
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/FunctionDeclarationDllImportTest.cs
@@ -394,5 +394,24 @@ namespace ClangSharp.Test
 
             return ValidateGeneratedCSharpLatestWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        protected override Task VarargsTestImpl()
+        {
+            const string InputContents = @"extern ""C"" void MyFunction(int value, ...);";
+
+            const string ExpectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void MyFunction(int value, __arglist );
+    }
+}
+";
+
+            return ValidateGeneratedCSharpLatestWindowsBindingsAsync(InputContents, ExpectedOutputContents);
+        }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/FunctionDeclarationDllImportTest.cs
@@ -406,7 +406,7 @@ namespace ClangSharp.Test
     public static partial class Methods
     {
         [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern void MyFunction(int value, __arglist );
+        public static extern void MyFunction(int value, __arglist);
     }
 }
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/FunctionDeclarationDllImportTest.cs
@@ -447,5 +447,7 @@ struct MyStruct
 
             return ValidateGeneratedXmlCompatibleUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        protected override Task VarargsTestImpl() => Task.CompletedTask;
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/FunctionDeclarationDllImportTest.cs
@@ -447,5 +447,7 @@ struct MyStruct
 
             return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        protected override Task VarargsTestImpl() => Task.CompletedTask;
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/FunctionDeclarationDllImportTest.cs
@@ -447,5 +447,7 @@ struct MyStruct
 
             return ValidateGeneratedXmlLatestUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        protected override Task VarargsTestImpl() => Task.CompletedTask;
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/FunctionDeclarationDllImportTest.cs
@@ -447,5 +447,7 @@ struct MyStruct
 
             return ValidateGeneratedXmlLatestWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
         }
+
+        protected override Task VarargsTestImpl() => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
According to microsoft/win32metadata#917 and https://github.com/microsoft/win32metadata/issues/33 , the win32 metadata doesn't recognize the varargs declarations, which gives much inconvenience. This PR adds simple dll-import support for varargs, and generate C# code with undocumented keyword `__arglist`.