### PR TITLE
Allow equals sign in value for parsed KVP Pairs

### DIFF
--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -852,9 +852,9 @@ public class Program
 
         foreach (var keyValuePair in keyValuePairs)
         {
-            var parts = keyValuePair.Split('=');
+            var parts = keyValuePair.Split('=',2);
 
-            if (parts.Length != 2)
+            if (parts.Length < 2)
             {
                 errorList.Add($"Error: Invalid key/value pair argument: {keyValuePair}. Expected 'name=value'");
                 continue;

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -852,7 +852,7 @@ public class Program
 
         foreach (var keyValuePair in keyValuePairs)
         {
-            var parts = keyValuePair.Split('=',2);
+            var parts = keyValuePair.Split('=', 2);
 
             if (parts.Length < 2)
             {


### PR DESCRIPTION
Parses KVP arg into a substring with only ever two parts based around the boundary of the first equals sign. Subsequent equals signs are ignored and and make their way into the final parsed value as is.
