### PR TITLE
Config option: strip-enum-member-type-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ Options:
   generate-unmanaged-constants           Unmanaged constants should be generated using static ref readonly properties. This is currently experimental.
   generate-vtbl-index-attribute          [VtblIndex(#)] attribute should be generated to document the underlying VTBL index for a helper method.
 
+  # Stripping Options
+
+  strip-enum-member-type-name            Strips the enum type name from the beginning of its member names.
+
   # Logging Options
 
   log-exclusions                         A list of excluded declaration types should be generated. This will also log if the exclusion was due to an exact or partial match.

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -297,9 +297,7 @@ public partial class PInvokeGenerator
 
         if (Config.StripEnumMemberTypeName)
         {
-            Regex stripParentNameRegex = new($"^{Regex.Escape(parentName)}_*", RegexOptions.IgnoreCase);
-            var strippedName = stripParentNameRegex.Replace(escapedName, string.Empty);
-            escapedName = strippedName;
+            escapedName = PrefixAndStrip(escapedName, parentName, trimChar: '_');
         }
 
         var kind = isAnonymousEnum ? ValueKind.Primitive : ValueKind.Enumerator;
@@ -543,12 +541,12 @@ public partial class PInvokeGenerator
         if ((cxxMethodDecl is not null) && cxxMethodDecl.IsVirtual)
         {
             isVirtual = true;
-            escapedName = PrefixAndStripName(name, GetOverloadIndex(cxxMethodDecl));
+            escapedName = PrefixAndStripMethodName(name, GetOverloadIndex(cxxMethodDecl));
         }
         else
         {
             isVirtual = false;
-            escapedName = EscapeAndStripName(name);
+            escapedName = EscapeAndStripMethodName(name);
         }
 
         var returnType = functionDecl.ReturnType;
@@ -2032,7 +2030,7 @@ public partial class PInvokeGenerator
 
             var desc = new FunctionOrDelegateDesc {
                 AccessSpecifier = AccessSpecifier.Public,
-                EscapedName = EscapeAndStripName(name),
+                EscapedName = EscapeAndStripMethodName(name),
                 IsMemberFunction = true,
                 NativeTypeName = nativeTypeName,
                 HasFnPtrCodeGen = !_config.ExcludeFnptrCodegen,
@@ -2120,7 +2118,7 @@ public partial class PInvokeGenerator
             }
 
             var remappedName = FixupNameForMultipleHits(cxxMethodDecl);
-            var escapedName = EscapeAndStripName(remappedName);
+            var escapedName = EscapeAndStripMethodName(remappedName);
 
             var desc = new FieldDesc
             {
@@ -2189,7 +2187,7 @@ public partial class PInvokeGenerator
             var desc = new FunctionOrDelegateDesc {
                 AccessSpecifier = AccessSpecifier.Public,
                 IsAggressivelyInlined = _config.GenerateAggressiveInlining,
-                EscapedName = EscapeAndStripName(name),
+                EscapedName = EscapeAndStripMethodName(name),
                 ParentName = parentName,
                 IsMemberFunction = true,
                 IsInherited = isInherited,
@@ -2269,7 +2267,7 @@ public partial class PInvokeGenerator
             {
                 body.Write("Marshal.GetDelegateForFunctionPointer<");
                 body.BeginMarker("delegate");
-                body.Write(PrefixAndStripName(name, GetOverloadIndex(cxxMethodDecl)));
+                body.Write(PrefixAndStripMethodName(name, GetOverloadIndex(cxxMethodDecl)));
                 body.EndMarker("delegate");
                 body.Write(">(");
             }
@@ -2278,7 +2276,7 @@ public partial class PInvokeGenerator
             {
                 body.Write("lpVtbl->");
                 body.BeginMarker("vtbl", new KeyValuePair<string, object>("explicit", true));
-                body.Write(EscapeAndStripName(remappedName));
+                body.Write(EscapeAndStripMethodName(remappedName));
                 body.EndMarker("vtbl");
             }
             else

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using ClangSharp.Abstractions;
 using ClangSharp.CSharp;
 using static ClangSharp.Interop.CX_CastKind;
@@ -19,7 +20,6 @@ using static ClangSharp.Interop.CX_UnaryExprOrTypeTrait;
 using static ClangSharp.Interop.CXUnaryOperatorKind;
 using static ClangSharp.Interop.CXEvalResultKind;
 using static ClangSharp.Interop.CXTypeKind;
-using System.Text.RegularExpressions;
 
 namespace ClangSharp;
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -19,6 +19,7 @@ using static ClangSharp.Interop.CX_UnaryExprOrTypeTrait;
 using static ClangSharp.Interop.CXUnaryOperatorKind;
 using static ClangSharp.Interop.CXEvalResultKind;
 using static ClangSharp.Interop.CXTypeKind;
+using System.Text.RegularExpressions;
 
 namespace ClangSharp;
 
@@ -294,6 +295,13 @@ public partial class PInvokeGenerator
             parentName = _outputBuilder.Name;
         }
 
+        var strippedName = escapedName;
+        if (Config.StripEnumMemberTypeName)
+        {
+            Regex stripParentNameRegex = new($"^{Regex.Escape(parentName)}_*");
+            strippedName = stripParentNameRegex.Replace(escapedName, string.Empty);
+        }
+
         var kind = isAnonymousEnum ? ValueKind.Primitive : ValueKind.Enumerator;
         var flags = ValueFlags.Constant;
 
@@ -305,7 +313,7 @@ public partial class PInvokeGenerator
         var desc = new ValueDesc {
             AccessSpecifier = accessSpecifier,
             TypeName = typeName,
-            EscapedName = escapedName,
+            EscapedName = Config.StripEnumMemberTypeName ? strippedName : escapedName,
             NativeTypeName = null,
             ParentName = parentName,
             Kind = kind,

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -298,7 +298,7 @@ public partial class PInvokeGenerator
         var strippedName = escapedName;
         if (Config.StripEnumMemberTypeName)
         {
-            Regex stripParentNameRegex = new($"^{Regex.Escape(parentName)}_*");
+            Regex stripParentNameRegex = new($"^{Regex.Escape(parentName)}_*", RegexOptions.IgnoreCase);
             strippedName = stripParentNameRegex.Replace(escapedName, string.Empty);
         }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -295,11 +295,11 @@ public partial class PInvokeGenerator
             parentName = _outputBuilder.Name;
         }
 
-        var strippedName = escapedName;
         if (Config.StripEnumMemberTypeName)
         {
             Regex stripParentNameRegex = new($"^{Regex.Escape(parentName)}_*", RegexOptions.IgnoreCase);
-            strippedName = stripParentNameRegex.Replace(escapedName, string.Empty);
+            var strippedName = stripParentNameRegex.Replace(escapedName, string.Empty);
+            escapedName = strippedName;
         }
 
         var kind = isAnonymousEnum ? ValueKind.Primitive : ValueKind.Enumerator;
@@ -313,7 +313,7 @@ public partial class PInvokeGenerator
         var desc = new ValueDesc {
             AccessSpecifier = accessSpecifier,
             TypeName = typeName,
-            EscapedName = Config.StripEnumMemberTypeName ? strippedName : escapedName,
+            EscapedName = escapedName,
             NativeTypeName = null,
             ParentName = parentName,
             Kind = kind,

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -970,7 +970,7 @@ public partial class PInvokeGenerator
 
             if (declRefExpr.Decl is FunctionDecl)
             {
-                escapedName = EscapeAndStripName(name);
+                escapedName = EscapeAndStripMethodName(name);
             }
         }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -2326,13 +2326,9 @@ public sealed partial class PInvokeGenerator : IDisposable
         }
     }
 
-    private string EscapeAndStripName(string name)
+    private string EscapeAndStripMethodName(string name)
     {
-        if (name.StartsWith(_config.MethodPrefixToStrip, StringComparison.Ordinal))
-        {
-            name = name[_config.MethodPrefixToStrip.Length..];
-        }
-
+        name = PrefixAndStrip(name, _config.MethodPrefixToStrip);
         return EscapeName(name);
     }
 
@@ -6198,13 +6194,32 @@ public sealed partial class PInvokeGenerator : IDisposable
         }
     }
 
-    private string PrefixAndStripName(string name, uint overloadIndex)
+    /// <summary>
+    /// Checks whether the specified name starts with a prefix, optionally trims a separator character following the prefix and returns the remainder.
+    /// </summary>
+    /// <param name="name">The name to strip.</param>
+    /// <param name="prefix">The prefix to strip from <paramref name="name"/>.</param>
+    /// <param name="trimChar">Additional separator that may follow <paramref name="prefix"/> which should also be trimmed away.</param>
+    /// <returns>
+    /// <paramref name="name"/> if it does not start with <paramref name="prefix"/>;
+    /// otherwise,
+    /// the remainder of <paramref name="name"/> after stripping <paramref name="prefix"/> and all immediate following occurences of <paramref name="trimChar"/> from it beginning.
+    /// </returns>
+    private static string PrefixAndStrip(string name, string prefix, char trimChar = '\0')
     {
-        if (name.StartsWith(_config.MethodPrefixToStrip, StringComparison.Ordinal))
+        var nameSpan = name.AsSpan();
+        if (nameSpan.StartsWith(prefix, StringComparison.Ordinal))
         {
-            name = name[_config.MethodPrefixToStrip.Length..];
+            nameSpan = nameSpan[prefix.Length..];
+            nameSpan = nameSpan.TrimStart(trimChar);
+            return nameSpan.ToString();
+        }
+        return name;
         }
 
+    private string PrefixAndStripMethodName(string name, uint overloadIndex)
+    {
+        name = PrefixAndStrip(name, _config.MethodPrefixToStrip);
         return $"_{name}{((overloadIndex != 0) ? overloadIndex.ToString(CultureInfo.InvariantCulture) : "")}";
     }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1454,18 +1454,18 @@ public sealed partial class PInvokeGenerator : IDisposable
                 return type.Contains('*', StringComparison.Ordinal)
                      ? (8, 4, +1)
                      : type switch {
-                        "sbyte" => (1, 1, -1),
-                        "byte" => (1, 1, +1),
-                        "short" => (2, 2, -1),
-                        "ushort" => (2, 2, +1),
-                        "int" => (4, 4, -1),
-                        "uint" => (4, 4, +1),
-                        "nint" => (8, 4, -1),
-                        "nuint" => (8, 4, +1),
-                        "long" => (8, 8, -1),
-                        "ulong" => (8, 8, +1),
-                        _ => (0, 0, 0),
-                    };
+                         "sbyte" => (1, 1, -1),
+                         "byte" => (1, 1, +1),
+                         "short" => (2, 2, -1),
+                         "ushort" => (2, 2, +1),
+                         "int" => (4, 4, -1),
+                         "uint" => (4, 4, +1),
+                         "nint" => (8, 4, -1),
+                         "nuint" => (8, 4, +1),
+                         "long" => (8, 8, -1),
+                         "ulong" => (8, 8, +1),
+                         _ => (0, 0, 0),
+                     };
             }
 
             static void OutputConversions(StreamWriter sw, string indentString, string name, string type, PInvokeGeneratorTransparentStructKind kind, string target)
@@ -5403,7 +5403,7 @@ public sealed partial class PInvokeGenerator : IDisposable
         => kind is PInvokeGeneratorTransparentStructKind.Boolean;
 
     private static bool IsTransparentStructHandle(PInvokeGeneratorTransparentStructKind kind)
-         =>  kind is PInvokeGeneratorTransparentStructKind.Handle
+         => kind is PInvokeGeneratorTransparentStructKind.Handle
                   or PInvokeGeneratorTransparentStructKind.HandleWin32;
 
     private static bool IsTransparentStructHexBased(PInvokeGeneratorTransparentStructKind kind)
@@ -6149,7 +6149,7 @@ public sealed partial class PInvokeGenerator : IDisposable
 
     private static bool NeedsNewKeyword(string name)
     {
-        return name.Equals("Equals",StringComparison.Ordinal)
+        return name.Equals("Equals", StringComparison.Ordinal)
             || name.Equals("GetHashCode", StringComparison.Ordinal)
             || name.Equals("GetType", StringComparison.Ordinal)
             || name.Equals("MemberwiseClone", StringComparison.Ordinal)
@@ -6215,7 +6215,7 @@ public sealed partial class PInvokeGenerator : IDisposable
             return nameSpan.ToString();
         }
         return name;
-        }
+    }
 
     private string PrefixAndStripMethodName(string name, uint overloadIndex)
     {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -265,6 +265,8 @@ public sealed class PInvokeGeneratorConfiguration
 
     public bool GenerateVtblIndexAttribute => _options.HasFlag(PInvokeGeneratorConfigurationOptions.GenerateVtblIndexAttribute);
 
+    public bool StripEnumMemberTypeName => _options.HasFlag(PInvokeGeneratorConfigurationOptions.StripEnumMemberTypeName);
+
     public string HeaderText => _headerText;
 
     [AllowNull]

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -86,4 +86,6 @@ public enum PInvokeGeneratorConfigurationOptions : long
     GenerateCallConvMemberFunction = 1L << 37,
 
     GenerateGenericPointerWrapper = 1L << 38,
+
+    StripEnumMemberTypeName = 1L << 39,
 }

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -178,6 +178,12 @@ public static class Program
         new TwoColumnHelpRow("generate-vtbl-index-attribute", "[VtblIndex(#)] attribute should be generated to document the underlying VTBL index for a helper method."),
 
         new TwoColumnHelpRow("", ""),
+        new TwoColumnHelpRow("# Stripping Options", ""),
+        new TwoColumnHelpRow("", ""),
+
+        new TwoColumnHelpRow("strip-enum-member-type-name", "Strips the enum type name from the beginning of its member names."),
+
+        new TwoColumnHelpRow("", ""),
         new TwoColumnHelpRow("# Logging Options", ""),
         new TwoColumnHelpRow("", ""),
 
@@ -614,6 +620,14 @@ public static class Program
                 case "log-visited-files":
                 {
                     configOptions |= PInvokeGeneratorConfigurationOptions.LogVisitedFiles;
+                    break;
+                }
+
+                // Strip Options
+
+                case "strip-enum-member-type-name":
+                {
+                    configOptions |= PInvokeGeneratorConfigurationOptions.StripEnumMemberTypeName;
                     break;
                 }
 


### PR DESCRIPTION
Adds a new configuration option `strip-enum-member-type-name`. This feature adresses the feature request described in issue #461.

When the config option is applied, the enum type name is stripped from the beginning of each enum member.

```C
enum abc_some_enum {
  abc_some_enum_key1,
  abc_some_enum_key2,
  abc_some_enum_key3,
};
```

becomes 

```C#
enum abc_some_enum {
  key1,
  key2,
  key3,
}
```

Note above, that the original member name starts with `abc_some_enum_` which matches the enum type name `abc_some_enum` separating underscores between the type name and the suffix are also stripped to avoid leading underscores in the member names.

The matching for the enum type name is only done if the type appears verbatim in the beginning of the member name. Infix or suffix matching of the type name is not supported.

As @tannergooding notes in https://github.com/dotnet/ClangSharp/issues/461#issuecomment-1930530486, there are other solutions to make C-language stype enum be nicely usable in C#. However, the different approaches are ultimately stylistic choices and therefore I argue that this feature makes sense as a configuration option, allowing users to choose freely between styles. Following that argument, the option is kept simply to apply to the entire code generation, i.e. generation for stripping one enum, but not another is not supported as that would lead to two different styles within the same generated codebase.