### PR TITLE
Handle `format` and `format_arg` attributes as no-ops.

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -6470,6 +6470,8 @@ public sealed partial class PInvokeGenerator : IDisposable
                         break;
                     }
 
+                    case CX_AttrKind_Format:
+                    case CX_AttrKind_FormatArg:
                     case CX_AttrKind_MSNoVTable:
                     case CX_AttrKind_MSAllocator:
                     case CX_AttrKind_MaxFieldAlignment:


### PR DESCRIPTION
```
    Warning (Line 3068, Column 26 in ../../api/binaryninjacore.h): Unsupported attribute: 'Format'. Generated bindings may be incomplete.
    Warning (Line 3072, Column 26 in ../../api/binaryninjacore.h): Unsupported attribute: 'Format'. Generated bindings may be incomplete.
    Warning (Line 3075, Column 26 in ../../api/binaryninjacore.h): Unsupported attribute: 'Format'. Generated bindings may be incomplete.
    Warning (Line 3078, Column 26 in ../../api/binaryninjacore.h): Unsupported attribute: 'Format'. Generated bindings may be incomplete.
    Warning (Line 3081, Column 26 in ../../api/binaryninjacore.h): Unsupported attribute: 'Format'. Generated bindings may be incomplete.
    Warning (Line 3084, Column 26 in ../../api/binaryninjacore.h): Unsupported attribute: 'Format'. Generated bindings may be incomplete.
    Warning (Line 3094, Column 26 in ../../api/binaryninjacore.h): Unsupported attribute: 'Format'. Generated bindings may be incomplete.
```