### PR TITLE
Fix crash when accessing property TemplateTypeParmDecl.DefaultArgument

### DIFF
--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -1001,15 +1001,19 @@ CXCursor clangsharp_Cursor_getDefaultArg(CXCursor C) {
 }
 
 CXType clangsharp_Cursor_getDefaultArgType(CXCursor C) {
+    QualType QT;
+
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
 
         if (const TemplateTypeParmDecl* TTPD = dyn_cast<TemplateTypeParmDecl>(D)) {
-            return MakeCXType(TTPD->getDefaultArgument(), getCursorTU(C));
+            if (TTPD->hasDefaultArgument()) {
+                QT = TTPD->getDefaultArgument();
+            }
         }
     }
 
-    return MakeCXType(QualType(), getCursorTU(C));
+    return MakeCXType(QT, getCursorTU(C));
 }
 
 CXCursor clangsharp_Cursor_getDefinition(CXCursor C) {


### PR DESCRIPTION
* getDefaultArgType() must not be called if hasDefaultArgType() returns false.
* Since the type may not have a default arg type, make the property nullable.