### PR TITLE
Add support for --with-packing

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/StructDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/StructDesc.cs
@@ -83,21 +83,12 @@ internal struct StructDesc
             {
                 Debug.Assert(layout.Kind == LayoutKind.Explicit);
 
-                var attribute = new StructLayoutAttribute(layout.Kind);
-
-                if (layout.Pack != 0)
-                {
-                    attribute.Pack = (int)layout.Pack;
-                }
-
-                return attribute;
+                return new StructLayoutAttribute(layout.Kind);
             }
 
-            if (layout.Pack != 0 || layout.PackOverride is not null)
+            if (layout.Pack is not null)
             {
-                return new StructLayoutAttribute(layout.Kind) {
-                    Pack = (int)layout.Pack
-                };
+                return new StructLayoutAttribute(layout.Kind);
             }
 
             return null;
@@ -110,8 +101,7 @@ internal struct StructDesc
         public long Alignment64 { get; set; }
         public long Size32 { get; set; }
         public long Size64 { get; set; }
-        public long Pack { get; set; }
-        public string? PackOverride { get; set; }
+        public string? Pack { get; set; }
         public long MaxFieldAlignment { get; set; }
         public LayoutKind Kind { get; set; }
     }

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/StructDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/StructDesc.cs
@@ -111,6 +111,7 @@ internal struct StructDesc
         public long Size32 { get; set; }
         public long Size64 { get; set; }
         public long Pack { get; set; }
+        public string? PackOverride { get; set; }
         public long MaxFieldAlignment { get; set; }
         public LayoutKind Kind { get; set; }
     }

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/StructDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/StructDesc.cs
@@ -93,7 +93,7 @@ internal struct StructDesc
                 return attribute;
             }
 
-            if (layout.Pack != 0)
+            if (layout.Pack != 0 || layout.PackOverride is not null)
             {
                 return new StructLayoutAttribute(layout.Kind) {
                     Pack = (int)layout.Pack

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -746,15 +746,10 @@ internal partial class CSharpOutputBuilder : IOutputBuilder
             WriteIndented("[StructLayout(LayoutKind.");
             Write(desc.LayoutAttribute.Value);
 
-            if (desc.Layout.PackOverride is { } packOverride)
+            if (desc.Layout.Pack != null)
             {
                 Write(", Pack = ");
-                Write(packOverride);
-            }
-            else if (desc.LayoutAttribute.Pack != 0)
-            {
-                Write(", Pack = ");
-                Write(desc.LayoutAttribute.Pack);
+                Write(desc.Layout.Pack);
             }
 
             WriteLine(")]");

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -740,18 +740,18 @@ internal partial class CSharpOutputBuilder : IOutputBuilder
             WriteLine("\"]/*' />");
         }
 
-        if (desc.LayoutAttribute is not null || desc.Layout.PackOverride is not null)
+        if (desc.LayoutAttribute is not null)
         {
             AddUsingDirective("System.Runtime.InteropServices");
             WriteIndented("[StructLayout(LayoutKind.");
-            Write(desc.LayoutAttribute?.Value ?? LayoutKind.Sequential);
+            Write(desc.LayoutAttribute.Value);
 
             if (desc.Layout.PackOverride is { } packOverride)
             {
                 Write(", Pack = ");
                 Write(packOverride);
             }
-            else if (desc.LayoutAttribute!.Pack != 0)
+            else if (desc.LayoutAttribute.Pack != 0)
             {
                 Write(", Pack = ");
                 Write(desc.LayoutAttribute.Pack);

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -740,13 +740,18 @@ internal partial class CSharpOutputBuilder : IOutputBuilder
             WriteLine("\"]/*' />");
         }
 
-        if (desc.LayoutAttribute is not null)
+        if (desc.LayoutAttribute is not null || desc.Layout.PackOverride is not null)
         {
             AddUsingDirective("System.Runtime.InteropServices");
             WriteIndented("[StructLayout(LayoutKind.");
-            Write(desc.LayoutAttribute.Value);
+            Write(desc.LayoutAttribute?.Value ?? LayoutKind.Sequential);
 
-            if (desc.LayoutAttribute.Pack != 0)
+            if (desc.Layout.PackOverride is { } packOverride)
+            {
+                Write(", Pack = ");
+                Write(packOverride);
+            }
+            else if (desc.LayoutAttribute!.Pack != 0)
             {
                 Write(", Pack = ");
                 Write(desc.LayoutAttribute.Pack);

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -746,7 +746,7 @@ internal partial class CSharpOutputBuilder : IOutputBuilder
             WriteIndented("[StructLayout(LayoutKind.");
             Write(desc.LayoutAttribute.Value);
 
-            if (desc.Layout.Pack != null)
+            if (desc.Layout.Pack is not null)
             {
                 Write(", Pack = ");
                 Write(desc.Layout.Pack);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1479,7 +1479,7 @@ public partial class PInvokeGenerator
                     Size32 = size32,
                     Size64 = size64,
                     Pack = alignment < maxAlignm ? alignment : 0,
-                    PackOverride = TryGetRemappedValue(recordDecl, _config.WithPackOverrides, out var packOverride) ? packOverride : null,
+                    PackOverride = TryGetRemappedValue(recordDecl, _config.WithPackings, out var packOverride) ? packOverride : null,
                     MaxFieldAlignment = maxAlignm,
                     Kind = layoutKind
                 },
@@ -2828,6 +2828,7 @@ public partial class PInvokeGenerator
                     Size32 = size32,
                     Size64 = size64,
                     Pack = alignment < maxAlignm ? alignment : 0,
+                    PackOverride = TryGetRemappedValue(recordDecl, _config.WithPackings, out var packOverride) ? packOverride : null,
                     MaxFieldAlignment = maxAlignm,
                     Kind = LayoutKind.Sequential
                 },

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1467,6 +1467,11 @@ public partial class PInvokeGenerator
                 baseTypeNames = baseTypeNamesBuilder.ToArray();
             }
 
+            if (!TryGetRemappedValue(recordDecl, _config.WithPackings, out var pack))
+            {
+                pack = alignment < maxAlignm ? alignment.ToString(CultureInfo.InvariantCulture) : null;
+            }
+
             var desc = new StructDesc {
                 AccessSpecifier = GetAccessSpecifier(recordDecl, matchStar: true),
                 EscapedName = escapedName,
@@ -1478,8 +1483,7 @@ public partial class PInvokeGenerator
                     Alignment64 = alignment64,
                     Size32 = size32,
                     Size64 = size64,
-                    Pack = alignment < maxAlignm ? alignment : 0,
-                    PackOverride = TryGetRemappedValue(recordDecl, _config.WithPackings, out var packOverride) ? packOverride : null,
+                    Pack = pack,
                     MaxFieldAlignment = maxAlignm,
                     Kind = layoutKind
                 },
@@ -1516,7 +1520,7 @@ public partial class PInvokeGenerator
 
                 if (desc.LayoutAttribute is not null)
                 {
-                    withAttributes.Add($"StructLayout(LayoutKind.{desc.LayoutAttribute.Value}{((desc.LayoutAttribute.Pack != 0) ? $", Pack = {desc.LayoutAttribute.Pack}" : "")})");
+                    withAttributes.Add($"StructLayout(LayoutKind.{desc.LayoutAttribute.Value}{((desc.Layout.Pack != null) ? $", Pack = {desc.Layout.Pack}" : "")})");
                     _ = withUsings.Add("System.Runtime.InteropServices");
                 }
 
@@ -2818,6 +2822,11 @@ public partial class PInvokeGenerator
                 AddDiagnostic(DiagnosticLevel.Info, $"{escapedName} (constant array field) has a size of 0", constantOrIncompleteArray);
             }
 
+            if (!TryGetRemappedValue(recordDecl, _config.WithPackings, out var pack))
+            {
+                pack = alignment < maxAlignm ? alignment.ToString(CultureInfo.InvariantCulture) : null;
+            }
+
             var desc = new StructDesc {
                 AccessSpecifier = accessSpecifier,
                 EscapedName = escapedName,
@@ -2827,8 +2836,7 @@ public partial class PInvokeGenerator
                     Alignment64 = alignment64,
                     Size32 = size32,
                     Size64 = size64,
-                    Pack = alignment < maxAlignm ? alignment : 0,
-                    PackOverride = TryGetRemappedValue(recordDecl, _config.WithPackings, out var packOverride) ? packOverride : null,
+                    Pack = pack,
                     MaxFieldAlignment = maxAlignm,
                     Kind = LayoutKind.Sequential
                 },

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1520,7 +1520,7 @@ public partial class PInvokeGenerator
 
                 if (desc.LayoutAttribute is not null)
                 {
-                    withAttributes.Add($"StructLayout(LayoutKind.{desc.LayoutAttribute.Value}{((desc.Layout.Pack != null) ? $", Pack = {desc.Layout.Pack}" : "")})");
+                    withAttributes.Add($"StructLayout(LayoutKind.{desc.LayoutAttribute.Value}{((desc.Layout.Pack is not null) ? $", Pack = {desc.Layout.Pack}" : "")})");
                     _ = withUsings.Add("System.Runtime.InteropServices");
                 }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1479,6 +1479,7 @@ public partial class PInvokeGenerator
                     Size32 = size32,
                     Size64 = size64,
                     Pack = alignment < maxAlignm ? alignment : 0,
+                    PackOverride = TryGetRemappedValue(recordDecl, _config.WithPackOverrides, out var packOverride) ? packOverride : null,
                     MaxFieldAlignment = maxAlignm,
                     Kind = layoutKind
                 },

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -45,6 +45,7 @@ public sealed class PInvokeGeneratorConfiguration
     private readonly SortedDictionary<string, (string, PInvokeGeneratorTransparentStructKind)> _withTransparentStructs;
     private readonly SortedDictionary<string, string> _withTypes;
     private readonly SortedDictionary<string, IReadOnlyList<string>> _withUsings;
+    private readonly SortedDictionary<string, string> _withPackOverrides;
 
     private PInvokeGeneratorConfigurationOptions _options;
 
@@ -94,6 +95,7 @@ public sealed class PInvokeGeneratorConfiguration
         _withTransparentStructs = new SortedDictionary<string, (string, PInvokeGeneratorTransparentStructKind)>();
         _withTypes = new SortedDictionary<string, string>();
         _withUsings = new SortedDictionary<string, IReadOnlyList<string>>();
+        _withPackOverrides = new SortedDictionary<string, string>();
 
         if ((outputMode == PInvokeGeneratorOutputMode.Xml) && !options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles) && (options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateTestsNUnit) || options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateTestsXUnit)))
         {
@@ -525,6 +527,20 @@ public sealed class PInvokeGeneratorConfiguration
         init
         {
             AddRange(_withUsings, value);
+        }
+    }
+
+    [AllowNull]
+    public IReadOnlyDictionary<string, string> WithPackOverrides
+    {
+        get
+        {
+            return _withPackOverrides;
+        }
+
+        init
+        {
+            AddRange(_withPackOverrides, value);
         }
     }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -45,7 +45,7 @@ public sealed class PInvokeGeneratorConfiguration
     private readonly SortedDictionary<string, (string, PInvokeGeneratorTransparentStructKind)> _withTransparentStructs;
     private readonly SortedDictionary<string, string> _withTypes;
     private readonly SortedDictionary<string, IReadOnlyList<string>> _withUsings;
-    private readonly SortedDictionary<string, string> _withPackOverrides;
+    private readonly SortedDictionary<string, string> _withPackings;
 
     private PInvokeGeneratorConfigurationOptions _options;
 
@@ -95,7 +95,7 @@ public sealed class PInvokeGeneratorConfiguration
         _withTransparentStructs = new SortedDictionary<string, (string, PInvokeGeneratorTransparentStructKind)>();
         _withTypes = new SortedDictionary<string, string>();
         _withUsings = new SortedDictionary<string, IReadOnlyList<string>>();
-        _withPackOverrides = new SortedDictionary<string, string>();
+        _withPackings = new SortedDictionary<string, string>();
 
         if ((outputMode == PInvokeGeneratorOutputMode.Xml) && !options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles) && (options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateTestsNUnit) || options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateTestsXUnit)))
         {
@@ -531,16 +531,16 @@ public sealed class PInvokeGeneratorConfiguration
     }
 
     [AllowNull]
-    public IReadOnlyDictionary<string, string> WithPackOverrides
+    public IReadOnlyDictionary<string, string> WithPackings
     {
         get
         {
-            return _withPackOverrides;
+            return _withPackings;
         }
 
         init
         {
-            AddRange(_withPackOverrides, value);
+            AddRange(_withPackings, value);
         }
     }
 

--- a/sources/ClangSharp.PInvokeGenerator/XML/XmlOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/XmlOutputBuilder.VisitDecl.cs
@@ -290,7 +290,7 @@ internal partial class XmlOutputBuilder
             _ = _sb.Append(info.LayoutAttribute.Value);
             _ = _sb.Append('"');
 
-            if (info.Layout.Pack != null)
+            if (info.Layout.Pack is not null)
             {
                 _ = _sb.Append(" pack=\"");
                 _ = _sb.Append(info.Layout.Pack);

--- a/sources/ClangSharp.PInvokeGenerator/XML/XmlOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/XmlOutputBuilder.VisitDecl.cs
@@ -290,10 +290,10 @@ internal partial class XmlOutputBuilder
             _ = _sb.Append(info.LayoutAttribute.Value);
             _ = _sb.Append('"');
 
-            if (info.LayoutAttribute.Pack != 0)
+            if (info.Layout.Pack != null)
             {
                 _ = _sb.Append(" pack=\"");
-                _ = _sb.Append(info.LayoutAttribute.Pack);
+                _ = _sb.Append(info.Layout.Pack);
                 _ = _sb.Append('"');
             }
         }

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -57,6 +57,7 @@ public class Program
     private static readonly Option<string[]> s_withTransparentStructNameValuePairs;
     private static readonly Option<string[]> s_withTypeNameValuePairs;
     private static readonly Option<string[]> s_withUsingNameValuePairs;
+    private static readonly Option<string[]> s_withPackOverrideNameValuePairs;
 
 
     private static readonly TwoColumnHelpRow[] s_configOptions = new TwoColumnHelpRow[]
@@ -161,6 +162,7 @@ public class Program
         s_withTransparentStructNameValuePairs = GetWithTransparentStructOption();
         s_withTypeNameValuePairs = GetWithTypeOption();
         s_withUsingNameValuePairs = GetWithUsingOption();
+        s_withPackOverrideNameValuePairs = GetWithPackOverrideOption();
 
         s_rootCommand = new RootCommand("ClangSharp P/Invoke Binding Generator")
         {
@@ -198,7 +200,8 @@ public class Program
             s_withSuppressGCTransitions,
             s_withTransparentStructNameValuePairs,
             s_withTypeNameValuePairs,
-            s_withUsingNameValuePairs
+            s_withUsingNameValuePairs,
+            s_withPackOverrideNameValuePairs
         };
         Handler.SetHandler(s_rootCommand, (Action<InvocationContext>)Run);
     }
@@ -255,6 +258,7 @@ public class Program
         var withTransparentStructNameValuePairs = context.ParseResult.GetValueForOption(s_withTransparentStructNameValuePairs) ?? Array.Empty<string>();
         var withTypeNameValuePairs = context.ParseResult.GetValueForOption(s_withTypeNameValuePairs) ?? Array.Empty<string>();
         var withUsingNameValuePairs = context.ParseResult.GetValueForOption(s_withUsingNameValuePairs) ?? Array.Empty<string>();
+        var withPackOverrideNameValuePairs = context.ParseResult.GetValueForOption(s_withPackOverrideNameValuePairs) ?? Array.Empty<string>();
 
         var versionResult = context.ParseResult.FindResultFor(s_versionOption);
 
@@ -295,6 +299,7 @@ public class Program
         ParseKeyValuePairs(withTransparentStructNameValuePairs, errorList, out Dictionary<string, (string, PInvokeGeneratorTransparentStructKind)> withTransparentStructs);
         ParseKeyValuePairs(withTypeNameValuePairs, errorList, out Dictionary<string, string> withTypes);
         ParseKeyValuePairs(withUsingNameValuePairs, errorList, out Dictionary<string, IReadOnlyList<string>> withUsings);
+        ParseKeyValuePairs(withPackOverrideNameValuePairs, errorList, out Dictionary<string, string> withPackOverrides);
 
         foreach (var key in withTransparentStructs.Keys)
         {
@@ -681,6 +686,7 @@ public class Program
             WithTransparentStructs = withTransparentStructs,
             WithTypes = withTypes,
             WithUsings = withUsings,
+            WithPackOverrides = withPackOverrides,
         };
 
         if (config.GenerateMacroBindings)
@@ -1283,6 +1289,17 @@ public class Program
         return new Option<string[]>(
             aliases: new string[] { "--with-using", "-wu" },
             description: "A using directive to be included for the given remapped declaration name during binding generation.",
+            getDefaultValue: Array.Empty<string>
+        ) {
+            AllowMultipleArgumentsPerToken = true
+        };
+    }
+
+    private static Option<string[]> GetWithPackOverrideOption()
+    {
+        return new Option<string[]>(
+            aliases: new string[] { "--with-pack-override", "-wpo" },
+            description: "Overrides the StructLayoutAttribute.Pack property for the given type.",
             getDefaultValue: Array.Empty<string>
         ) {
             AllowMultipleArgumentsPerToken = true

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -57,7 +57,7 @@ public class Program
     private static readonly Option<string[]> s_withTransparentStructNameValuePairs;
     private static readonly Option<string[]> s_withTypeNameValuePairs;
     private static readonly Option<string[]> s_withUsingNameValuePairs;
-    private static readonly Option<string[]> s_withPackOverrideNameValuePairs;
+    private static readonly Option<string[]> s_withPackingNameValuePairs;
 
 
     private static readonly TwoColumnHelpRow[] s_configOptions = new TwoColumnHelpRow[]
@@ -162,7 +162,7 @@ public class Program
         s_withTransparentStructNameValuePairs = GetWithTransparentStructOption();
         s_withTypeNameValuePairs = GetWithTypeOption();
         s_withUsingNameValuePairs = GetWithUsingOption();
-        s_withPackOverrideNameValuePairs = GetWithPackOverrideOption();
+        s_withPackingNameValuePairs = GetWithPackingOption();
 
         s_rootCommand = new RootCommand("ClangSharp P/Invoke Binding Generator")
         {
@@ -201,7 +201,7 @@ public class Program
             s_withTransparentStructNameValuePairs,
             s_withTypeNameValuePairs,
             s_withUsingNameValuePairs,
-            s_withPackOverrideNameValuePairs
+            s_withPackingNameValuePairs
         };
         Handler.SetHandler(s_rootCommand, (Action<InvocationContext>)Run);
     }
@@ -258,7 +258,7 @@ public class Program
         var withTransparentStructNameValuePairs = context.ParseResult.GetValueForOption(s_withTransparentStructNameValuePairs) ?? Array.Empty<string>();
         var withTypeNameValuePairs = context.ParseResult.GetValueForOption(s_withTypeNameValuePairs) ?? Array.Empty<string>();
         var withUsingNameValuePairs = context.ParseResult.GetValueForOption(s_withUsingNameValuePairs) ?? Array.Empty<string>();
-        var withPackOverrideNameValuePairs = context.ParseResult.GetValueForOption(s_withPackOverrideNameValuePairs) ?? Array.Empty<string>();
+        var withPackingNameValuePairs = context.ParseResult.GetValueForOption(s_withPackingNameValuePairs) ?? Array.Empty<string>();
 
         var versionResult = context.ParseResult.FindResultFor(s_versionOption);
 
@@ -299,7 +299,7 @@ public class Program
         ParseKeyValuePairs(withTransparentStructNameValuePairs, errorList, out Dictionary<string, (string, PInvokeGeneratorTransparentStructKind)> withTransparentStructs);
         ParseKeyValuePairs(withTypeNameValuePairs, errorList, out Dictionary<string, string> withTypes);
         ParseKeyValuePairs(withUsingNameValuePairs, errorList, out Dictionary<string, IReadOnlyList<string>> withUsings);
-        ParseKeyValuePairs(withPackOverrideNameValuePairs, errorList, out Dictionary<string, string> withPackOverrides);
+        ParseKeyValuePairs(withPackingNameValuePairs, errorList, out Dictionary<string, string> withPackings);
 
         foreach (var key in withTransparentStructs.Keys)
         {
@@ -686,7 +686,7 @@ public class Program
             WithTransparentStructs = withTransparentStructs,
             WithTypes = withTypes,
             WithUsings = withUsings,
-            WithPackOverrides = withPackOverrides,
+            WithPackings = withPackings,
         };
 
         if (config.GenerateMacroBindings)
@@ -1295,10 +1295,10 @@ public class Program
         };
     }
 
-    private static Option<string[]> GetWithPackOverrideOption()
+    private static Option<string[]> GetWithPackingOption()
     {
         return new Option<string[]>(
-            aliases: new string[] { "--with-pack-override", "-wpo" },
+            aliases: new string[] { "--with-packing", "-wp" },
             description: "Overrides the StructLayoutAttribute.Pack property for the given type.",
             getDefaultValue: Array.Empty<string>
         ) {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
@@ -106,7 +106,7 @@ public abstract class PInvokeGeneratorTest
             WithTransparentStructs = withTransparentStructs,
             WithTypes = withTypes,
             WithUsings = withUsings,
-            WithPackOverrides = null,
+            WithPackings = null,
         };
 
         using (var pinvokeGenerator = new PInvokeGenerator(config, (path) => outputStream))

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
@@ -106,6 +106,7 @@ public abstract class PInvokeGeneratorTest
             WithTransparentStructs = withTransparentStructs,
             WithTypes = withTypes,
             WithUsings = withUsings,
+            WithPackOverrides = null,
         };
 
         using (var pinvokeGenerator = new PInvokeGenerator(config, (path) => outputStream))


### PR DESCRIPTION
Allows a user to specify an exact value for `StructLayoutAttribute.Pack`, which is useful for controlling packing with a constant value defined in C#.

For example, `--with-packing ExampleStruct=InteropDetails.PackConstant` given the following header:
```cpp
struct ExampleStruct
{
};
```
Will output the following C# definition of `ExampleStruct`:
```cs
[StructLayout(LayoutKind.Sequential, Pack = InteropDetails.PackConstant)]
public partial struct ExampleStruct
{
}
```