### PR TITLE
Ignore the TypeVisibility and NoThrow attributes

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -6691,7 +6691,9 @@ public sealed partial class PInvokeGenerator : IDisposable
                     case CX_AttrKind_MSNoVTable:
                     case CX_AttrKind_MSAllocator:
                     case CX_AttrKind_MaxFieldAlignment:
+                    case CX_AttrKind_NoThrow:
                     case CX_AttrKind_SelectAny:
+                    case CX_AttrKind_TypeVisibility:
                     case CX_AttrKind_Uuid:
                     {
                         // Nothing to handle


### PR DESCRIPTION
`NoThrow` - C# has no equivalent of this concept.

`TypeVisibility` - There's no need to maintain this concept once the type is translated to C#, everything should be `public`.