### PR TITLE
Add new getHas*DefaultArg C++ functions to ClangSharp.h

### DIFF
--- a/sources/libClangSharp/ClangSharp.h
+++ b/sources/libClangSharp/ClangSharp.h
@@ -371,6 +371,10 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasBody(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasDefaultArg(CXCursor C);
 
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasUnparsedDefaultArg(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasUninstantiatedDefaultArg(CXCursor C);
+
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasElseStorage(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasExplicitTemplateArgs(CXCursor C);


### PR DESCRIPTION
`getHasUnparsedDefaultArg` and `getHasUninstantiatedDefaultArg` were added to ClangSharp.cpp in #546, but they also need to be added to ClangSharp.h.