### PR TITLE
Don't apply --with-packing overrides to fixed buffer types

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -2822,11 +2822,6 @@ public partial class PInvokeGenerator
                 AddDiagnostic(DiagnosticLevel.Info, $"{escapedName} (constant array field) has a size of 0", constantOrIncompleteArray);
             }
 
-            if (!TryGetRemappedValue(recordDecl, _config.WithPackings, out var pack))
-            {
-                pack = alignment < maxAlignm ? alignment.ToString(CultureInfo.InvariantCulture) : null;
-            }
-
             var desc = new StructDesc {
                 AccessSpecifier = accessSpecifier,
                 EscapedName = escapedName,
@@ -2836,7 +2831,7 @@ public partial class PInvokeGenerator
                     Alignment64 = alignment64,
                     Size32 = size32,
                     Size64 = size64,
-                    Pack = pack,
+                    Pack = alignment < maxAlignm ? alignment.ToString(CultureInfo.InvariantCulture) : null,
                     MaxFieldAlignment = maxAlignm,
                     Kind = LayoutKind.Sequential
                 },


### PR DESCRIPTION
Due to an oversight in https://github.com/dotnet/ClangSharp/pull/405, `--with-packing` on `MyStruct` will also apply to any nested fixed buffer types generated for its fields.

For example, the following C structure:
```c
struct MyStruct
{
    size_t FixedBuffer[1];
};
```
Will currently generate the following C# code (latest-codegen):
```cs
using System;
using System.Diagnostics.CodeAnalysis;
using System.Runtime.InteropServices;

namespace ClangSharp.Test
{
    [StructLayout(LayoutKind.Sequential, Pack = CustomPackValue)]
    public partial struct MyStruct
    {
        [NativeTypeName("size_t[1]")]
        public _FixedBuffer_e__FixedBuffer FixedBuffer;

        [StructLayout(LayoutKind.Sequential, Pack = CustomPackValue)]
        public partial struct _FixedBuffer_e__FixedBuffer
        {
            public nuint e0;

            [UnscopedRef]
            public ref nuint this[int index]
            {
                get
                {
                    return ref AsSpan(int.MaxValue)[index];
                }
            }

            [UnscopedRef]
            public Span<nuint> AsSpan(int length) => MemoryMarshal.CreateSpan(ref e0, length);
        }
    }
}
```
This issue does not apply to fixed buffers of types supported naturally by C#, only those that require ClangSharp to generate an `_e__FixedBuffer` type.

Tests are covered in https://github.com/dotnet/ClangSharp/pull/406.