### PR TITLE
Ensure compatible-codegen inserts "unsafe" where required

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -5933,7 +5933,7 @@ public sealed partial class PInvokeGenerator : IDisposable
             {
                 return true;
             }
-            else if ((decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymousStructOrUnion && IsUnsafe(nestedRecordDecl))
+            else if ((decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymousStructOrUnion && (IsUnsafe(nestedRecordDecl) || Config.GenerateCompatibleCode))
             {
                 return true;
             }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/FunctionDeclarationBodyImportTest.cs
@@ -1446,7 +1446,7 @@ void MyFunction()
 namespace ClangSharp.Test
 {
     [StructLayout(LayoutKind.Explicit)]
-    public partial struct MyUnion
+    public unsafe partial struct MyUnion
     {
         [FieldOffset(0)]
         [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
@@ -1249,7 +1249,7 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous1_e__Struct
+            public unsafe partial struct _Anonymous1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
@@ -1318,7 +1318,7 @@ namespace ClangSharp.Test
 
         var expectedOutputContents = @"namespace ClangSharp.Test
 {
-    public partial struct MyStruct
+    public unsafe partial struct MyStruct
     {
         public int x;
 
@@ -1375,7 +1375,7 @@ namespace ClangSharp.Test
             }
         }
 
-        public partial struct _Anonymous_e__Struct
+        public unsafe partial struct _Anonymous_e__Struct
         {
             public int z;
 
@@ -1708,7 +1708,7 @@ struct example_s {
 
         var expectedOutputContents = @"namespace ClangSharp.Test
 {
-    public partial struct MyStruct
+    public unsafe partial struct MyStruct
     {
         public double r;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/UnionDeclarationTest.cs
@@ -891,7 +891,7 @@ namespace ClangSharp.Test
 namespace ClangSharp.Test
 {
     [StructLayout(LayoutKind.Explicit)]
-    public partial struct MyUnion
+    public unsafe partial struct MyUnion
     {
         [FieldOffset(0)]
         public int x;
@@ -952,7 +952,7 @@ namespace ClangSharp.Test
         }
 
         [StructLayout(LayoutKind.Explicit)]
-        public partial struct _Anonymous_e__Union
+        public unsafe partial struct _Anonymous_e__Union
         {
             [FieldOffset(0)]
             public int z;
@@ -1283,7 +1283,7 @@ namespace ClangSharp.Test
 namespace ClangSharp.Test
 {
     [StructLayout(LayoutKind.Explicit)]
-    public partial struct MyUnion
+    public unsafe partial struct MyUnion
     {
         [FieldOffset(0)]
         public double r;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/FunctionDeclarationBodyImportTest.cs
@@ -1446,7 +1446,7 @@ void MyFunction()
 namespace ClangSharp.Test
 {
     [StructLayout(LayoutKind.Explicit)]
-    public partial struct MyUnion
+    public unsafe partial struct MyUnion
     {
         [FieldOffset(0)]
         [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
@@ -1257,7 +1257,7 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous1_e__Struct
+            public unsafe partial struct _Anonymous1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
@@ -1326,7 +1326,7 @@ namespace ClangSharp.Test
 
         var expectedOutputContents = @"namespace ClangSharp.Test
 {
-    public partial struct MyStruct
+    public unsafe partial struct MyStruct
     {
         public int x;
 
@@ -1383,7 +1383,7 @@ namespace ClangSharp.Test
             }
         }
 
-        public partial struct _Anonymous_e__Struct
+        public unsafe partial struct _Anonymous_e__Struct
         {
             public int z;
 
@@ -1716,7 +1716,7 @@ struct example_s {
 
         var expectedOutputContents = @"namespace ClangSharp.Test
 {
-    public partial struct MyStruct
+    public unsafe partial struct MyStruct
     {
         public double r;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/UnionDeclarationTest.cs
@@ -898,7 +898,7 @@ namespace ClangSharp.Test
 namespace ClangSharp.Test
 {
     [StructLayout(LayoutKind.Explicit)]
-    public partial struct MyUnion
+    public unsafe partial struct MyUnion
     {
         [FieldOffset(0)]
         public int x;
@@ -959,7 +959,7 @@ namespace ClangSharp.Test
         }
 
         [StructLayout(LayoutKind.Explicit)]
-        public partial struct _Anonymous_e__Union
+        public unsafe partial struct _Anonymous_e__Union
         {
             [FieldOffset(0)]
             public int z;
@@ -1290,7 +1290,7 @@ namespace ClangSharp.Test
 namespace ClangSharp.Test
 {
     [StructLayout(LayoutKind.Explicit)]
-    public partial struct MyUnion
+    public unsafe partial struct MyUnion
     {
         [FieldOffset(0)]
         public double r;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/FunctionDeclarationBodyImportTest.cs
@@ -1629,7 +1629,7 @@ void MyFunction()
         var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyUnion"" access=""public"" layout=""Explicit"">
+    <struct name=""MyUnion"" access=""public"" unsafe=""true"" layout=""Explicit"">
       <field name=""Anonymous"" access=""public"" offset=""0"">
         <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
       </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
@@ -1258,7 +1258,7 @@ struct MyStruct
         var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyStruct"" access=""public"">
+    <struct name=""MyStruct"" access=""public"" unsafe=""true"">
       <field name=""x"" access=""public"">
         <type>int</type>
       </field>
@@ -1304,7 +1304,7 @@ struct MyStruct
           <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
         </set>
       </field>
-      <struct name=""_Anonymous_e__Struct"" access=""public"">
+      <struct name=""_Anonymous_e__Struct"" access=""public"" unsafe=""true"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
@@ -1654,7 +1654,7 @@ struct example_s {
         var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyStruct"" access=""public"">
+    <struct name=""MyStruct"" access=""public"" unsafe=""true"">
       <field name=""r"" access=""public"">
         <type>double</type>
       </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/UnionDeclarationTest.cs
@@ -846,7 +846,7 @@ union MyUnion
         var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyUnion"" access=""public"" layout=""Explicit"">
+    <struct name=""MyUnion"" access=""public"" unsafe=""true"" layout=""Explicit"">
       <field name=""x"" access=""public"" offset=""0"">
         <type>int</type>
       </field>
@@ -892,7 +892,7 @@ union MyUnion
           <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
         </set>
       </field>
-      <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+      <struct name=""_Anonymous_e__Union"" access=""public"" unsafe=""true"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
@@ -1188,7 +1188,7 @@ union example_s {
         var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyUnion"" access=""public"" layout=""Explicit"">
+    <struct name=""MyUnion"" access=""public"" unsafe=""true"" layout=""Explicit"">
       <field name=""r"" access=""public"" offset=""0"">
         <type>double</type>
       </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/FunctionDeclarationBodyImportTest.cs
@@ -1629,7 +1629,7 @@ void MyFunction()
         var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyUnion"" access=""public"" layout=""Explicit"">
+    <struct name=""MyUnion"" access=""public"" unsafe=""true"" layout=""Explicit"">
       <field name=""Anonymous"" access=""public"" offset=""0"">
         <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
       </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
@@ -1270,7 +1270,7 @@ struct MyStruct
         var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyStruct"" access=""public"">
+    <struct name=""MyStruct"" access=""public"" unsafe=""true"">
       <field name=""x"" access=""public"">
         <type>int</type>
       </field>
@@ -1316,7 +1316,7 @@ struct MyStruct
           <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
         </set>
       </field>
-      <struct name=""_Anonymous_e__Struct"" access=""public"">
+      <struct name=""_Anonymous_e__Struct"" access=""public"" unsafe=""true"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
@@ -1665,7 +1665,7 @@ struct example_s {
         var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyStruct"" access=""public"">
+    <struct name=""MyStruct"" access=""public"" unsafe=""true"">
       <field name=""r"" access=""public"">
         <type>double</type>
       </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/UnionDeclarationTest.cs
@@ -852,7 +852,7 @@ union MyUnion
         var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyUnion"" access=""public"" layout=""Explicit"">
+    <struct name=""MyUnion"" access=""public"" unsafe=""true"" layout=""Explicit"">
       <field name=""x"" access=""public"" offset=""0"">
         <type>int</type>
       </field>
@@ -898,7 +898,7 @@ union MyUnion
           <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
         </set>
       </field>
-      <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+      <struct name=""_Anonymous_e__Union"" access=""public"" unsafe=""true"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
@@ -1194,7 +1194,7 @@ union example_s {
         var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
 <bindings>
   <namespace name=""ClangSharp.Test"">
-    <struct name=""MyUnion"" access=""public"" layout=""Explicit"">
+    <struct name=""MyUnion"" access=""public"" unsafe=""true"" layout=""Explicit"">
       <field name=""r"" access=""public"" offset=""0"">
         <type>double</type>
       </field>


### PR DESCRIPTION
This resolves https://github.com/dotnet/ClangSharp/issues/492

Notably it's the "quick" fix and it doesn't fully account for ensuring the least number of `unsafe` is emitted. But it is now correct.