### PR TITLE
Add AssociatedDecl property to SubstTemplateTypeParamType.

### DIFF
--- a/sources/ClangSharp.Interop/clangsharp/clangsharp.cs
+++ b/sources/ClangSharp.Interop/clangsharp/clangsharp.cs
@@ -1032,6 +1032,9 @@ public static partial class @clangsharp
     [DllImport("libClangSharp", CallingConvention = CallingConvention.Cdecl, EntryPoint = "clangsharp_Type_getOriginalType", ExactSpelling = true)]
     public static extern CXType Type_getOriginalType(CXType CT);
 
+    [DllImport("libClangSharp", CallingConvention = CallingConvention.Cdecl, EntryPoint = "clangsharp_Type_getSubstTemplateTypeParamAssociatedDecl", ExactSpelling = true)]
+    public static extern CXCursor Type_getSubstTemplateTypeParamAssociatedDecl(CXType CT);
+
     [DllImport("libClangSharp", CallingConvention = CallingConvention.Cdecl, EntryPoint = "clangsharp_Type_getOwnedTagDecl", ExactSpelling = true)]
     public static extern CXCursor Type_getOwnedTagDecl(CXType CT);
 

--- a/sources/ClangSharp/Types/SubstTemplateTypeParmType.cs
+++ b/sources/ClangSharp/Types/SubstTemplateTypeParmType.cs
@@ -9,14 +9,21 @@ namespace ClangSharp;
 
 public sealed class SubstTemplateTypeParmType : Type
 {
+    private readonly Lazy<Decl?> _associatedDecl;
     private readonly Lazy<TemplateTypeParmType> _replacedParameter;
 
     internal SubstTemplateTypeParmType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_SubstTemplateTypeParm)
     {
+        _associatedDecl = new Lazy<Decl?>(() => {
+            CXCursor cursor = clangsharp.Type_getSubstTemplateTypeParamAssociatedDecl(Handle);
+            return cursor.IsNull ? null : TranslationUnit.GetOrCreate<Decl>(cursor);
+        });
         _replacedParameter = new Lazy<TemplateTypeParmType>(() => TranslationUnit.GetOrCreate<TemplateTypeParmType>(Handle.OriginalType));
     }
 
     public TemplateTypeParmType ReplacedParameter => _replacedParameter.Value;
 
     public Type ReplacementType => Desugar;
+
+    public Decl? AssociatedDecl => _associatedDecl.Value;
 }

--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -5366,6 +5366,17 @@ CXType clangsharp_Type_getOriginalType(CXType CT) {
     return MakeCXType(QualType(), GetTypeTU(CT));
 }
 
+CXCursor clangsharp_Type_getSubstTemplateTypeParamAssociatedDecl(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const SubstTemplateTypeParmType* STTPT = dyn_cast<SubstTemplateTypeParmType>(TP)) {
+        return MakeCXCursor(STTPT->getAssociatedDecl(), GetTypeTU(CT));
+    }
+
+    clang_getNullCursor();
+}
+
 CXCursor clangsharp_Type_getOwnedTagDecl(CXType CT) {
     QualType T = GetQualType(CT);
     const Type* TP = T.getTypePtrOrNull();

--- a/sources/libClangSharp/ClangSharp.h
+++ b/sources/libClangSharp/ClangSharp.h
@@ -817,6 +817,8 @@ CLANGSHARP_LINKAGE int clangsharp_Type_getNumRows(CXType CT);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Type_getOriginalType(CXType CT);
 
+CLANGSHARP_LINKAGE CXCursor clangsharp_Type_getSubstTemplateTypeParamAssociatedDecl(CXType CT);
+
 CLANGSHARP_LINKAGE CXCursor clangsharp_Type_getOwnedTagDecl(CXType CT);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Type_getPointeeType(CXType CT);


### PR DESCRIPTION
* This calls getAssociatedDecl() on the underlying clang c++ type object.

Note: I added a function to clangsharp.cpp and .h, but the clangsharp.cs file was updated manually. I was having issues getting ClangSharpPInvokeGenerator to output the .cs source files correctly. It seems to not be as simple as just running the generator with the clangsharp response file?