### PR TITLE
Add OverloadedDeclRef

### DIFF
--- a/sources/ClangSharp/Cursors/Refs/OverloadedDeclRef.cs
+++ b/sources/ClangSharp/Cursors/Refs/OverloadedDeclRef.cs
@@ -24,5 +24,4 @@ public sealed class OverloadedDeclRef : Ref
     }
 
     public IEnumerable<Decl> OverloadedDecls => _overloadedDecls.Value;
-
 }

--- a/sources/ClangSharp/Cursors/Refs/OverloadedDeclRef.cs
+++ b/sources/ClangSharp/Cursors/Refs/OverloadedDeclRef.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ClangSharp.Interop;
+using static ClangSharp.Interop.CXCursorKind;
+
+namespace ClangSharp;
+
+public sealed class OverloadedDeclRef : Ref
+{
+    private readonly Lazy<IEnumerable<Decl>> _overloadedDecls;
+
+    internal OverloadedDeclRef(CXCursor handle) : base(handle, CXCursor_OverloadedDeclRef)
+    {
+        _overloadedDecls = new Lazy<IEnumerable<Decl>>(() => {
+            uint num = Handle.NumOverloadedDecls;
+            return Enumerable.Range(0, (int)num)
+                .Select(i => Handle.GetOverloadedDecl((uint)i))
+                .Select(c => TranslationUnit.GetOrCreate<Decl>(c))
+                .ToArray();
+        });
+    }
+
+    public IEnumerable<Decl> OverloadedDecls => _overloadedDecls.Value;
+
+}

--- a/sources/ClangSharp/Cursors/Refs/Ref.cs
+++ b/sources/ClangSharp/Cursors/Refs/Ref.cs
@@ -34,6 +34,12 @@ public class Ref : Cursor
                 break;
             }
 
+            case CXCursor_OverloadedDeclRef:
+            {
+                result = new OverloadedDeclRef(handle);
+                break;
+            }
+
             case CXCursor_ObjCSuperClassRef:
             case CXCursor_ObjCProtocolRef:
             case CXCursor_ObjCClassRef:
@@ -42,7 +48,6 @@ public class Ref : Cursor
             case CXCursor_NamespaceRef:
             case CXCursor_MemberRef:
             case CXCursor_LabelRef:
-            case CXCursor_OverloadedDeclRef:
             case CXCursor_VariableRef:
             {
                 result = new Ref(handle, handle.Kind);


### PR DESCRIPTION
For cursors of the kind CXCursor_OverloadedDeclRef. This allows easier access of this cursor kind's overloaded decls in their higher-level ClangSharp wrapper type, rather than as CXCursors.

Note: I assumed that OverloadedDecls should be `IEnumerable<Decl>` over `IEnumerable<Cursor>`, as I don't think it's expected for any of the cursors return by clang_getOverloadedDecl to not be a Decl cursor.