### PR TITLE
Fix native crashes / asserts in libClangSharp and CXXRecordDecl Destructor property.

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -717,7 +717,7 @@ public partial class PInvokeGenerator
                 {
                     outputBuilder.Write("Base");
                 }
-                
+
                 outputBuilder.Write('.');
                 outputBuilder.Write(name);
                 outputBuilder.Write('(');
@@ -1817,7 +1817,11 @@ public partial class PInvokeGenerator
                 {
                     var cxxDestructorDecl = cxxRecordDecl.Destructor;
 
-                    if (!cxxDestructorDecl.IsVirtual && !IsExcluded(cxxDestructorDecl))
+                    if (cxxDestructorDecl == null)
+                    {
+                        AddDiagnostic(DiagnosticLevel.Warning, "Record has user declared destructor, but Destructor property was null. Generated bindings may be incomplete.", cxxRecordDecl);
+                    }
+                    else if (!cxxDestructorDecl.IsVirtual && !IsExcluded(cxxDestructorDecl))
                     {
                         Visit(cxxDestructorDecl);
                         _outputBuilder.WriteDivider();

--- a/sources/ClangSharp/Cursors/Decls/CXXRecordDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CXXRecordDecl.cs
@@ -14,7 +14,7 @@ public class CXXRecordDecl : RecordDecl
     private readonly Lazy<IReadOnlyList<CXXConstructorDecl>> _ctors;
     private readonly Lazy<FunctionTemplateDecl> _dependentLambdaCallOperator;
     private readonly Lazy<ClassTemplateDecl> _describedClassTemplate;
-    private readonly Lazy<CXXDestructorDecl> _destructor;
+    private readonly Lazy<CXXDestructorDecl?> _destructor;
     private readonly Lazy<IReadOnlyList<FriendDecl>> _friends;
     private readonly Lazy<CXXRecordDecl> _instantiatedFromMemberClass;
     private readonly Lazy<CXXMethodDecl> _lambdaCallOperator;
@@ -63,7 +63,10 @@ public class CXXRecordDecl : RecordDecl
 
         _dependentLambdaCallOperator = new Lazy<FunctionTemplateDecl>(() => TranslationUnit.GetOrCreate<FunctionTemplateDecl>(Handle.DependentLambdaCallOperator));
         _describedClassTemplate = new Lazy<ClassTemplateDecl>(() => TranslationUnit.GetOrCreate<ClassTemplateDecl>(Handle.DescribedCursorTemplate));
-        _destructor = new Lazy<CXXDestructorDecl>(() => TranslationUnit.GetOrCreate<CXXDestructorDecl>(Handle.Destructor));
+        _destructor = new Lazy<CXXDestructorDecl?>(() => {
+            CXCursor destructor = Handle.Destructor;
+            return destructor.IsNull ? null : TranslationUnit.GetOrCreate<CXXDestructorDecl>(Handle.Destructor);
+        });
 
         _friends = new Lazy<IReadOnlyList<FriendDecl>>(() => {
             var numFriends = Handle.NumFriends;
@@ -126,7 +129,7 @@ public class CXXRecordDecl : RecordDecl
 
     public ClassTemplateDecl DescribedClassTemplate => _describedClassTemplate.Value;
 
-    public CXXDestructorDecl Destructor => _destructor.Value;
+    public CXXDestructorDecl? Destructor => _destructor.Value;
 
     public IReadOnlyList<FriendDecl> Friends => _friends.Value;
 

--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -2813,6 +2813,11 @@ CXCursor clangsharp_Cursor_getLambdaStaticInvoker(CXCursor C) {
         const Decl* D = getCursorDecl(C);
 
         if (const CXXRecordDecl* CRD = dyn_cast<CXXRecordDecl>(D)) {
+            CXXMethodDecl *CallOp = CRD->getLambdaCallOperator();
+            // Work around a Clang bug: CRD->getLambdaStaticInvoker will crash if getLambdaCallOperator returns null.
+            if (CallOp == nullptr) {
+                return clang_getNullCursor();
+            }
             return MakeCXCursor(CRD->getLambdaStaticInvoker(), getCursorTU(C));
         }
     }
@@ -3088,6 +3093,9 @@ int clangsharp_Cursor_getNumAssociatedConstraints(CXCursor C) {
 int clangsharp_Cursor_getNumAttrs(CXCursor C) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
+        if (!D->hasAttrs()) {
+            return 0;
+        }
         return D->getAttrs().size();
     }
 


### PR DESCRIPTION
* Work around a clang crash in clangsharp_Cursor_getLambdaStaticInvoker when CRD->getLambdaCallOperator() returns null and CRD->getLambdaStaticInvoker() is called.

* clangsharp_Cursor_getNumAttrs: Calling D->getAttrs() will assert if D->hasAttrs() returns false. Fix by checking D->hasAttrs() first.

* A CXXRecordDecl may return null for getDestructor. Change the C# CXXRecordDecl Destructor property to be nullable to support this case.

Hopefully these changes make inspecting ClangSharp objects in the debugger much less likely to crash.