### PR TITLE
Ensure that multiple-inheritance scenarios generate unique field names

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -2500,6 +2501,20 @@ namespace ClangSharp
             {
                 wasRemapped = true;
                 // We don't track remapped operators in _usedRemappings
+                return AddUsingDirectiveIfNeeded(_outputBuilder, remappedName, skipUsing);
+            }
+
+            if ((cursor is CXXBaseSpecifier cxxBaseSpecifier) && remappedName.StartsWith("__AnonymousBase_"))
+            {
+                remappedName = "Base";
+
+                if (_cxxRecordDeclContext.Bases.Count > 1)
+                {
+                    var index = _cxxRecordDeclContext.Bases.IndexOf(cxxBaseSpecifier) + 1;
+                    remappedName += index.ToString();
+                }
+
+                wasRemapped = true;
                 return AddUsingDirectiveIfNeeded(_outputBuilder, remappedName, skipUsing);
             }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
@@ -755,9 +755,9 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
     [NativeTypeName(""struct MyStruct2 : MyStruct1A, MyStruct1B"")]
     public partial struct MyStruct2
     {
-        public MyStruct1A Base;
+        public MyStruct1A Base1;
 
-        public MyStruct1B Base;
+        public MyStruct1B Base2;
 
         public int z;
 
@@ -810,9 +810,9 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
     [NativeInheritance(""MyStruct1B"")]
     public partial struct MyStruct2
     {
-        public MyStruct1A Base;
+        public MyStruct1A Base1;
 
-        public MyStruct1B Base;
+        public MyStruct1B Base2;
 
         public int z;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
@@ -759,9 +759,9 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
     [NativeTypeName(""struct MyStruct2 : MyStruct1A, MyStruct1B"")]
     public partial struct MyStruct2
     {
-        public MyStruct1A Base;
+        public MyStruct1A Base1;
 
-        public MyStruct1B Base;
+        public MyStruct1B Base2;
 
         public int z;
 
@@ -814,9 +814,9 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
     [NativeInheritance(""MyStruct1B"")]
     public partial struct MyStruct2
     {
-        public MyStruct1A Base;
+        public MyStruct1A Base1;
 
-        public MyStruct1B Base;
+        public MyStruct1B Base2;
 
         public int z;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
@@ -763,9 +763,9 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
     [NativeTypeName(""struct MyStruct2 : MyStruct1A, MyStruct1B"")]
     public partial struct MyStruct2
     {
-        public MyStruct1A Base;
+        public MyStruct1A Base1;
 
-        public MyStruct1B Base;
+        public MyStruct1B Base2;
 
         public int z;
 
@@ -818,9 +818,9 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
     [NativeInheritance(""MyStruct1B"")]
     public partial struct MyStruct2
     {
-        public MyStruct1A Base;
+        public MyStruct1A Base1;
 
-        public MyStruct1B Base;
+        public MyStruct1B Base2;
 
         public int z;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
@@ -767,9 +767,9 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
     [NativeTypeName(""struct MyStruct2 : MyStruct1A, MyStruct1B"")]
     public partial struct MyStruct2
     {
-        public MyStruct1A Base;
+        public MyStruct1A Base1;
 
-        public MyStruct1B Base;
+        public MyStruct1B Base2;
 
         public int z;
 
@@ -822,9 +822,9 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
     [NativeInheritance(""MyStruct1B"")]
     public partial struct MyStruct2
     {
-        public MyStruct1A Base;
+        public MyStruct1A Base1;
 
-        public MyStruct1B Base;
+        public MyStruct1B Base2;
 
         public int z;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
@@ -798,10 +798,10 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
       </field>
     </struct>
     <struct name=""MyStruct2"" access=""public"" native=""struct MyStruct2 : MyStruct1A, MyStruct1B"">
-      <field name=""Base"" access=""public"" inherited=""MyStruct1A"">
+      <field name=""Base1"" access=""public"" inherited=""MyStruct1A"">
         <type>MyStruct1A</type>
       </field>
-      <field name=""Base"" access=""public"" inherited=""MyStruct1B"">
+      <field name=""Base2"" access=""public"" inherited=""MyStruct1B"">
         <type>MyStruct1B</type>
       </field>
       <field name=""z"" access=""public"">
@@ -859,10 +859,10 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
       </field>
     </struct>
     <struct name=""MyStruct2"" access=""public"" native=""struct MyStruct2 : MyStruct1A, MyStruct1B"" parent=""MyStruct1B"">
-      <field name=""Base"" access=""public"" inherited=""MyStruct1A"">
+      <field name=""Base1"" access=""public"" inherited=""MyStruct1A"">
         <type>MyStruct1A</type>
       </field>
-      <field name=""Base"" access=""public"" inherited=""MyStruct1B"">
+      <field name=""Base2"" access=""public"" inherited=""MyStruct1B"">
         <type>MyStruct1B</type>
       </field>
       <field name=""z"" access=""public"">

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
@@ -804,10 +804,10 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
       </field>
     </struct>
     <struct name=""MyStruct2"" access=""public"" native=""struct MyStruct2 : MyStruct1A, MyStruct1B"">
-      <field name=""Base"" access=""public"" inherited=""MyStruct1A"">
+      <field name=""Base1"" access=""public"" inherited=""MyStruct1A"">
         <type>MyStruct1A</type>
       </field>
-      <field name=""Base"" access=""public"" inherited=""MyStruct1B"">
+      <field name=""Base2"" access=""public"" inherited=""MyStruct1B"">
         <type>MyStruct1B</type>
       </field>
       <field name=""z"" access=""public"">
@@ -865,10 +865,10 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
       </field>
     </struct>
     <struct name=""MyStruct2"" access=""public"" native=""struct MyStruct2 : MyStruct1A, MyStruct1B"" parent=""MyStruct1B"">
-      <field name=""Base"" access=""public"" inherited=""MyStruct1A"">
+      <field name=""Base1"" access=""public"" inherited=""MyStruct1A"">
         <type>MyStruct1A</type>
       </field>
-      <field name=""Base"" access=""public"" inherited=""MyStruct1B"">
+      <field name=""Base2"" access=""public"" inherited=""MyStruct1B"">
         <type>MyStruct1B</type>
       </field>
       <field name=""z"" access=""public"">

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
@@ -802,10 +802,10 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
       </field>
     </struct>
     <struct name=""MyStruct2"" access=""public"" native=""struct MyStruct2 : MyStruct1A, MyStruct1B"">
-      <field name=""Base"" access=""public"" inherited=""MyStruct1A"">
+      <field name=""Base1"" access=""public"" inherited=""MyStruct1A"">
         <type>MyStruct1A</type>
       </field>
-      <field name=""Base"" access=""public"" inherited=""MyStruct1B"">
+      <field name=""Base2"" access=""public"" inherited=""MyStruct1B"">
         <type>MyStruct1B</type>
       </field>
       <field name=""z"" access=""public"">
@@ -863,10 +863,10 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
       </field>
     </struct>
     <struct name=""MyStruct2"" access=""public"" native=""struct MyStruct2 : MyStruct1A, MyStruct1B"" parent=""MyStruct1B"">
-      <field name=""Base"" access=""public"" inherited=""MyStruct1A"">
+      <field name=""Base1"" access=""public"" inherited=""MyStruct1A"">
         <type>MyStruct1A</type>
       </field>
-      <field name=""Base"" access=""public"" inherited=""MyStruct1B"">
+      <field name=""Base2"" access=""public"" inherited=""MyStruct1B"">
         <type>MyStruct1B</type>
       </field>
       <field name=""z"" access=""public"">

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
@@ -808,10 +808,10 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
       </field>
     </struct>
     <struct name=""MyStruct2"" access=""public"" native=""struct MyStruct2 : MyStruct1A, MyStruct1B"">
-      <field name=""Base"" access=""public"" inherited=""MyStruct1A"">
+      <field name=""Base1"" access=""public"" inherited=""MyStruct1A"">
         <type>MyStruct1A</type>
       </field>
-      <field name=""Base"" access=""public"" inherited=""MyStruct1B"">
+      <field name=""Base2"" access=""public"" inherited=""MyStruct1B"">
         <type>MyStruct1B</type>
       </field>
       <field name=""z"" access=""public"">
@@ -869,10 +869,10 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
       </field>
     </struct>
     <struct name=""MyStruct2"" access=""public"" native=""struct MyStruct2 : MyStruct1A, MyStruct1B"" parent=""MyStruct1B"">
-      <field name=""Base"" access=""public"" inherited=""MyStruct1A"">
+      <field name=""Base1"" access=""public"" inherited=""MyStruct1A"">
         <type>MyStruct1A</type>
       </field>
-      <field name=""Base"" access=""public"" inherited=""MyStruct1B"">
+      <field name=""Base2"" access=""public"" inherited=""MyStruct1B"">
         <type>MyStruct1B</type>
       </field>
       <field name=""z"" access=""public"">


### PR DESCRIPTION
This resolves https://github.com/dotnet/ClangSharp/issues/367 and gives multiple-inheritance `Base` fields the same convention as the automatic `Anonymous` fields scenario.

In particular, if only one base exists the name is `Base`. If more than one exists, it is `Base1, Base2, ...`.