### PR TITLE
Refactor Enum member type escaping

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -273,7 +273,6 @@ public partial class PInvokeGenerator
 
         var accessSpecifier = AccessSpecifier.None;
         var name = GetRemappedCursorName(enumConstantDecl);
-        var escapedName = EscapeName(name);
         var typeName = GetTargetTypeName(enumConstantDecl, out _);
         var isAnonymousEnum = false;
         var parentName = "";
@@ -295,10 +294,7 @@ public partial class PInvokeGenerator
             parentName = _outputBuilder.Name;
         }
 
-        if (Config.StripEnumMemberTypeName)
-        {
-            escapedName = PrefixAndStrip(escapedName, parentName, trimChar: '_');
-        }
+        var escapedName = EscapeAndStripEnumMemberName(name, parentName);
 
         var kind = isAnonymousEnum ? ValueKind.Primitive : ValueKind.Enumerator;
         var flags = ValueFlags.Constant;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -2332,6 +2332,20 @@ public sealed partial class PInvokeGenerator : IDisposable
         return EscapeName(name);
     }
 
+    private string EscapeAndStripEnumMemberName(string name, string enumTypeName)
+    {
+        if (Config.StripEnumMemberTypeName)
+        {
+            var escapedName = PrefixAndStrip(name, enumTypeName, trimChar: '_');
+            if (escapedName.Length > 0 && char.IsAsciiDigit(escapedName[0]))
+            {
+                escapedName = '_' + escapedName;
+            }
+            return escapedName;
+        }
+        return EscapeName(name);
+    }
+
     internal static string EscapeCharacter(char value) => value switch {
         '\0' => @"\0",
         '\\' => @"\\",


### PR DESCRIPTION
As @tannergooding notes in comment https://github.com/dotnet/ClangSharp/pull/527#discussion_r1613585056 the logic to strip the Enum type name from its members can lead to Enum members starting with digits or Enum members that are otherwise invalid (e.g. C# keywords). 

The logic to create a stripped Enum member name has been refactored into its own method similar to the `EscapeAndStripMethodName`.