### PR TITLE
Adding tests and validate handling for various global string literal variables

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -144,6 +144,13 @@ namespace ClangSharp.CSharp
             {
                 Write(GetAccessSpecifierString(desc.AccessSpecifier, isNested: true));
                 Write(" static ");
+
+                if (desc.TypeName == "uint[]")
+                {
+                    Write("readonly ");
+                    isExpressionBody = false;
+                }
+
                 Write(desc.TypeName);
                 Write(' ');
             }

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -145,9 +145,12 @@ namespace ClangSharp.CSharp
                 Write(GetAccessSpecifierString(desc.AccessSpecifier, isNested: true));
                 Write(" static ");
 
-                if (desc.TypeName == "uint[]")
+                if (desc.TypeName is "byte[]" or "uint[]")
                 {
-                    Write("readonly ");
+                    if (desc.IsConstant)
+                    {
+                        Write("readonly ");
+                    }
                     isExpressionBody = false;
                 }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -3235,16 +3235,31 @@ namespace ClangSharp
                         {
                             if (_config.GenerateUnixTypes)
                             {
-                                goto default;
+                                goto case CX_CharacterKind.CX_CLK_UTF32;
                             }
-
-                            goto case CX_CharacterKind.CX_CLK_UTF16;
+                            else
+                            {
+                                goto case CX_CharacterKind.CX_CLK_UTF16;
+                            }
                         }
 
                         case CX_CharacterKind.CX_CLK_UTF16:
                         {
                             kind = ValueKind.Primitive;
                             typeName = "string";
+                            break;
+                        }
+
+                        case CX_CharacterKind.CX_CLK_UTF32:
+                        {
+                            if (_config.GeneratePreviewCode)
+                            {
+                                typeName = "ReadOnlySpan<uint>";
+                            }
+                            else
+                            {
+                                typeName = "uint[]";
+                            }
                             break;
                         }
 
@@ -3327,7 +3342,7 @@ namespace ClangSharp
                 {
                     StartUsingOutputBuilder(className);
 
-                    if ((kind == ValueKind.String) && (typeName == "ReadOnlySpan<byte>"))
+                    if ((kind == ValueKind.String) && typeName.StartsWith("ReadOnlySpan<"))
                     {
                         _outputBuilder.EmitSystemSupport();
                     }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -3227,7 +3227,14 @@ namespace ClangSharp
                         case CX_CharacterKind.CX_CLK_Ascii:
                         case CX_CharacterKind.CX_CLK_UTF8:
                         {
-                            typeName = "ReadOnlySpan<byte>";
+                            if (flags.HasFlag(ValueFlags.Constant))
+                            {
+                                typeName = "ReadOnlySpan<byte>";
+                            }
+                            else
+                            {
+                                typeName = "byte[]";
+                            }
                             break;
                         }
 
@@ -3252,7 +3259,7 @@ namespace ClangSharp
 
                         case CX_CharacterKind.CX_CLK_UTF32:
                         {
-                            if (_config.GeneratePreviewCode)
+                            if (_config.GeneratePreviewCode && flags.HasFlag(ValueFlags.Constant))
                             {
                                 typeName = "ReadOnlySpan<uint>";
                             }

--- a/sources/ClangSharp.PInvokeGenerator/XML/XmlOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/XmlOutputBuilder.VisitDecl.cs
@@ -34,9 +34,21 @@ namespace ClangSharp.XML
 
         public void BeginValue(in ValueDesc desc)
         {
-            _ = _sb.Append((desc.Kind != ValueKind.Enumerator)
-                ? $"<constant name=\"{desc.EscapedName}\" access=\"{desc.AccessSpecifier.AsString()}\">"
-                : $"<enumerator name=\"{desc.EscapedName}\" access=\"{desc.AccessSpecifier.AsString()}\">");
+            if (desc.Kind == ValueKind.Enumerator)
+            {
+                _ = _sb.Append("<enumerator");
+            }
+            else if (desc.IsConstant)
+            {
+                _ = _sb.Append("<constant");
+            }
+            else
+            {
+                _ = _sb.Append("<field");
+            }
+
+            _ = _sb.Append($" name=\"{desc.EscapedName}\" access=\"{desc.AccessSpecifier.AsString()}\">");
+
             desc.WriteCustomAttrs?.Invoke(desc.CustomAttrGeneratorData);
             _ = _sb.Append($"<type primitive=\"{desc.Kind == ValueKind.Primitive}\">");
             _ = _sb.Append(EscapeText(desc.TypeName));
@@ -58,7 +70,18 @@ namespace ClangSharp.XML
                 _ = _sb.Append("</value>");
             }
 
-            _ = _sb.Append((desc.Kind != ValueKind.Enumerator) ? "</constant>" : "</enumerator>");
+            if (desc.Kind == ValueKind.Enumerator)
+            {
+                _ = _sb.Append("</enumerator>");
+            }
+            else if (desc.IsConstant)
+            {
+                _ = _sb.Append("</constant>");
+            }
+            else
+            {
+                _ = _sb.Append("</field>");
+            }
         }
 
         public void BeginEnum(in EnumDesc desc)

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/VarDeclarationTest.cs
@@ -54,6 +54,12 @@ namespace ClangSharp.UnitTests
         public Task StringLiteralConstTest() => StringLiteralConstTestImpl();
 
         [Test]
+        public Task WideStringLiteralStaticConstTest() => WideStringLiteralStaticConstTestImpl();
+
+        [Test]
+        public Task StringLiteralStaticConstTest() => StringLiteralStaticConstTestImpl();
+
+        [Test]
         public Task UncheckedConversionMacroTest() => UncheckedConversionMacroTestImpl();
 
         [Test]
@@ -93,6 +99,10 @@ namespace ClangSharp.UnitTests
         protected abstract Task WideStringLiteralConstTestImpl();
 
         protected abstract Task StringLiteralConstTestImpl();
+
+        protected abstract Task WideStringLiteralStaticConstTestImpl();
+
+        protected abstract Task StringLiteralStaticConstTestImpl();
 
         protected abstract Task UncheckedConversionMacroTestImpl();
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/VarDeclarationTest.cs
@@ -151,13 +151,66 @@ namespace ClangSharp.Test
             return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
-        protected override Task WideStringLiteralConstTestImpl() =>
-            // Unsupported string literal kind: 'CX_CLK_Wide'
-            Task.CompletedTask;
+        protected override Task WideStringLiteralConstTestImpl()
+        {
+            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
+
+            var expectedOutputContents = $@"using System;
+
+namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""const wchar_t[5]"")]
+        public static readonly uint[] MyConst1 = new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
 
         protected override Task StringLiteralConstTestImpl()
         {
             var inputContents = $@"const char MyConst1[] = ""Test"";";
+
+            var expectedOutputContents = $@"using System;
+
+namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""const char[5]"")]
+        public static ReadOnlySpan<byte> MyConst1 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        protected override Task WideStringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+
+            var expectedOutputContents = $@"using System;
+
+namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""const wchar_t[5]"")]
+        public static readonly uint[] MyConst1 = new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        protected override Task StringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const char MyConst1[] = ""Test"";";
 
             var expectedOutputContents = $@"using System;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/VarDeclarationTest.cs
@@ -155,14 +155,12 @@ namespace ClangSharp.Test
         {
             var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
 
-            var expectedOutputContents = $@"using System;
-
-namespace ClangSharp.Test
+            var expectedOutputContents = $@"namespace ClangSharp.Test
 {{
     public static partial class Methods
     {{
         [NativeTypeName(""const wchar_t[5]"")]
-        public static readonly uint[] MyConst1 = new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+        public static readonly uint[] MyConst1 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
     }}
 }}
 ";
@@ -193,14 +191,12 @@ namespace ClangSharp.Test
         {
             var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
 
-            var expectedOutputContents = $@"using System;
-
-namespace ClangSharp.Test
+            var expectedOutputContents = $@"namespace ClangSharp.Test
 {{
     public static partial class Methods
     {{
         [NativeTypeName(""const wchar_t[5]"")]
-        public static readonly uint[] MyConst1 = new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+        public static readonly uint[] MyConst1 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/VarDeclarationTest.cs
@@ -153,7 +153,9 @@ namespace ClangSharp.Test
 
         protected override Task WideStringLiteralConstTestImpl()
         {
-            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";
+const wchar_t* MyConst2 = L""Test"";
+const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"namespace ClangSharp.Test
 {{
@@ -161,6 +163,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const wchar_t[5]"")]
         public static readonly uint[] MyConst1 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
+
+        [NativeTypeName(""const wchar_t *"")]
+        public static uint[] MyConst2 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
+
+        [NativeTypeName(""const wchar_t *const"")]
+        public static readonly uint[] MyConst3 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
     }}
 }}
 ";
@@ -170,7 +178,9 @@ namespace ClangSharp.Test
 
         protected override Task StringLiteralConstTestImpl()
         {
-            var inputContents = $@"const char MyConst1[] = ""Test"";";
+            var inputContents = $@"const char MyConst1[] = ""Test"";
+const char* MyConst2 = ""Test"";
+const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"using System;
 
@@ -180,6 +190,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const char[5]"")]
         public static ReadOnlySpan<byte> MyConst1 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *"")]
+        public static byte[] MyConst2 = new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *const"")]
+        public static ReadOnlySpan<byte> MyConst3 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
     }}
 }}
 ";
@@ -189,7 +205,9 @@ namespace ClangSharp.Test
 
         protected override Task WideStringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";
+static const wchar_t* MyConst2 = L""Test"";
+static const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"namespace ClangSharp.Test
 {{
@@ -197,6 +215,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const wchar_t[5]"")]
         public static readonly uint[] MyConst1 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
+
+        [NativeTypeName(""const wchar_t *"")]
+        public static uint[] MyConst2 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
+
+        [NativeTypeName(""const wchar_t *const"")]
+        public static readonly uint[] MyConst3 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
     }}
 }}
 ";
@@ -206,7 +230,9 @@ namespace ClangSharp.Test
 
         protected override Task StringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+            var inputContents = $@"static const char MyConst1[] = ""Test"";
+static const char* MyConst2 = ""Test"";
+static const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"using System;
 
@@ -216,6 +242,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const char[5]"")]
         public static ReadOnlySpan<byte> MyConst1 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *"")]
+        public static byte[] MyConst2 = new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *const"")]
+        public static ReadOnlySpan<byte> MyConst3 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/VarDeclarationTest.cs
@@ -187,6 +187,42 @@ namespace ClangSharp.Test
             return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        protected override Task WideStringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""const wchar_t[5]"")]
+        public const string MyConst1 = ""Test"";
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        protected override Task StringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+
+            var expectedOutputContents = $@"using System;
+
+namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""const char[5]"")]
+        public static ReadOnlySpan<byte> MyConst1 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         protected override Task UncheckedConversionMacroTestImpl()
         {
             var inputContents = $@"#define MyMacro1 (long)0x80000000L

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/VarDeclarationTest.cs
@@ -153,7 +153,9 @@ namespace ClangSharp.Test
 
         protected override Task WideStringLiteralConstTestImpl()
         {
-            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";
+const wchar_t* MyConst2 = L""Test"";
+const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"namespace ClangSharp.Test
 {{
@@ -161,6 +163,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const wchar_t[5]"")]
         public const string MyConst1 = ""Test"";
+
+        [NativeTypeName(""const wchar_t *"")]
+        public static string MyConst2 = ""Test"";
+
+        [NativeTypeName(""const wchar_t *const"")]
+        public const string MyConst3 = ""Test"";
     }}
 }}
 ";
@@ -170,7 +178,9 @@ namespace ClangSharp.Test
 
         protected override Task StringLiteralConstTestImpl()
         {
-            var inputContents = $@"const char MyConst1[] = ""Test"";";
+            var inputContents = $@"const char MyConst1[] = ""Test"";
+const char* MyConst2 = ""Test"";
+const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"using System;
 
@@ -180,6 +190,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const char[5]"")]
         public static ReadOnlySpan<byte> MyConst1 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *"")]
+        public static byte[] MyConst2 = new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *const"")]
+        public static ReadOnlySpan<byte> MyConst3 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
     }}
 }}
 ";
@@ -189,7 +205,9 @@ namespace ClangSharp.Test
 
         protected override Task WideStringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";
+static const wchar_t* MyConst2 = L""Test"";
+static const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"namespace ClangSharp.Test
 {{
@@ -197,6 +215,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const wchar_t[5]"")]
         public const string MyConst1 = ""Test"";
+
+        [NativeTypeName(""const wchar_t *"")]
+        public static string MyConst2 = ""Test"";
+
+        [NativeTypeName(""const wchar_t *const"")]
+        public const string MyConst3 = ""Test"";
     }}
 }}
 ";
@@ -206,7 +230,9 @@ namespace ClangSharp.Test
 
         protected override Task StringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+            var inputContents = $@"static const char MyConst1[] = ""Test"";
+static const char* MyConst2 = ""Test"";
+static const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"using System;
 
@@ -216,6 +242,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const char[5]"")]
         public static ReadOnlySpan<byte> MyConst1 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *"")]
+        public static byte[] MyConst2 = new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *const"")]
+        public static ReadOnlySpan<byte> MyConst3 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/VarDeclarationTest.cs
@@ -155,14 +155,12 @@ namespace ClangSharp.Test
         {
             var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
 
-            var expectedOutputContents = $@"using System;
-
-namespace ClangSharp.Test
+            var expectedOutputContents = $@"namespace ClangSharp.Test
 {{
     public static partial class Methods
     {{
         [NativeTypeName(""const wchar_t[5]"")]
-        public static readonly uint[] MyConst1 = new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+        public static readonly uint[] MyConst1 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
     }}
 }}
 ";
@@ -193,14 +191,12 @@ namespace ClangSharp.Test
         {
             var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
 
-            var expectedOutputContents = $@"using System;
-
-namespace ClangSharp.Test
+            var expectedOutputContents = $@"namespace ClangSharp.Test
 {{
     public static partial class Methods
     {{
         [NativeTypeName(""const wchar_t[5]"")]
-        public static readonly uint[] MyConst1 = new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+        public static readonly uint[] MyConst1 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/VarDeclarationTest.cs
@@ -153,7 +153,9 @@ namespace ClangSharp.Test
 
         protected override Task WideStringLiteralConstTestImpl()
         {
-            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";
+const wchar_t* MyConst2 = L""Test"";
+const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"namespace ClangSharp.Test
 {{
@@ -161,6 +163,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const wchar_t[5]"")]
         public static readonly uint[] MyConst1 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
+
+        [NativeTypeName(""const wchar_t *"")]
+        public static uint[] MyConst2 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
+
+        [NativeTypeName(""const wchar_t *const"")]
+        public static readonly uint[] MyConst3 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
     }}
 }}
 ";
@@ -170,7 +178,9 @@ namespace ClangSharp.Test
 
         protected override Task StringLiteralConstTestImpl()
         {
-            var inputContents = $@"const char MyConst1[] = ""Test"";";
+            var inputContents = $@"const char MyConst1[] = ""Test"";
+const char* MyConst2 = ""Test"";
+const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"using System;
 
@@ -180,6 +190,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const char[5]"")]
         public static ReadOnlySpan<byte> MyConst1 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *"")]
+        public static byte[] MyConst2 = new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *const"")]
+        public static ReadOnlySpan<byte> MyConst3 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
     }}
 }}
 ";
@@ -189,7 +205,9 @@ namespace ClangSharp.Test
 
         protected override Task WideStringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";
+static const wchar_t* MyConst2 = L""Test"";
+static const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"namespace ClangSharp.Test
 {{
@@ -197,6 +215,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const wchar_t[5]"")]
         public static readonly uint[] MyConst1 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
+
+        [NativeTypeName(""const wchar_t *"")]
+        public static uint[] MyConst2 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
+
+        [NativeTypeName(""const wchar_t *const"")]
+        public static readonly uint[] MyConst3 = new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }};
     }}
 }}
 ";
@@ -206,7 +230,9 @@ namespace ClangSharp.Test
 
         protected override Task StringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+            var inputContents = $@"static const char MyConst1[] = ""Test"";
+static const char* MyConst2 = ""Test"";
+static const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"using System;
 
@@ -216,6 +242,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const char[5]"")]
         public static ReadOnlySpan<byte> MyConst1 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *"")]
+        public static byte[] MyConst2 = new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *const"")]
+        public static ReadOnlySpan<byte> MyConst3 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/VarDeclarationTest.cs
@@ -151,13 +151,66 @@ namespace ClangSharp.Test
             return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
-        protected override Task WideStringLiteralConstTestImpl() =>
-            // Unsupported string literal kind: 'CX_CLK_Wide'
-            Task.CompletedTask;
+        protected override Task WideStringLiteralConstTestImpl()
+        {
+            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
+
+            var expectedOutputContents = $@"using System;
+
+namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""const wchar_t[5]"")]
+        public static readonly uint[] MyConst1 = new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
 
         protected override Task StringLiteralConstTestImpl()
         {
             var inputContents = $@"const char MyConst1[] = ""Test"";";
+
+            var expectedOutputContents = $@"using System;
+
+namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""const char[5]"")]
+        public static ReadOnlySpan<byte> MyConst1 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        protected override Task WideStringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+
+            var expectedOutputContents = $@"using System;
+
+namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""const wchar_t[5]"")]
+        public static readonly uint[] MyConst1 = new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        protected override Task StringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const char MyConst1[] = ""Test"";";
 
             var expectedOutputContents = $@"using System;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/VarDeclarationTest.cs
@@ -187,6 +187,42 @@ namespace ClangSharp.Test
             return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        protected override Task WideStringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+
+            var expectedOutputContents = $@"namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""const wchar_t[5]"")]
+        public const string MyConst1 = ""Test"";
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        protected override Task StringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+
+            var expectedOutputContents = $@"using System;
+
+namespace ClangSharp.Test
+{{
+    public static partial class Methods
+    {{
+        [NativeTypeName(""const char[5]"")]
+        public static ReadOnlySpan<byte> MyConst1 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+    }}
+}}
+";
+
+            return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         protected override Task UncheckedConversionMacroTestImpl()
         {
             var inputContents = $@"#define MyMacro1 (long)0x80000000L

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/VarDeclarationTest.cs
@@ -153,7 +153,9 @@ namespace ClangSharp.Test
 
         protected override Task WideStringLiteralConstTestImpl()
         {
-            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";
+const wchar_t* MyConst2 = L""Test"";
+const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"namespace ClangSharp.Test
 {{
@@ -161,6 +163,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const wchar_t[5]"")]
         public const string MyConst1 = ""Test"";
+
+        [NativeTypeName(""const wchar_t *"")]
+        public static string MyConst2 = ""Test"";
+
+        [NativeTypeName(""const wchar_t *const"")]
+        public const string MyConst3 = ""Test"";
     }}
 }}
 ";
@@ -170,7 +178,9 @@ namespace ClangSharp.Test
 
         protected override Task StringLiteralConstTestImpl()
         {
-            var inputContents = $@"const char MyConst1[] = ""Test"";";
+            var inputContents = $@"const char MyConst1[] = ""Test"";
+const char* MyConst2 = ""Test"";
+const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"using System;
 
@@ -180,6 +190,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const char[5]"")]
         public static ReadOnlySpan<byte> MyConst1 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *"")]
+        public static byte[] MyConst2 = new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *const"")]
+        public static ReadOnlySpan<byte> MyConst3 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
     }}
 }}
 ";
@@ -189,7 +205,9 @@ namespace ClangSharp.Test
 
         protected override Task WideStringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";
+static const wchar_t* MyConst2 = L""Test"";
+static const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"namespace ClangSharp.Test
 {{
@@ -197,6 +215,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const wchar_t[5]"")]
         public const string MyConst1 = ""Test"";
+
+        [NativeTypeName(""const wchar_t *"")]
+        public static string MyConst2 = ""Test"";
+
+        [NativeTypeName(""const wchar_t *const"")]
+        public const string MyConst3 = ""Test"";
     }}
 }}
 ";
@@ -206,7 +230,9 @@ namespace ClangSharp.Test
 
         protected override Task StringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+            var inputContents = $@"static const char MyConst1[] = ""Test"";
+static const char* MyConst2 = ""Test"";
+static const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"using System;
 
@@ -216,6 +242,12 @@ namespace ClangSharp.Test
     {{
         [NativeTypeName(""const char[5]"")]
         public static ReadOnlySpan<byte> MyConst1 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *"")]
+        public static byte[] MyConst2 = new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
+
+        [NativeTypeName(""const char *const"")]
+        public static ReadOnlySpan<byte> MyConst3 => new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }};
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/VarDeclarationTest.cs
@@ -188,16 +188,16 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task WideStringLiteralConstTestImpl()
         {
-            var inputContents = $@"const char MyConst1[] = ""Test"";";
+            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <class name=""Methods"" access=""public"" static=""true"" readonly=""true"">
+    <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
         <type primitive=""False"">uint[]</type>
         <value>
-          <code>new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+          <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
         </value>
       </constant>
     </class>
@@ -232,16 +232,16 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task WideStringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <class name=""Methods"" access=""public"" static=""true"" readonly=""true"">
+    <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
         <type primitive=""False"">uint[]</type>
         <value>
-          <code>new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+          <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
         </value>
       </constant>
     </class>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/VarDeclarationTest.cs
@@ -186,13 +186,75 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
             return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
-        protected override Task WideStringLiteralConstTestImpl() =>
-            // Unsupported string literal kind: 'CX_CLK_Wide'
-            Task.CompletedTask;
+        protected override Task WideStringLiteralConstTestImpl()
+        {
+            var inputContents = $@"const char MyConst1[] = ""Test"";";
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"" readonly=""true"">
+      <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">uint[]</type>
+        <value>
+          <code>new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
 
         protected override Task StringLiteralConstTestImpl()
         {
             var inputContents = $@"const char MyConst1[] = ""Test"";";
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        protected override Task WideStringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"" readonly=""true"">
+      <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">uint[]</type>
+        <value>
+          <code>new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        protected override Task StringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const char MyConst1[] = ""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/VarDeclarationTest.cs
@@ -15,12 +15,12 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
-      <constant name=""MyVariable"" access=""public"">
+      <field name=""MyVariable"" access=""public"">
         <type primitive=""True"">{expectedManagedType}</type>
         <value>
           <code>0</code>
         </value>
-      </constant>
+      </field>
     </class>
   </namespace>
 </bindings>
@@ -37,12 +37,12 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
-      <constant name=""MyVariable"" access=""public"">
+      <field name=""MyVariable"" access=""public"">
         <type primitive=""True"">{expectedManagedType}</type>
         <value>
           <code>0</code>
         </value>
-      </constant>
+      </field>
     </class>
   </namespace>
 </bindings>
@@ -188,13 +188,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task WideStringLiteralConstTestImpl()
         {
-            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";
+const wchar_t* MyConst2 = L""Test"";
+const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">uint[]</type>
+        <value>
+          <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""False"">uint[]</type>
+        <value>
+          <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""False"">uint[]</type>
         <value>
           <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
@@ -210,13 +224,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task StringLiteralConstTestImpl()
         {
-            var inputContents = $@"const char MyConst1[] = ""Test"";";
+            var inputContents = $@"const char MyConst1[] = ""Test"";
+const char* MyConst2 = ""Test"";
+const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""False"">byte[]</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
         <value>
           <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
@@ -232,13 +260,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task WideStringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";
+static const wchar_t* MyConst2 = L""Test"";
+static const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">uint[]</type>
+        <value>
+          <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""False"">uint[]</type>
+        <value>
+          <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""False"">uint[]</type>
         <value>
           <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
@@ -254,13 +296,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task StringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+            var inputContents = $@"static const char MyConst1[] = ""Test"";
+static const char* MyConst2 = ""Test"";
+static const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""False"">byte[]</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
         <value>
           <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/VarDeclarationTest.cs
@@ -230,6 +230,50 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
             return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        protected override Task WideStringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyConst1"" access=""public"">
+        <type primitive=""True"">string</type>
+        <value>
+          <code>""Test""</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        protected override Task StringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         protected override Task UncheckedConversionMacroTestImpl()
         {
             var inputContents = $@"#define MyMacro1 (long)0x80000000L

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/VarDeclarationTest.cs
@@ -15,12 +15,12 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
-      <constant name=""MyVariable"" access=""public"">
+      <field name=""MyVariable"" access=""public"">
         <type primitive=""True"">{expectedManagedType}</type>
         <value>
           <code>0</code>
         </value>
-      </constant>
+      </field>
     </class>
   </namespace>
 </bindings>
@@ -37,12 +37,12 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
-      <constant name=""MyVariable"" access=""public"">
+      <field name=""MyVariable"" access=""public"">
         <type primitive=""True"">{expectedManagedType}</type>
         <value>
           <code>0</code>
         </value>
-      </constant>
+      </field>
     </class>
   </namespace>
 </bindings>
@@ -188,13 +188,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task WideStringLiteralConstTestImpl()
         {
-            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";
+const wchar_t* MyConst2 = L""Test"";
+const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""True"">string</type>
+        <value>
+          <code>""Test""</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""True"">string</type>
+        <value>
+          <code>""Test""</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""True"">string</type>
         <value>
           <code>""Test""</code>
@@ -210,13 +224,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task StringLiteralConstTestImpl()
         {
-            var inputContents = $@"const char MyConst1[] = ""Test"";";
+            var inputContents = $@"const char MyConst1[] = ""Test"";
+const char* MyConst2 = ""Test"";
+const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""False"">byte[]</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
         <value>
           <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
@@ -232,13 +260,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task WideStringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";
+static const wchar_t* MyConst2 = L""Test"";
+static const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""True"">string</type>
+        <value>
+          <code>""Test""</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""True"">string</type>
+        <value>
+          <code>""Test""</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""True"">string</type>
         <value>
           <code>""Test""</code>
@@ -254,13 +296,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task StringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+            var inputContents = $@"static const char MyConst1[] = ""Test"";
+static const char* MyConst2 = ""Test"";
+static const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""False"">byte[]</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
         <value>
           <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/VarDeclarationTest.cs
@@ -186,13 +186,75 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
             return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
         }
 
-        protected override Task WideStringLiteralConstTestImpl() =>
-            // Unsupported string literal kind: 'CX_CLK_Wide'
-            Task.CompletedTask;
+        protected override Task WideStringLiteralConstTestImpl()
+        {
+            var inputContents = $@"const char MyConst1[] = ""Test"";";
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"" readonly=""true"">
+      <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">uint[]</type>
+        <value>
+          <code>new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
 
         protected override Task StringLiteralConstTestImpl()
         {
             var inputContents = $@"const char MyConst1[] = ""Test"";";
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        protected override Task WideStringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"" readonly=""true"">
+      <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">uint[]</type>
+        <value>
+          <code>new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        protected override Task StringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const char MyConst1[] = ""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/VarDeclarationTest.cs
@@ -188,16 +188,16 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task WideStringLiteralConstTestImpl()
         {
-            var inputContents = $@"const char MyConst1[] = ""Test"";";
+            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <class name=""Methods"" access=""public"" static=""true"" readonly=""true"">
+    <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
         <type primitive=""False"">uint[]</type>
         <value>
-          <code>new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+          <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
         </value>
       </constant>
     </class>
@@ -232,16 +232,16 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task WideStringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <class name=""Methods"" access=""public"" static=""true"" readonly=""true"">
+    <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
         <type primitive=""False"">uint[]</type>
         <value>
-          <code>new uint[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+          <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
         </value>
       </constant>
     </class>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/VarDeclarationTest.cs
@@ -15,12 +15,12 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
-      <constant name=""MyVariable"" access=""public"">
+      <field name=""MyVariable"" access=""public"">
         <type primitive=""True"">{expectedManagedType}</type>
         <value>
           <code>0</code>
         </value>
-      </constant>
+      </field>
     </class>
   </namespace>
 </bindings>
@@ -37,12 +37,12 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
-      <constant name=""MyVariable"" access=""public"">
+      <field name=""MyVariable"" access=""public"">
         <type primitive=""True"">{expectedManagedType}</type>
         <value>
           <code>0</code>
         </value>
-      </constant>
+      </field>
     </class>
   </namespace>
 </bindings>
@@ -188,13 +188,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task WideStringLiteralConstTestImpl()
         {
-            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";
+const wchar_t* MyConst2 = L""Test"";
+const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">uint[]</type>
+        <value>
+          <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""False"">uint[]</type>
+        <value>
+          <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""False"">uint[]</type>
         <value>
           <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
@@ -210,13 +224,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task StringLiteralConstTestImpl()
         {
-            var inputContents = $@"const char MyConst1[] = ""Test"";";
+            var inputContents = $@"const char MyConst1[] = ""Test"";
+const char* MyConst2 = ""Test"";
+const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""False"">byte[]</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
         <value>
           <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
@@ -232,13 +260,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task WideStringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";
+static const wchar_t* MyConst2 = L""Test"";
+static const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">uint[]</type>
+        <value>
+          <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""False"">uint[]</type>
+        <value>
+          <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""False"">uint[]</type>
         <value>
           <code>new uint[] {{ 0x00000054, 0x00000065, 0x00000073, 0x00000074, 0x00000000 }}</code>
@@ -254,13 +296,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task StringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+            var inputContents = $@"static const char MyConst1[] = ""Test"";
+static const char* MyConst2 = ""Test"";
+static const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""False"">byte[]</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
         <value>
           <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/VarDeclarationTest.cs
@@ -230,6 +230,50 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
             return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
         }
 
+        protected override Task WideStringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyConst1"" access=""public"">
+        <type primitive=""True"">string</type>
+        <value>
+          <code>""Test""</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
+        protected override Task StringLiteralStaticConstTestImpl()
+        {
+            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+
+            var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <class name=""Methods"" access=""public"" static=""true"">
+      <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>
+";
+
+            return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+        }
+
         protected override Task UncheckedConversionMacroTestImpl()
         {
             var inputContents = $@"#define MyMacro1 (long)0x80000000L

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/VarDeclarationTest.cs
@@ -15,12 +15,12 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
-      <constant name=""MyVariable"" access=""public"">
+      <field name=""MyVariable"" access=""public"">
         <type primitive=""True"">{expectedManagedType}</type>
         <value>
           <code>0</code>
         </value>
-      </constant>
+      </field>
     </class>
   </namespace>
 </bindings>
@@ -37,12 +37,12 @@ namespace ClangSharp.UnitTests
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
-      <constant name=""MyVariable"" access=""public"">
+      <field name=""MyVariable"" access=""public"">
         <type primitive=""True"">{expectedManagedType}</type>
         <value>
           <code>0</code>
         </value>
-      </constant>
+      </field>
     </class>
   </namespace>
 </bindings>
@@ -188,13 +188,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task WideStringLiteralConstTestImpl()
         {
-            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"const wchar_t MyConst1[] = L""Test"";
+const wchar_t* MyConst2 = L""Test"";
+const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""True"">string</type>
+        <value>
+          <code>""Test""</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""True"">string</type>
+        <value>
+          <code>""Test""</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""True"">string</type>
         <value>
           <code>""Test""</code>
@@ -210,13 +224,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task StringLiteralConstTestImpl()
         {
-            var inputContents = $@"const char MyConst1[] = ""Test"";";
+            var inputContents = $@"const char MyConst1[] = ""Test"";
+const char* MyConst2 = ""Test"";
+const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""False"">byte[]</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
         <value>
           <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
@@ -232,13 +260,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task WideStringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";";
+            var inputContents = $@"static const wchar_t MyConst1[] = L""Test"";
+static const wchar_t* MyConst2 = L""Test"";
+static const wchar_t* const MyConst3 = L""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""True"">string</type>
+        <value>
+          <code>""Test""</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""True"">string</type>
+        <value>
+          <code>""Test""</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""True"">string</type>
         <value>
           <code>""Test""</code>
@@ -254,13 +296,27 @@ const GUID IID_IUnknown = {{ 0x00000000, 0x0000, 0x0000, {{ 0xC0, 0x00, 0x00, 0x
 
         protected override Task StringLiteralStaticConstTestImpl()
         {
-            var inputContents = $@"static const char MyConst1[] = ""Test"";";
+            var inputContents = $@"static const char MyConst1[] = ""Test"";
+static const char* MyConst2 = ""Test"";
+static const char* const MyConst3 = ""Test"";";
 
             var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <class name=""Methods"" access=""public"" static=""true"">
       <constant name=""MyConst1"" access=""public"">
+        <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </constant>
+      <field name=""MyConst2"" access=""public"">
+        <type primitive=""False"">byte[]</type>
+        <value>
+          <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>
+        </value>
+      </field>
+      <constant name=""MyConst3"" access=""public"">
         <type primitive=""False"">ReadOnlySpan&lt;byte&gt;</type>
         <value>
           <code>new byte[] {{ 0x54, 0x65, 0x73, 0x74, 0x00 }}</code>


### PR DESCRIPTION
This resolves https://github.com/dotnet/ClangSharp/issues/369 by adding additional tests validating the behavior of various global string literal variables.

In particular, it validates that `const T*` is correctly emitted as a mutable `static` and that `const T* const` is emitted as a `static readonly` (or equivalent).