### PR TITLE
Do not remove parethensis

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -1612,7 +1612,7 @@ namespace ClangSharp
 
             if (!memberExpr.IsImplicitAccess || isForDerivedType)
             {
-                var memberExprBase = memberExpr.Base.IgnoreParens.IgnoreImplicit;
+                var memberExprBase = memberExpr.Base.IgnoreImplicit;
 
                 if (isForDerivedType)
                 {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationTest.cs
@@ -58,6 +58,46 @@ namespace ClangSharp.UnitTests
         [Test]
         public Task VirtualWithVtblIndexAttributeTest() => VirtualWithVtblIndexAttributeTestImpl();
 
+        [Test]
+        public virtual Task MacrosExpansionTest()
+        {
+            var inputContents = @"typedef struct
+{
+	unsigned char *buf;
+	int size;
+} context_t;
+
+int buf_close(void *pcontext)
+{
+	((context_t*)pcontext)->buf=0;
+	return 0;
+}
+";
+
+            var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public unsafe partial struct context_t
+    {
+        [NativeTypeName(""unsigned char *"")]
+        public byte* buf;
+
+        public int size;
+    }
+
+    public static unsafe partial class Methods
+    {
+        public static int buf_close(void* pcontext)
+        {
+            ((context_t*)(pcontext))->buf = null;
+            return 0;
+        }
+    }
+}
+";
+
+            return ValidateBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         protected abstract Task ConstructorTestImpl();
 
         protected abstract Task ConstructorWithInitializeTestImpl();
@@ -91,5 +131,7 @@ namespace ClangSharp.UnitTests
         protected abstract Task VirtualTestImpl();
 
         protected abstract Task VirtualWithVtblIndexAttributeTestImpl();
+
+        protected abstract Task ValidateBindingsAsync(string inputContents, string expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationXmlTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationXmlTest.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests
+{
+    public abstract class CXXMethodDeclarationXmlTest: CXXMethodDeclarationTest
+    {
+        [Test]
+        public override Task MacrosExpansionTest()
+        {
+            var inputContents = @"typedef struct
+{
+	unsigned char *buf;
+	int size;
+} context_t;
+
+int buf_close(void *pcontext)
+{
+	((context_t*)pcontext)->buf=0;
+	return 0;
+}
+";
+
+            var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""context_t"" access=""public"" unsafe=""true"">
+      <field name=""buf"" access=""public"">
+        <type native=""unsigned char *"">byte*</type>
+      </field>
+      <field name=""size"" access=""public"">
+        <type>int</type>
+      </field>
+    </struct>
+    <class name=""Methods"" access=""public"" static=""true"">
+      <function name=""buf_close"" access=""public"" static=""true"" unsafe=""true"">
+        <type>int</type>
+        <param name=""pcontext"">
+          <type>void*</type>
+        </param>
+        <code>((context_t*)(<value>pcontext</value>))-&gt;buf = null;
+      return 0;</code>
+      </function>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateBindingsAsync(inputContents, expectedOutputContents);
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -937,5 +937,7 @@ namespace ClangSharp.Test
 
             return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateVtblIndexAttribute);
         }
+
+        protected override Task ValidateBindingsAsync(string inputContents, string expectedOutputContents) => ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -937,5 +937,7 @@ namespace ClangSharp.Test
 
             return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateVtblIndexAttribute);
         }
+
+        protected override Task ValidateBindingsAsync(string inputContents, string expectedOutputContents) => ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
@@ -847,5 +847,7 @@ namespace ClangSharp.Test
 
             return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateVtblIndexAttribute);
         }
+
+        protected override Task ValidateBindingsAsync(string inputContents, string expectedOutputContents) => ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -847,5 +847,7 @@ namespace ClangSharp.Test
 
             return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateVtblIndexAttribute);
         }
+
+        protected override Task ValidateBindingsAsync(string inputContents, string expectedOutputContents) => ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace ClangSharp.UnitTests
 {
-    public sealed class XmlCompatibleUnix_CXXMethodDeclarationTest : CXXMethodDeclarationTest
+    public sealed class XmlCompatibleUnix_CXXMethodDeclarationTest : CXXMethodDeclarationXmlTest
     {
         protected override Task ConstructorTestImpl()
         {
@@ -1113,5 +1113,7 @@ extern ""C"" void MyFunction();";
 
             return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateVtblIndexAttribute);
         }
+
+        protected override Task ValidateBindingsAsync(string inputContents, string expectedOutputContents) => ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace ClangSharp.UnitTests
 {
-    public sealed class XmlCompatibleWindows_CXXMethodDeclarationTest : CXXMethodDeclarationTest
+    public sealed class XmlCompatibleWindows_CXXMethodDeclarationTest : CXXMethodDeclarationXmlTest
     {
         protected override Task ConstructorTestImpl()
         {
@@ -1113,5 +1113,7 @@ extern ""C"" void MyFunction();";
 
             return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateVtblIndexAttribute);
         }
+
+        protected override Task ValidateBindingsAsync(string inputContents, string expectedOutputContents) => ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace ClangSharp.UnitTests
 {
-    public sealed class XmlLatestUnix_CXXMethodDeclarationTest : CXXMethodDeclarationTest
+    public sealed class XmlLatestUnix_CXXMethodDeclarationTest : CXXMethodDeclarationXmlTest
     {
         protected override Task ConstructorTestImpl()
         {
@@ -969,5 +969,7 @@ extern ""C"" void MyFunction();";
 
             return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateVtblIndexAttribute);
         }
+
+        protected override Task ValidateBindingsAsync(string inputContents, string expectedOutputContents) => ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace ClangSharp.UnitTests
 {
-    public sealed class XmlLatestWindows_CXXMethodDeclarationTest : CXXMethodDeclarationTest
+    public sealed class XmlLatestWindows_CXXMethodDeclarationTest : CXXMethodDeclarationXmlTest
     {
         protected override Task ConstructorTestImpl()
         {
@@ -969,5 +969,7 @@ extern ""C"" void MyFunction();";
 
             return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateVtblIndexAttribute);
         }
+
+        protected override Task ValidateBindingsAsync(string inputContents, string expectedOutputContents) => ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 }


### PR DESCRIPTION
That's potentially risky move on real codebases, but that's not captured anywhere in tests, so I will move ahead with a change.

Would be good if somebody test that on some larger codebase and check how it works for them.

Most other changes is only in testing infra. I take liberty and do following change operating from following premises.
- there only 2 radically different output formats: CSharp and Xml
- Most codegeneration would be platform neutral.
- You will need to override tests based on platform needs (like it is right now)

I do trying not create sets of identical tests for each platform, since it's a bit boring and timeconsuming to validate. For example using existing approach not clear what's platform-independent behaviour and what is OS specific behavior of ClangSharp. After this change all platform independent tests may sit in Base folder, and additional tests and/or augmentations will be in same location as it is now.

Fixes #357