### PR TITLE
Enable matching `*` for `--with-using`

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -7001,7 +7001,7 @@ public sealed partial class PInvokeGenerator : IDisposable
     {
         Debug.Assert(_outputBuilder is not null);
 
-        if (TryGetRemappedValue(namedDecl, _config.WithUsings, out var usings))
+        if (TryGetRemappedValue(namedDecl, _config.WithUsings, out var usings, matchStar: true))
         {
             foreach (var @using in usings)
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/OptionsTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/OptionsTest.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+public sealed class OptionsTest : PInvokeGeneratorTest
+{
+    [Test]
+    public Task WithUsings()
+    {
+        var inputContents = @"struct StructA {};
+namespace NS
+{
+    struct StructB {};
+    struct StructC {};
+}
+struct StructD {};
+";
+        var expectedOutputContents = @"using ForStar;
+using ForStructA1;
+using ForStructA2;
+using ForStructBWithDoubleColon;
+using ForStructCWithDot;
+
+namespace ClangSharp.Test
+{
+    public partial struct StructA
+    {
+    }
+
+    public partial struct StructB
+    {
+    }
+
+    public partial struct StructC
+    {
+    }
+
+    public partial struct StructD
+    {
+    }
+}
+";
+        var withUsings = new Dictionary<string, IReadOnlyList<string>> {
+            ["StructA"] = ["ForStructA1", "ForStructA2"],
+            ["*"] = ["ForStar"],
+            ["NS::StructB"] = ["ForStructBWithDoubleColon"],
+            ["NS.StructC"] = ["ForStructCWithDot"],
+            ["DoesNotExist"] = ["ErrorShouldNotBeInOutput"],
+        };
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, withUsings: withUsings);
+    }
+}


### PR DESCRIPTION
Allows `--with-using=*=SomeNamespace` to work.

Partial fix for #536
