### PR TITLE
Exclude template specializations unless `generate-template-bindings` is set

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -4587,7 +4587,7 @@ public sealed partial class PInvokeGenerator : IDisposable
         bool IsExcludedByConfig(Cursor cursor)
         {
             return (_config.ExcludeFunctionsWithBody && (cursor is FunctionDecl functionDecl) && functionDecl.HasBody)
-                || (!_config.GenerateTemplateBindings && (cursor is TemplateDecl));
+                || (!_config.GenerateTemplateBindings && ((cursor is TemplateDecl) || (cursor is ClassTemplateSpecializationDecl)));
         }
 
         bool IsExcludedByFile(Cursor cursor)


### PR DESCRIPTION
ClangSharp currently excludes templates unless the `generate-template-bindings` config option is set, but it still visits template specialization declarations, resulting in the warning `Class template specializations are not supported`.

This change excludes template specializations unless the `generate-template-bindings` config option is set.