### PR TITLE
Fix crash when using a default argument from a base template

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1253,10 +1253,13 @@ public partial class PInvokeGenerator
 
             var handledDefaultArg = false;
             var isExprDefaultValue = false;
+            var defaultArg = (parmVarDecl.HasDefaultArg && !parmVarDecl.HasUnparsedDefaultArg) ?
+                (parmVarDecl.HasUninstantiatedDefaultArg ? parmVarDecl.UninstantiatedDefaultArg : parmVarDecl.DefaultArg) :
+                null;
 
-            if (parmVarDecl.HasDefaultArg)
+            if (defaultArg != null)
             {
-                isExprDefaultValue = IsDefaultValue(parmVarDecl.DefaultArg);
+                isExprDefaultValue = IsDefaultValue(defaultArg);
 
                 if ((_outputBuilder is CSharpOutputBuilder csharpOutputBuilder) && (_config.WithTransparentStructs.ContainsKey(typeName) || parameters.Skip(index).Any((parmVarDecl) => {
                     var type = parmVarDecl.Type;
@@ -1264,18 +1267,16 @@ public partial class PInvokeGenerator
                     return _config.WithTransparentStructs.ContainsKey(typeName);
                 })))
                 {
-                    desc.CustomAttrGeneratorData = (parmVarDecl, this, csharpOutputBuilder, isExprDefaultValue ? null : parmVarDecl.DefaultArg);
+                    desc.CustomAttrGeneratorData = (parmVarDecl, this, csharpOutputBuilder, isExprDefaultValue ? null : defaultArg);
                     handledDefaultArg = true;
                 }
             }
 
             _outputBuilder.BeginParameter(in desc);
 
-            if (parmVarDecl.HasDefaultArg && !handledDefaultArg)
+            if (defaultArg != null && !handledDefaultArg)
             {
                 _outputBuilder.BeginParameterDefault();
-
-                var defaultArg = parmVarDecl.DefaultArg;
 
                 if (IsTypePointerOrReference(parmVarDecl) && (defaultArg.Handle.Evaluate.Kind == CXEval_UnExposed))
                 {
@@ -1290,7 +1291,7 @@ public partial class PInvokeGenerator
                 }
                 else
                 {
-                    Visit(parmVarDecl.DefaultArg);
+                    Visit(defaultArg);
                 }
 
                 _outputBuilder.EndParameterDefault();
@@ -1341,10 +1342,10 @@ public partial class PInvokeGenerator
 
             _outputBuilder.BeginParameter(in desc);
 
-            if (parmVarDecl.HasDefaultArg)
+            if (parmVarDecl.HasDefaultArg && !parmVarDecl.HasUnparsedDefaultArg)
             {
                 _outputBuilder.BeginParameterDefault();
-                Visit(parmVarDecl.DefaultArg);
+                Visit(parmVarDecl.HasUninstantiatedDefaultArg ? parmVarDecl.UninstantiatedDefaultArg : parmVarDecl.DefaultArg);
                 _outputBuilder.EndParameterDefault();
             }
 

--- a/sources/ClangSharp/Cursors/Decls/ParmVarDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ParmVarDecl.cs
@@ -28,6 +28,10 @@ public sealed class ParmVarDecl : VarDecl
 
     public bool HasDefaultArg => Handle.HasDefaultArg;
 
+    public bool HasUnparsedDefaultArg => Handle.HasUnparsedDefaultArg;
+
+    public bool HasUninstantiatedDefaultArg => Handle.HasUninstantiatedDefaultArg;
+
     public bool HasInheritedDefaultArg => Handle.HasInheritedDefaultArg;
 
     public Type OriginalType => _originalType.Value;

--- a/sources/ClangSharp/Cursors/Exprs/CXXDefaultArgExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXDefaultArgExpr.cs
@@ -21,8 +21,6 @@ public sealed class CXXDefaultArgExpr : Expr
         _usedContext = new Lazy<IDeclContext?>(() => TranslationUnit.GetOrCreate<Decl>(Handle.UsedContext) as IDeclContext);
     }
 
-    public Expr Expr => Param.DefaultArg;
-
     public ParmVarDecl Param => _param.Value;
 
     public IDeclContext? UsedContext => _usedContext.Value;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/CXXMethodDeclarationTest.cs
@@ -17,6 +17,9 @@ public abstract class CXXMethodDeclarationTest : PInvokeGeneratorTest
     public Task ConversionTest() => ConversionTestImpl();
 
     [Test]
+    public Task DefaultParameterInheritedFromTemplateTest() => DefaultParameterInheritedFromTemplateTestImpl();
+
+    [Test]
     public Task DestructorTest() => DestructorTestImpl();
 
     [Test]
@@ -106,6 +109,8 @@ int buf_close(void *pContext)
     protected abstract Task ConstructorWithInitializeTestImpl();
 
     protected abstract Task ConversionTestImpl();
+
+    protected abstract Task DefaultParameterInheritedFromTemplateTestImpl();
 
     protected abstract Task DestructorTestImpl();
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -125,6 +125,40 @@ public sealed class CSharpCompatibleUnix_CXXMethodDeclarationTest : CXXMethodDec
         return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+
+        var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8$MyTemplateDoWorkEv" : "_ZN10MyTemplateIiE6DoWorkEPi";
+
+        var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [NativeTypeName(""struct MyStruct : MyTemplate<int>"")]
+    public unsafe partial struct MyStruct
+    {{
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        public static extern int* DoWork(MyStruct* pThis, int* value = null);
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/CXXMethodDeclarationTest.cs
@@ -125,6 +125,40 @@ public sealed class CSharpDefaultWindows_CXXMethodDeclarationTest : CXXMethodDec
         return ValidateGeneratedCSharpDefaultWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+
+        var entryPoint = Environment.Is64BitProcess ? "?DoWork@?$MyTemplate@H@@QEAAPEAHPEAH@Z" : "?DoWork@?$MyTemplate@H@@QEAPEHPEH@Z";
+
+        var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [NativeTypeName(""struct MyStruct : MyTemplate<int>"")]
+    public unsafe partial struct MyStruct
+    {{
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        public static extern int* DoWork(MyStruct* pThis, int* value = null);
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpDefaultWindowsBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
@@ -125,6 +125,40 @@ public sealed class CSharpLatestUnix_CXXMethodDeclarationTest : CXXMethodDeclara
         return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+
+        var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8$MyTemplateDoWorkEv" : "_ZN10MyTemplateIiE6DoWorkEPi";
+
+        var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [NativeTypeName(""struct MyStruct : MyTemplate<int>"")]
+    public unsafe partial struct MyStruct
+    {{
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        public static extern int* DoWork(MyStruct* pThis, int* value = null);
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpLatestUnixBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -125,6 +125,40 @@ public sealed class CSharpLatestWindows_CXXMethodDeclarationTest : CXXMethodDecl
         return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+
+        var entryPoint = Environment.Is64BitProcess ? "?DoWork@?$MyTemplate@H@@QEAAPEAHPEAH@Z" : "?DoWork@?$MyTemplate@H@@QEAPEHPEH@Z";
+
+        var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [NativeTypeName(""struct MyStruct : MyTemplate<int>"")]
+    public unsafe partial struct MyStruct
+    {{
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        public static extern int* DoWork(MyStruct* pThis, int* value = null);
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/CXXMethodDeclarationTest.cs
@@ -125,6 +125,40 @@ public sealed class CSharpPreviewUnix_CXXMethodDeclarationTest : CXXMethodDeclar
         return ValidateGeneratedCSharpPreviewUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+
+        var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8$MyTemplateDoWorkEv" : "_ZN10MyTemplateIiE6DoWorkEPi";
+
+        var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [NativeTypeName(""struct MyStruct : MyTemplate<int>"")]
+    public unsafe partial struct MyStruct
+    {{
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        public static extern int* DoWork(MyStruct* pThis, int* value = null);
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpPreviewUnixBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/CXXMethodDeclarationTest.cs
@@ -125,6 +125,40 @@ public sealed class CSharpPreviewWindows_CXXMethodDeclarationTest : CXXMethodDec
         return ValidateGeneratedCSharpPreviewWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+
+        var entryPoint = Environment.Is64BitProcess ? "?DoWork@?$MyTemplate@H@@QEAAPEAHPEAH@Z" : "?DoWork@?$MyTemplate@H@@QEAPEHPEH@Z";
+
+        var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [NativeTypeName(""struct MyStruct : MyTemplate<int>"")]
+    public unsafe partial struct MyStruct
+    {{
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.ThisCall, EntryPoint = ""{entryPoint}"", ExactSpelling = true)]
+        public static extern int* DoWork(MyStruct* pThis, int* value = null);
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpPreviewWindowsBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -165,6 +165,47 @@ public sealed class XmlCompatibleUnix_CXXMethodDeclarationTest : CXXMethodDeclar
         return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+        var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8$MyTemplateDoWorkEv" : "_ZN10MyTemplateIiE6DoWorkEPi";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" native=""struct MyStruct : MyTemplate&lt;int&gt;"" unsafe=""true"">
+      <function name=""DoWork"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"" unsafe=""true"">
+        <type>int*</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""value"">
+          <type>int*</type>
+          <init>
+            <code>null</code>
+          </init>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlCompatibleUnixBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -165,6 +165,48 @@ public sealed class XmlCompatibleWindows_CXXMethodDeclarationTest : CXXMethodDec
         return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+
+        var entryPoint = Environment.Is64BitProcess ? "?DoWork@?$MyTemplate@H@@QEAAPEAHPEAH@Z" : "?DoWork@?$MyTemplate@H@@QEAPEHPEH@Z";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" native=""struct MyStruct : MyTemplate&lt;int&gt;"" unsafe=""true"">
+      <function name=""DoWork"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"" unsafe=""true"">
+        <type>int*</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""value"">
+          <type>int*</type>
+          <init>
+            <code>null</code>
+          </init>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/CXXMethodDeclarationTest.cs
@@ -165,6 +165,48 @@ public sealed class XmlDefaultUnix_CXXMethodDeclarationTest : CXXMethodDeclarati
         return ValidateGeneratedXmlDefaultUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+
+        var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8$MyTemplateDoWorkEv" : "_ZN10MyTemplateIiE6DoWorkEPi";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" native=""struct MyStruct : MyTemplate&lt;int&gt;"" unsafe=""true"">
+      <function name=""DoWork"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"" unsafe=""true"">
+        <type>int*</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""value"">
+          <type>int*</type>
+          <init>
+            <code>null</code>
+          </init>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlDefaultUnixBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/CXXMethodDeclarationTest.cs
@@ -165,6 +165,48 @@ public sealed class XmlDefaultWindows_CXXMethodDeclarationTest : CXXMethodDeclar
         return ValidateGeneratedXmlDefaultWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+
+        var entryPoint = Environment.Is64BitProcess ? "?DoWork@?$MyTemplate@H@@QEAAPEAHPEAH@Z" : "?DoWork@?$MyTemplate@H@@QEAPEHPEH@Z";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" native=""struct MyStruct : MyTemplate&lt;int&gt;"" unsafe=""true"">
+      <function name=""DoWork"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"" unsafe=""true"">
+        <type>int*</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""value"">
+          <type>int*</type>
+          <init>
+            <code>null</code>
+          </init>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlDefaultWindowsBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/CXXMethodDeclarationTest.cs
@@ -165,6 +165,48 @@ public sealed class XmlLatestUnix_CXXMethodDeclarationTest : CXXMethodDeclaratio
         return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+
+        var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8$MyTemplateDoWorkEv" : "_ZN10MyTemplateIiE6DoWorkEPi";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" native=""struct MyStruct : MyTemplate&lt;int&gt;"" unsafe=""true"">
+      <function name=""DoWork"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"" unsafe=""true"">
+        <type>int*</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""value"">
+          <type>int*</type>
+          <init>
+            <code>null</code>
+          </init>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlLatestUnixBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/CXXMethodDeclarationTest.cs
@@ -165,6 +165,48 @@ public sealed class XmlLatestWindows_CXXMethodDeclarationTest : CXXMethodDeclara
         return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+
+        var entryPoint = Environment.Is64BitProcess ? "?DoWork@?$MyTemplate@H@@QEAAPEAHPEAH@Z" : "?DoWork@?$MyTemplate@H@@QEAPEHPEH@Z";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" native=""struct MyStruct : MyTemplate&lt;int&gt;"" unsafe=""true"">
+      <function name=""DoWork"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"" unsafe=""true"">
+        <type>int*</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""value"">
+          <type>int*</type>
+          <init>
+            <code>null</code>
+          </init>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlLatestWindowsBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/CXXMethodDeclarationTest.cs
@@ -165,6 +165,46 @@ public sealed class XmlPreviewUnix_CXXMethodDeclarationTest : CXXMethodDeclarati
         return ValidateGeneratedXmlPreviewUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+
+        var entryPoint = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "__ZN8$MyTemplateDoWorkEv" : "_ZN10MyTemplateIiE6DoWorkEPi";
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" native=""struct MyStruct : MyTemplate&lt;int&gt;"" unsafe=""true"">
+      <function name=""DoWork"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"" unsafe=""true"">
+        <type>int*</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""value"">
+          <type>int*</type>
+          <init>
+            <code>null</code>
+          </init>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+        return ValidateGeneratedXmlPreviewUnixBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/CXXMethodDeclarationTest.cs
@@ -165,6 +165,47 @@ public sealed class XmlPreviewWindows_CXXMethodDeclarationTest : CXXMethodDeclar
         return ValidateGeneratedXmlPreviewWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 
+    protected override Task DefaultParameterInheritedFromTemplateTestImpl()
+    {
+        // NOTE: This is a regression test where a struct inherits a function from a template with a default parameter.
+        const string InputContents = @"template <typename T>
+struct MyTemplate
+{
+    int* DoWork(int* value = nullptr)
+    {
+        return value;
+    }
+};
+
+struct MyStruct : public MyTemplate<int>
+{};
+";
+
+        var entryPoint = Environment.Is64BitProcess ? "?DoWork@?$MyTemplate@H@@QEAAPEAHPEAH@Z" : "?DoWork@?$MyTemplate@H@@QEAPEHPEH@Z";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""MyStruct"" access=""public"" native=""struct MyStruct : MyTemplate&lt;int&gt;"" unsafe=""true"">
+      <function name=""DoWork"" access=""public"" lib=""ClangSharpPInvokeGenerator"" convention=""ThisCall"" entrypoint=""{entryPoint}"" static=""true"" unsafe=""true"">
+        <type>int*</type>
+        <param name=""pThis"">
+          <type>MyStruct*</type>
+        </param>
+        <param name=""value"">
+          <type>int*</type>
+          <init>
+            <code>null</code>
+          </init>
+        </param>
+      </function>
+    </struct>
+  </namespace>
+</bindings>
+";
+        return ValidateGeneratedXmlPreviewWindowsBindingsAsync(InputContents, expectedOutputContents);
+    }
+
     protected override Task DestructorTestImpl()
     {
         var inputContents = @"struct MyStruct


### PR DESCRIPTION
Even if `ParamVarDecl::hasDefaultArg` returns `true`, the default argument can be one of three kinds: normal, unparsed and uninstantiated. Each of these kinds needs to be handled differently:
* Normal: get the default arg via `getDefaultArg`
* Unparsed: treat as not having a default arg.
* Uninstantiated: get the default arg via `getUninstantiatedDefaultArg`

This change handles all three kinds and centralizes the checks for and calls to get default args to a single location per method.