### PR TITLE
ClangSharpPInvokeGenerator should exit with '0' on success

### DIFF
--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -777,23 +777,9 @@ public static class Program
                     context.Console.Write("    ");
                     context.Console.WriteLine(diagnostic.ToString());
 
-                    if (diagnostic.Level == DiagnosticLevel.Warning)
+                    if (diagnostic.Level == DiagnosticLevel.Error)
                     {
-                        if (exitCode >= 0)
-                        {
-                            exitCode++;
-                        }
-                    }
-                    else if (diagnostic.Level == DiagnosticLevel.Error)
-                    {
-                        if (exitCode >= 0)
-                        {
-                            exitCode = -1;
-                        }
-                        else
-                        {
-                            exitCode--;
-                        }
+                        exitCode = -1;
                     }
                 }
             }


### PR DESCRIPTION
It's common practice for tools to use an exit code of 0 on success, there are various tools (like [NMake](https://learn.microsoft.com/en-us/cpp/build/reference/commands-in-a-makefile?view=msvc-170#:~:text=By%20default%2C%20NMAKE%20halts%20when%20a%20command%20returns%20a%20nonzero%20exit%20code)) that assume this.

By returning a non-zero exit code if there are warnings, and providing no way to suppress those warnings, it is difficult to integrate ClangSharpPInvokeGenerator into build systems, especially since there is no way to differentiate between "ClangSharpPInvokeGenerator emitted lots of warnings", "ClangSharpPInvokeGenerator failed to load libclang" and "dotnet failed" without inspecting stdout (as they all have positive exit codes).