### PR TITLE
Fix `lpVtbl` field declaration when both `explicit-vtbls` and `generate-marker interfaces` are specified

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1545,7 +1545,14 @@ namespace ClangSharp
 
                     if (_config.GenerateExplicitVtbls)
                     {
-                        _outputBuilder.WriteRegularField("Vtbl*", "lpVtbl");
+                        if (_config.GenerateMarkerInterfaces && !_config.GenerateCompatibleCode)
+                        {
+                            _outputBuilder.WriteRegularField($"Vtbl<{nativeName}>*", "lpVtbl");
+                        }
+                        else
+                        {
+                            _outputBuilder.WriteRegularField("Vtbl*", "lpVtbl");
+                        }
                     }
                     else
                     {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationTest.cs
@@ -38,6 +38,9 @@ namespace ClangSharp.UnitTests
         public Task NewKeywordVirtualWithExplicitVtblTest() => NewKeywordVirtualWithExplicitVtblTestImpl();
 
         [Test]
+        public Task NewKeywordVirtualWithExplicitVtblAndMarkerInterfaceTest() => NewKeywordVirtualWithExplicitVtblAndMarkerInterfaceTestImpl();
+
+        [Test]
         public Task OperatorTest() => OperatorTestImpl();
 
         [Test]
@@ -117,6 +120,8 @@ int buf_close(void *pcontext)
         protected abstract Task NewKeywordVirtualTestImpl();
 
         protected abstract Task NewKeywordVirtualWithExplicitVtblTestImpl();
+
+        protected abstract Task NewKeywordVirtualWithExplicitVtblAndMarkerInterfaceTestImpl();
 
         protected abstract Task OperatorTestImpl();
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -539,6 +539,91 @@ namespace ClangSharp.Test
             return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls);
         }
 
+        protected override Task NewKeywordVirtualWithExplicitVtblAndMarkerInterfaceTestImpl()
+        {
+            var inputContents = @"struct MyStruct
+{
+    virtual int GetType(int obj) = 0;
+    virtual int GetType() = 0;
+    virtual int GetType(int objA, int objB) = 0;
+};";
+
+            var nativeCallConv = "";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
+            {
+                nativeCallConv = " __attribute__((thiscall))";
+            }
+
+            var expectedOutputContents = $@"using System;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    public unsafe partial struct MyStruct : MyStruct.Interface
+    {{
+        public Vtbl* lpVtbl;
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _GetType(MyStruct* pThis, int objA, int objB);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _GetType1(MyStruct* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _GetType2(MyStruct* pThis, int obj);
+
+        public int GetType(int objA, int objB)
+        {{
+            fixed (MyStruct* pThis = &this)
+            {{
+                return Marshal.GetDelegateForFunctionPointer<_GetType>(lpVtbl->GetType)(pThis, objA, objB);
+            }}
+        }}
+
+        public new int GetType()
+        {{
+            fixed (MyStruct* pThis = &this)
+            {{
+                return Marshal.GetDelegateForFunctionPointer<_GetType1>(lpVtbl->GetType1)(pThis);
+            }}
+        }}
+
+        public int GetType(int obj)
+        {{
+            fixed (MyStruct* pThis = &this)
+            {{
+                return Marshal.GetDelegateForFunctionPointer<_GetType2>(lpVtbl->GetType2)(pThis, obj);
+            }}
+        }}
+
+        public interface Interface
+        {{
+            int GetType(int objA, int objB);
+
+            int GetType();
+
+            int GetType(int obj);
+        }}
+
+        public partial struct Vtbl
+        {{
+            [NativeTypeName(""int (int, int){nativeCallConv}"")]
+            public new IntPtr GetType;
+
+            [NativeTypeName(""int (){nativeCallConv}"")]
+            public IntPtr GetType1;
+
+            [NativeTypeName(""int (int){nativeCallConv}"")]
+            public IntPtr GetType2;
+        }}
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls | PInvokeGeneratorConfigurationOptions.GenerateMarkerInterfaces);
+        }
+
         protected override Task OperatorTestImpl()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -501,6 +501,73 @@ namespace ClangSharp.Test
             return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls);
         }
 
+        protected override Task NewKeywordVirtualWithExplicitVtblAndMarkerInterfaceTestImpl()
+        {
+            var inputContents = @"struct MyStruct
+{
+    virtual int GetType(int obj) = 0;
+    virtual int GetType() = 0;
+    virtual int GetType(int objA, int objB) = 0;
+};";
+
+            var nativeCallConv = "";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
+            {
+                nativeCallConv = " __attribute__((thiscall))";
+            }
+
+            var expectedOutputContents = $@"using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{{
+    public unsafe partial struct MyStruct : MyStruct.Interface
+    {{
+        public Vtbl<MyStruct>* lpVtbl;
+
+        public int GetType(int objA, int objB)
+        {{
+            return lpVtbl->GetType((MyStruct*)Unsafe.AsPointer(ref this), objA, objB);
+        }}
+
+        public new int GetType()
+        {{
+            return lpVtbl->GetType1((MyStruct*)Unsafe.AsPointer(ref this));
+        }}
+
+        public int GetType(int obj)
+        {{
+            return lpVtbl->GetType2((MyStruct*)Unsafe.AsPointer(ref this), obj);
+        }}
+
+        public interface Interface
+        {{
+            int GetType(int objA, int objB);
+
+            int GetType();
+
+            int GetType(int obj);
+        }}
+
+        public partial struct Vtbl<TSelf>
+            where TSelf : unmanaged, Interface
+        {{
+            [NativeTypeName(""int (int, int){nativeCallConv}"")]
+            public new delegate* unmanaged[Thiscall]<TSelf*, int, int, int> GetType;
+
+            [NativeTypeName(""int (){nativeCallConv}"")]
+            public delegate* unmanaged[Thiscall]<TSelf*, int> GetType1;
+
+            [NativeTypeName(""int (int){nativeCallConv}"")]
+            public delegate* unmanaged[Thiscall]<TSelf*, int, int> GetType2;
+        }}
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls | PInvokeGeneratorConfigurationOptions.GenerateMarkerInterfaces);
+        }
+
         protected override Task OperatorTestImpl()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -655,6 +655,131 @@ int MyFunctionB(MyStruct* x)
             return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls);
         }
 
+        protected override Task NewKeywordVirtualWithExplicitVtblAndMarkerInterfaceTestImpl()
+        {
+            var inputContents = @"struct MyStruct
+{
+    virtual int GetType(int obj) = 0;
+    virtual int GetType() = 0;
+    virtual int GetType(int objA, int objB) = 0;
+};";
+
+            var nativeCallConv = "";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
+            {
+                nativeCallConv = " __attribute__((thiscall))";
+            }
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" vtbl=""true"" unsafe=""true"">
+      <field name=""lpVtbl"" access=""public"">
+        <type>Vtbl*</type>
+      </field>
+      <delegate name=""_GetType"" access=""public"" convention=""ThisCall"">
+        <type>int</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""objA"">
+          <type>int</type>
+        </param>
+        <param name=""objB"">
+          <type>int</type>
+        </param>
+      </delegate>
+      <delegate name=""_GetType1"" access=""public"" convention=""ThisCall"">
+        <type>int</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+      </delegate>
+      <delegate name=""_GetType2"" access=""public"" convention=""ThisCall"">
+        <type>int</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""obj"">
+          <type>int</type>
+        </param>
+      </delegate>
+      <function name=""GetType"" access=""public"" unsafe=""true"">
+        <type>int</type>
+        <param name=""objA"">
+          <type>int</type>
+        </param>
+        <param name=""objB"">
+          <type>int</type>
+        </param>
+        <body>
+          <code>fixed (MyStruct* pThis = &amp;this)
+    {{
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_GetType</delegate>&gt;(lpVtbl-&gt;<vtbl explicit=""True"">GetType</vtbl>)(<param special=""thisPtr"">pThis</param>, <param name=""objA"">objA</param>, <param name=""objB"">objB</param>);
+    }}</code>
+        </body>
+      </function>
+      <function name=""GetType"" access=""public"" unsafe=""true"">
+        <type>int</type>
+        <body>
+          <code>fixed (MyStruct* pThis = &amp;this)
+    {{
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_GetType1</delegate>&gt;(lpVtbl-&gt;<vtbl explicit=""True"">GetType1</vtbl>)(<param special=""thisPtr"">pThis</param>);
+    }}</code>
+        </body>
+      </function>
+      <function name=""GetType"" access=""public"" unsafe=""true"">
+        <type>int</type>
+        <param name=""obj"">
+          <type>int</type>
+        </param>
+        <body>
+          <code>fixed (MyStruct* pThis = &amp;this)
+    {{
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_GetType2</delegate>&gt;(lpVtbl-&gt;<vtbl explicit=""True"">GetType2</vtbl>)(<param special=""thisPtr"">pThis</param>, <param name=""obj"">obj</param>);
+    }}</code>
+        </body>
+      </function>
+      <interface>
+        <function name=""GetType"" access=""public"" unsafe=""true"">
+          <type>int</type>
+          <param name=""objA"">
+            <type>int</type>
+          </param>
+          <param name=""objB"">
+            <type>int</type>
+          </param>
+        </function>
+        <function name=""GetType"" access=""public"" unsafe=""true"">
+          <type>int</type>
+        </function>
+        <function name=""GetType"" access=""public"" unsafe=""true"">
+          <type>int</type>
+          <param name=""obj"">
+            <type>int</type>
+          </param>
+        </function>
+      </interface>
+      <vtbl>
+        <field name=""GetType"" access=""public"">
+          <type native=""int (int, int){nativeCallConv}"">IntPtr</type>
+        </field>
+        <field name=""GetType1"" access=""public"">
+          <type native=""int (){nativeCallConv}"">IntPtr</type>
+        </field>
+        <field name=""GetType2"" access=""public"">
+          <type native=""int (int){nativeCallConv}"">IntPtr</type>
+        </field>
+      </vtbl>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls | PInvokeGeneratorConfigurationOptions.GenerateMarkerInterfaces);
+        }
+
         protected override Task OperatorTestImpl()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -655,6 +655,131 @@ int MyFunctionB(MyStruct* x)
             return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls);
         }
 
+        protected override Task NewKeywordVirtualWithExplicitVtblAndMarkerInterfaceTestImpl()
+        {
+            var inputContents = @"struct MyStruct
+{
+    virtual int GetType(int obj) = 0;
+    virtual int GetType() = 0;
+    virtual int GetType(int objA, int objB) = 0;
+};";
+
+            var nativeCallConv = "";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
+            {
+                nativeCallConv = " __attribute__((thiscall))";
+            }
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" vtbl=""true"" unsafe=""true"">
+      <field name=""lpVtbl"" access=""public"">
+        <type>Vtbl*</type>
+      </field>
+      <delegate name=""_GetType"" access=""public"" convention=""ThisCall"">
+        <type>int</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""objA"">
+          <type>int</type>
+        </param>
+        <param name=""objB"">
+          <type>int</type>
+        </param>
+      </delegate>
+      <delegate name=""_GetType1"" access=""public"" convention=""ThisCall"">
+        <type>int</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+      </delegate>
+      <delegate name=""_GetType2"" access=""public"" convention=""ThisCall"">
+        <type>int</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""obj"">
+          <type>int</type>
+        </param>
+      </delegate>
+      <function name=""GetType"" access=""public"" unsafe=""true"">
+        <type>int</type>
+        <param name=""objA"">
+          <type>int</type>
+        </param>
+        <param name=""objB"">
+          <type>int</type>
+        </param>
+        <body>
+          <code>fixed (MyStruct* pThis = &amp;this)
+    {{
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_GetType</delegate>&gt;(lpVtbl-&gt;<vtbl explicit=""True"">GetType</vtbl>)(<param special=""thisPtr"">pThis</param>, <param name=""objA"">objA</param>, <param name=""objB"">objB</param>);
+    }}</code>
+        </body>
+      </function>
+      <function name=""GetType"" access=""public"" unsafe=""true"">
+        <type>int</type>
+        <body>
+          <code>fixed (MyStruct* pThis = &amp;this)
+    {{
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_GetType1</delegate>&gt;(lpVtbl-&gt;<vtbl explicit=""True"">GetType1</vtbl>)(<param special=""thisPtr"">pThis</param>);
+    }}</code>
+        </body>
+      </function>
+      <function name=""GetType"" access=""public"" unsafe=""true"">
+        <type>int</type>
+        <param name=""obj"">
+          <type>int</type>
+        </param>
+        <body>
+          <code>fixed (MyStruct* pThis = &amp;this)
+    {{
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_GetType2</delegate>&gt;(lpVtbl-&gt;<vtbl explicit=""True"">GetType2</vtbl>)(<param special=""thisPtr"">pThis</param>, <param name=""obj"">obj</param>);
+    }}</code>
+        </body>
+      </function>
+      <interface>
+        <function name=""GetType"" access=""public"" unsafe=""true"">
+          <type>int</type>
+          <param name=""objA"">
+            <type>int</type>
+          </param>
+          <param name=""objB"">
+            <type>int</type>
+          </param>
+        </function>
+        <function name=""GetType"" access=""public"" unsafe=""true"">
+          <type>int</type>
+        </function>
+        <function name=""GetType"" access=""public"" unsafe=""true"">
+          <type>int</type>
+          <param name=""obj"">
+            <type>int</type>
+          </param>
+        </function>
+      </interface>
+      <vtbl>
+        <field name=""GetType"" access=""public"">
+          <type native=""int (int, int){nativeCallConv}"">IntPtr</type>
+        </field>
+        <field name=""GetType1"" access=""public"">
+          <type native=""int (){nativeCallConv}"">IntPtr</type>
+        </field>
+        <field name=""GetType2"" access=""public"">
+          <type native=""int (int){nativeCallConv}"">IntPtr</type>
+        </field>
+      </vtbl>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls | PInvokeGeneratorConfigurationOptions.GenerateMarkerInterfaces);
+        }
+
         protected override Task OperatorTestImpl()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
@@ -583,6 +583,95 @@ int MyFunctionB(MyStruct* x)
             return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls);
         }
 
+        protected override Task NewKeywordVirtualWithExplicitVtblAndMarkerInterfaceTestImpl()
+        {
+            var inputContents = @"struct MyStruct
+{
+    virtual int GetType(int obj) = 0;
+    virtual int GetType() = 0;
+    virtual int GetType(int objA, int objB) = 0;
+};";
+
+            var nativeCallConv = "";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
+            {
+                nativeCallConv = " __attribute__((thiscall))";
+            }
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" vtbl=""true"" unsafe=""true"">
+      <field name=""lpVtbl"" access=""public"">
+        <type>Vtbl&lt;MyStruct&gt;*</type>
+      </field>
+      <function name=""GetType"" access=""public"" unsafe=""true"">
+        <type>int</type>
+        <param name=""objA"">
+          <type>int</type>
+        </param>
+        <param name=""objB"">
+          <type>int</type>
+        </param>
+        <body>
+          <code>return lpVtbl-&gt;<vtbl explicit=""True"">GetType</vtbl>(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>, <param name=""objA"">objA</param>, <param name=""objB"">objB</param>);</code>
+        </body>
+      </function>
+      <function name=""GetType"" access=""public"" unsafe=""true"">
+        <type>int</type>
+        <body>
+          <code>return lpVtbl-&gt;<vtbl explicit=""True"">GetType1</vtbl>(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name=""GetType"" access=""public"" unsafe=""true"">
+        <type>int</type>
+        <param name=""obj"">
+          <type>int</type>
+        </param>
+        <body>
+          <code>return lpVtbl-&gt;<vtbl explicit=""True"">GetType2</vtbl>(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>, <param name=""obj"">obj</param>);</code>
+        </body>
+      </function>
+      <interface>
+        <function name=""GetType"" access=""public"" unsafe=""true"">
+          <type>int</type>
+          <param name=""objA"">
+            <type>int</type>
+          </param>
+          <param name=""objB"">
+            <type>int</type>
+          </param>
+        </function>
+        <function name=""GetType"" access=""public"" unsafe=""true"">
+          <type>int</type>
+        </function>
+        <function name=""GetType"" access=""public"" unsafe=""true"">
+          <type>int</type>
+          <param name=""obj"">
+            <type>int</type>
+          </param>
+        </function>
+      </interface>
+      <vtbl>
+        <field name=""GetType"" access=""public"">
+          <type native=""int (int, int){nativeCallConv}"">delegate* unmanaged[Thiscall]&lt;TSelf*, int, int, int&gt;</type>
+        </field>
+        <field name=""GetType1"" access=""public"">
+          <type native=""int (){nativeCallConv}"">delegate* unmanaged[Thiscall]&lt;TSelf*, int&gt;</type>
+        </field>
+        <field name=""GetType2"" access=""public"">
+          <type native=""int (int){nativeCallConv}"">delegate* unmanaged[Thiscall]&lt;TSelf*, int, int&gt;</type>
+        </field>
+      </vtbl>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls | PInvokeGeneratorConfigurationOptions.GenerateMarkerInterfaces);
+        }
+
         protected override Task OperatorTestImpl()
         {
             var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
@@ -583,6 +583,95 @@ int MyFunctionB(MyStruct* x)
             return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls);
         }
 
+        protected override Task NewKeywordVirtualWithExplicitVtblAndMarkerInterfaceTestImpl()
+        {
+            var inputContents = @"struct MyStruct
+{
+    virtual int GetType(int obj) = 0;
+    virtual int GetType() = 0;
+    virtual int GetType(int objA, int objB) = 0;
+};";
+
+            var nativeCallConv = "";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
+            {
+                nativeCallConv = " __attribute__((thiscall))";
+            }
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" vtbl=""true"" unsafe=""true"">
+      <field name=""lpVtbl"" access=""public"">
+        <type>Vtbl&lt;MyStruct&gt;*</type>
+      </field>
+      <function name=""GetType"" access=""public"" unsafe=""true"">
+        <type>int</type>
+        <param name=""objA"">
+          <type>int</type>
+        </param>
+        <param name=""objB"">
+          <type>int</type>
+        </param>
+        <body>
+          <code>return lpVtbl-&gt;<vtbl explicit=""True"">GetType</vtbl>(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>, <param name=""objA"">objA</param>, <param name=""objB"">objB</param>);</code>
+        </body>
+      </function>
+      <function name=""GetType"" access=""public"" unsafe=""true"">
+        <type>int</type>
+        <body>
+          <code>return lpVtbl-&gt;<vtbl explicit=""True"">GetType1</vtbl>(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name=""GetType"" access=""public"" unsafe=""true"">
+        <type>int</type>
+        <param name=""obj"">
+          <type>int</type>
+        </param>
+        <body>
+          <code>return lpVtbl-&gt;<vtbl explicit=""True"">GetType2</vtbl>(<param special=""thisPtr"">(MyStruct*)Unsafe.AsPointer(ref this)</param>, <param name=""obj"">obj</param>);</code>
+        </body>
+      </function>
+      <interface>
+        <function name=""GetType"" access=""public"" unsafe=""true"">
+          <type>int</type>
+          <param name=""objA"">
+            <type>int</type>
+          </param>
+          <param name=""objB"">
+            <type>int</type>
+          </param>
+        </function>
+        <function name=""GetType"" access=""public"" unsafe=""true"">
+          <type>int</type>
+        </function>
+        <function name=""GetType"" access=""public"" unsafe=""true"">
+          <type>int</type>
+          <param name=""obj"">
+            <type>int</type>
+          </param>
+        </function>
+      </interface>
+      <vtbl>
+        <field name=""GetType"" access=""public"">
+          <type native=""int (int, int){nativeCallConv}"">delegate* unmanaged[Thiscall]&lt;TSelf*, int, int, int&gt;</type>
+        </field>
+        <field name=""GetType1"" access=""public"">
+          <type native=""int (){nativeCallConv}"">delegate* unmanaged[Thiscall]&lt;TSelf*, int&gt;</type>
+        </field>
+        <field name=""GetType2"" access=""public"">
+          <type native=""int (int){nativeCallConv}"">delegate* unmanaged[Thiscall]&lt;TSelf*, int, int&gt;</type>
+        </field>
+      </vtbl>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls | PInvokeGeneratorConfigurationOptions.GenerateMarkerInterfaces);
+        }
+
         protected override Task OperatorTestImpl()
         {
             var inputContents = @"struct MyStruct


### PR DESCRIPTION
Fixes #362