### PR TITLE
Ensure that we null out the stream for generate-multi-file for all helper class generation methods.

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -435,6 +435,11 @@ public sealed partial class PInvokeGenerator : IDisposable
             {
                 sw.WriteLine('}');
             }
+
+            if (!leaveStreamOpen)
+            {
+                stream = null;
+            }
         }
 
         static void GenerateNativeTypeNameAttribute(PInvokeGenerator generator, Stream? stream, bool leaveStreamOpen)
@@ -513,6 +518,11 @@ public sealed partial class PInvokeGenerator : IDisposable
             {
                 sw.WriteLine('}');
             }
+
+            if (!leaveStreamOpen)
+            {
+                stream = null;
+            }
         }
 
         static void GenerateSetsLastSystemErrorAttribute(PInvokeGenerator generator, Stream? stream, bool leaveStreamOpen)
@@ -580,6 +590,11 @@ public sealed partial class PInvokeGenerator : IDisposable
             if (!generator.Config.GenerateFileScopedNamespaces)
             {
                 sw.WriteLine('}');
+            }
+
+            if (!leaveStreamOpen)
+            {
+                stream = null;
             }
         }
 
@@ -659,6 +674,11 @@ public sealed partial class PInvokeGenerator : IDisposable
             if (!generator.Config.GenerateFileScopedNamespaces)
             {
                 sw.WriteLine('}');
+            }
+
+            if (!leaveStreamOpen)
+            {
+                stream = null;
             }
         }
 


### PR DESCRIPTION
This is an extension of #393.
Fixes #413.