### PR TITLE
Fixing C Incomplete Array to be treated as a Constant Array of length 1

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -1049,9 +1049,9 @@ namespace ClangSharp
                     }
                     long size = -1;
 
-                    if (arrayType is ConstantArrayType constantArrayType)
+                    if (arrayType is ConstantArrayType or IncompleteArrayType)
                     {
-                        size = constantArrayType.Size;
+                        size = Math.Max((arrayType as ConstantArrayType)?.Size ?? 0, 1);
                     }
                     else
                     {

--- a/sources/ClangSharp/Types/IncompleteArrayType.cs
+++ b/sources/ClangSharp/Types/IncompleteArrayType.cs
@@ -6,7 +6,6 @@ namespace ClangSharp
 {
     public sealed class IncompleteArrayType : ArrayType
     {
-
         internal IncompleteArrayType(CXType handle) : base(handle, CXTypeKind.CXType_IncompleteArray, CX_TypeClass.CX_TypeClass_IncompleteArray)
         {
         }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/StructDeclarationTest.cs
@@ -7,11 +7,11 @@ namespace ClangSharp.UnitTests
 {
     public abstract class StructDeclarationTest : PInvokeGeneratorTest
     {
-        [TestCase("double", "double*")]
-        [TestCase("short", "short*")]
-        [TestCase("int", "int*")]
-        [TestCase("float", "float*")]
-        public Task ArrayUnknownSizeTest(string nativeType, string expectedManagedType) => ArrayUnknownSizeTestImpl(nativeType, expectedManagedType);
+        [TestCase("double", "double")]
+        [TestCase("short", "short")]
+        [TestCase("int", "int")]
+        [TestCase("float", "float")]
+        public Task IncompleteArraySizeTest(string nativeType, string expectedManagedType) => IncompleteArraySizeTestImpl(nativeType, expectedManagedType);
 
         [TestCase("double", "double")]
         [TestCase("short", "short")]
@@ -206,7 +206,7 @@ namespace ClangSharp.UnitTests
         [Test]
         public Task SourceLocationAttributeTest() => SourceLocationAttributeTestImpl();
 
-        protected abstract Task ArrayUnknownSizeTestImpl(string nativeType, string expectedManagedType);
+        protected abstract Task IncompleteArraySizeTestImpl(string nativeType, string expectedManagedType);
 
         protected abstract Task BasicTestImpl(string nativeType, string expectedManagedType);
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
@@ -10,7 +10,7 @@ namespace ClangSharp.UnitTests
 {
     public sealed class CSharpCompatibleUnix_StructDeclarationTest : StructDeclarationTest
     {
-        protected override Task ArrayUnknownSizeTestImpl(string nativeType, string expectedManagedType)
+        protected override Task IncompleteArraySizeTestImpl(string nativeType, string expectedManagedType)
         {
             var inputContents = $@"struct MyStruct
 {{
@@ -23,7 +23,7 @@ namespace ClangSharp.UnitTests
     public unsafe partial struct MyStruct
     {{
         [NativeTypeName(""{nativeType}[]"")]
-        public {expectedManagedType} x;
+        public fixed {expectedManagedType} x[1];
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
@@ -10,7 +10,7 @@ namespace ClangSharp.UnitTests
 {
     public sealed class CSharpCompatibleWindows_StructDeclarationTest : StructDeclarationTest
     {
-        protected override Task ArrayUnknownSizeTestImpl(string nativeType, string expectedManagedType)
+        protected override Task IncompleteArraySizeTestImpl(string nativeType, string expectedManagedType)
         {
             var inputContents = $@"struct MyStruct
 {{
@@ -23,7 +23,7 @@ namespace ClangSharp.UnitTests
     public unsafe partial struct MyStruct
     {{
         [NativeTypeName(""{nativeType}[]"")]
-        public {expectedManagedType} x;
+        public fixed {expectedManagedType} x[1];
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
@@ -10,7 +10,7 @@ namespace ClangSharp.UnitTests
 {
     public sealed class CSharpLatestUnix_StructDeclarationTest : StructDeclarationTest
     {
-        protected override Task ArrayUnknownSizeTestImpl(string nativeType, string expectedManagedType)
+        protected override Task IncompleteArraySizeTestImpl(string nativeType, string expectedManagedType)
         {
             var inputContents = $@"struct MyStruct
 {{
@@ -23,7 +23,7 @@ namespace ClangSharp.UnitTests
     public unsafe partial struct MyStruct
     {{
         [NativeTypeName(""{nativeType}[]"")]
-        public {expectedManagedType} x;
+        public fixed {expectedManagedType} x[1];
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
@@ -10,7 +10,7 @@ namespace ClangSharp.UnitTests
 {
     public sealed class CSharpLatestWindows_StructDeclarationTest : StructDeclarationTest
     {
-        protected override Task ArrayUnknownSizeTestImpl(string nativeType, string expectedManagedType)
+        protected override Task IncompleteArraySizeTestImpl(string nativeType, string expectedManagedType)
         {
             var inputContents = $@"struct MyStruct
 {{
@@ -23,7 +23,7 @@ namespace ClangSharp.UnitTests
     public unsafe partial struct MyStruct
     {{
         [NativeTypeName(""{nativeType}[]"")]
-        public {expectedManagedType} x;
+        public fixed {expectedManagedType} x[1];
     }}
 }}
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
@@ -10,7 +10,7 @@ namespace ClangSharp.UnitTests
 {
     public sealed class XmlCompatibleUnix_StructDeclarationTest : StructDeclarationTest
     {
-        protected override Task ArrayUnknownSizeTestImpl(string nativeType, string expectedManagedType)
+        protected override Task IncompleteArraySizeTestImpl(string nativeType, string expectedManagedType)
         {
             var inputContents = $@"struct MyStruct
 {{
@@ -23,7 +23,7 @@ namespace ClangSharp.UnitTests
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"" unsafe=""true"">
       <field name=""x"" access=""public"">
-        <type native=""{nativeType}[]"">{expectedManagedType}</type>
+        <type native=""{nativeType}[]"" count=""1"" fixed=""_x_e__FixedBuffer"">{expectedManagedType}</type>
       </field>
     </struct>
   </namespace>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
@@ -10,7 +10,7 @@ namespace ClangSharp.UnitTests
 {
     public sealed class XmlCompatibleWindows_StructDeclarationTest : StructDeclarationTest
     {
-        protected override Task ArrayUnknownSizeTestImpl(string nativeType, string expectedManagedType)
+        protected override Task IncompleteArraySizeTestImpl(string nativeType, string expectedManagedType)
         {
             var inputContents = $@"struct MyStruct
 {{
@@ -23,7 +23,7 @@ namespace ClangSharp.UnitTests
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"" unsafe=""true"">
       <field name=""x"" access=""public"">
-        <type native=""{nativeType}[]"">{expectedManagedType}</type>
+        <type native=""{nativeType}[]"" count=""1"" fixed=""_x_e__FixedBuffer"">{expectedManagedType}</type>
       </field>
     </struct>
   </namespace>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
@@ -10,7 +10,7 @@ namespace ClangSharp.UnitTests
 {
     public sealed class XmlLatestUnix_StructDeclarationTest : StructDeclarationTest
     {
-        protected override Task ArrayUnknownSizeTestImpl(string nativeType, string expectedManagedType)
+        protected override Task IncompleteArraySizeTestImpl(string nativeType, string expectedManagedType)
         {
             var inputContents = $@"struct MyStruct
 {{
@@ -23,7 +23,7 @@ namespace ClangSharp.UnitTests
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"" unsafe=""true"">
       <field name=""x"" access=""public"">
-        <type native=""{nativeType}[]"">{expectedManagedType}</type>
+        <type native=""{nativeType}[]"" count=""1"" fixed=""_x_e__FixedBuffer"">{expectedManagedType}</type>
       </field>
     </struct>
   </namespace>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
@@ -10,7 +10,7 @@ namespace ClangSharp.UnitTests
 {
     public sealed class XmlLatestWindows_StructDeclarationTest : StructDeclarationTest
     {
-        protected override Task ArrayUnknownSizeTestImpl(string nativeType, string expectedManagedType)
+        protected override Task IncompleteArraySizeTestImpl(string nativeType, string expectedManagedType)
         {
             var inputContents = $@"struct MyStruct
 {{
@@ -23,7 +23,7 @@ namespace ClangSharp.UnitTests
   <namespace name=""ClangSharp.Test"">
     <struct name=""MyStruct"" access=""public"" unsafe=""true"">
       <field name=""x"" access=""public"">
-        <type native=""{nativeType}[]"">{expectedManagedType}</type>
+        <type native=""{nativeType}[]"" count=""1"" fixed=""_x_e__FixedBuffer"">{expectedManagedType}</type>
       </field>
     </struct>
   </namespace>


### PR DESCRIPTION
This resolves https://github.com/dotnet/ClangSharp/issues/366 and ensures `IncompleteArray` is treated the same as `ConstantArray with Size=0` given this is how MSVC and Clang both handle it.

I'm going to separately work on also adding a `--with-specified-length` parameter to the command line. This will allow the `AsSpan()` helper codegen to use the correct length coming from the relevant associated param/field for non-primitive fixed-sized buffers.

Such a parameter would also allow the relevant metadata to be emitted as an associated attribute where relevant. Ideally in the future we could also automatically pull such info from the SAL annotations.