### PR TITLE
Fixed instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ git clone https://github.com/dotnet/clangsharp
 cd clangsharp
 mkdir -p artifacts/bin/native
 cd artifacts/bin/native
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DPATH_TO_LLVM=../../../../llvm-project/artifacts/install
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DPATH_TO_LLVM=../../../../llvm-project/artifacts/install ../../../
 make install
 ```
 


### PR DESCRIPTION
Per @tannergooding's [recommendation](https://github.com/dotnet/ClangSharp/issues/516#issuecomment-1863455168). There were some symbols missing from this line