### PR TITLE
Add XML Serialization classes

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/GlobalSuppressions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/GlobalSuppressions.cs
@@ -1,0 +1,16 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage(
+    "Design",
+    "CA1002: Do not expose generic lists",
+    Scope = "namespaceAndDescendants",
+    Target = "~N:ClangSharp.XML",
+    Justification = nameof(System.Xml.Serialization)
+    )]
+

--- a/sources/ClangSharp.PInvokeGenerator/XML/BindingsElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/BindingsElement.cs
@@ -1,0 +1,18 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+[XmlRoot("bindings")]
+public sealed class BindingsElement
+{
+    [XmlElement("comment")]
+    public string? HeaderText { get; init; }
+
+    [XmlElement("namespace")]
+    public List<NamespaceElement> Namespaces { get; } = [];
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/CSharpCodeElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/CSharpCodeElement.cs
@@ -1,0 +1,15 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public sealed class CSharpCodeElement
+{
+    [XmlText]
+    [XmlAnyElement]
+    public List<XmlNode> Segments { get; } = [];
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/ConstantDescElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/ConstantDescElement.cs
@@ -1,0 +1,8 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class ConstantDescElement : FieldDescElement { }

--- a/sources/ClangSharp.PInvokeGenerator/XML/DelegateDescElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/DelegateDescElement.cs
@@ -1,0 +1,8 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class DelegateDescElement : FunctionOrDelegateDescElement { }

--- a/sources/ClangSharp.PInvokeGenerator/XML/EnumConstantDeclElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/EnumConstantDeclElement.cs
@@ -1,0 +1,10 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Diagnostics;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+[DebuggerDisplay($"{{{nameof(Name)},nq}}")]
+public class EnumConstantDeclElement : FieldDescElement { }

--- a/sources/ClangSharp.PInvokeGenerator/XML/EnumDescElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/EnumDescElement.cs
@@ -1,0 +1,19 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class EnumDescElement : NamedAccessDescElement
+{
+    [XmlElement("attribute")]
+    public List<string> Attributes { get; } = [];
+
+    [XmlElement("type")]
+    public required string TypeName { get; init; }
+
+    [XmlElement("enumerator")]
+    public List<EnumConstantDeclElement> Enumerators { get; } = [];
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/FieldDescElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/FieldDescElement.cs
@@ -1,0 +1,54 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+[DebuggerDisplay($"{{{nameof(AccessSpecifier)},nq}} {{{nameof(Type)}}} {{{nameof(Name)},nq}}")]
+public class FieldDescElement : NamedAccessDescElement
+{
+    [XmlAttribute("inherited")]
+    public string? InheritedFrom { get; init; }
+
+    [XmlAttribute("offset")]
+    public string? OffsetValue { get; init; }
+
+    [XmlIgnore]
+    public int? Offset
+    {
+        get
+        {
+            return int.TryParse(
+                OffsetValue,
+                CultureInfo.InvariantCulture,
+                out var offset
+                ) ? offset : null;
+        }
+
+        init
+        {
+            OffsetValue = value.HasValue
+                ? value.Value.ToString(CultureInfo.InvariantCulture)
+                : null;
+        }
+    }
+
+    [XmlElement("attribute")]
+    public List<string> Attributes { get; } = [];
+
+    [XmlElement("type")]
+    public required FieldTypeElement Type { get; init; }
+
+    [XmlElement("value")]
+    public ValueDescValueElement? Initializer { get; init; }
+
+    [XmlElement("get")]
+    public PropertyAccessorElement? Getter { get; init; }
+
+    [XmlElement("set")]
+    public PropertyAccessorElement? Setter { get; init; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/FieldTypeElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/FieldTypeElement.cs
@@ -1,0 +1,15 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class FieldTypeElement : TypeWithNativeTypeNameElement
+{
+    [XmlAttribute("count")]
+    public string? Count { get; init; }
+
+    [XmlAttribute("fixed")]
+    public string? FixedName { get; init; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/FunctionBodyElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/FunctionBodyElement.cs
@@ -1,0 +1,12 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class FunctionBodyElement
+{
+    [XmlElement("code")]
+    public CSharpCodeElement? Code { get; init; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/FunctionDescElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/FunctionDescElement.cs
@@ -1,0 +1,19 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class FunctionDescElement : FunctionOrDelegateDescElement
+{
+    [XmlElement("init")]
+    public List<TypeInitializationExpressionElement> TypeInitializationExpressions { get; } = [];
+
+    [XmlElement("body")]
+    public FunctionBodyElement? BlockBody { get; init; }
+
+    [XmlElement("code")]
+    public CSharpCodeElement? ExpressionBody { get; init; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/FunctionOrDelegateDescElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/FunctionOrDelegateDescElement.cs
@@ -1,0 +1,76 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public abstract class FunctionOrDelegateDescElement : NamedAccessDescElement
+{
+    [XmlAttribute("lib")]
+    public string? LibraryPath { get; init; }
+
+    [XmlAttribute("convention")]
+    public string? CallingConvention { get; init; }
+
+    [XmlAttribute("entrypoint")]
+    public string? EntryPoint { get; init; }
+
+    [XmlAttribute("setlasterror")]
+    public bool SetLastError { get; init; }
+
+    [XmlIgnore]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool SetLastErrorSpecified => SetLastError;
+
+    [XmlAttribute("static")]
+    public bool IsStatic { get; init; }
+
+    [XmlIgnore]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool IsStaticSpecified => IsStatic;
+
+    [XmlAttribute("unsafe")]
+    public bool IsUnsafe { get; init; }
+
+    [XmlIgnore]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool IsUnsafeSpecified => IsUnsafe;
+
+    [XmlAttribute("vtblindex")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public string? VtblIndexValue { get; init; }
+
+    [XmlIgnore]
+    public long? VtblIndex
+    {
+        get
+        {
+            return !string.IsNullOrEmpty(VtblIndexValue)
+                && long.TryParse(
+                    VtblIndexValue,
+                    CultureInfo.InvariantCulture,
+                    out var vtblindex
+                    ) ? vtblindex : null;
+        }
+
+        init
+        {
+            VtblIndexValue = value.HasValue
+                ? value.Value.ToString(CultureInfo.InvariantCulture)
+                : null;
+        }
+    }
+
+    [XmlElement("attribute")]
+    public List<string> Attributes { get; } = [];
+
+    [XmlElement("type")]
+    public required TypeWithNativeTypeNameElement ReturnType { get; init; }
+
+    [XmlElement("param")]
+    public List<ParameterDescElement> Parameters { get; } = [];
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/IidDescElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/IidDescElement.cs
@@ -1,0 +1,12 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class IidDescElement : NamedDescElement
+{
+    [XmlAttribute("value")]
+    public required string Value { get; init; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/IndexerDeclElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/IndexerDeclElement.cs
@@ -1,0 +1,29 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.ComponentModel;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class IndexerDeclElement
+{
+    [XmlAttribute("access")]
+    public required string AccessSpecifier { get; init; }
+
+    [XmlAttribute("unsafe")]
+    public bool IsUnsafe { get; init; }
+
+    [XmlIgnore]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool IsUnsafeSpecified => IsUnsafe;
+
+    [XmlElement("type")]
+    public required string Type { get; init; }
+
+    [XmlElement("param")]
+    public required ParameterDescElement IndexerParameter { get; init; }
+
+    [XmlElement("get")]
+    public required PropertyAccessorElement Getter { get; init; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/InterfaceElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/InterfaceElement.cs
@@ -1,0 +1,15 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class InterfaceElement
+{
+    [XmlElement("constant", typeof(ConstantDescElement))]
+    [XmlElement("field", typeof(FieldDescElement))]
+    [XmlElement("function", typeof(FunctionDescElement))]
+    public List<NamedAccessDescElement> Decls { get; } = [];
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/MethodClassElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/MethodClassElement.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class MethodClassElement : NamedAccessDescElement
+{
+    [XmlAttribute("static")]
+    public bool IsStatic { get; init; }
+
+    [XmlIgnore]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool IsStaticSpecified => IsStatic;
+
+    [XmlAttribute("unsafe")]
+    public bool IsUnsafe { get; init; }
+
+    [XmlIgnore]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool IsUnsafeSpecified => IsUnsafe;
+
+    [XmlElement("constant", typeof(ConstantDescElement))]
+    [XmlElement("field", typeof(FieldDescElement))]
+    [XmlElement("function", typeof(FunctionDescElement))]
+    [XmlElement("delegate", typeof(DelegateDescElement))]
+    [XmlElement("iid", typeof(IidDescElement))]
+    public List<NamedDescElement> Decls { get; } = [];
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/NamedAccessDescElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/NamedAccessDescElement.cs
@@ -1,0 +1,12 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+public abstract class NamedAccessDescElement : NamedDescElement
+{
+    [XmlAttribute("access")]
+    public required string AccessSpecifier { get; init; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/NamedDescElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/NamedDescElement.cs
@@ -1,0 +1,12 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+public abstract class NamedDescElement
+{
+    [XmlAttribute("name")]
+    public required string Name { get; init; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/NamespaceElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/NamespaceElement.cs
@@ -1,0 +1,31 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+[DebuggerDisplay($"{{{nameof(Name)},nq}}")]
+public sealed class NamespaceElement : NamedDescElement
+{
+    public NamespaceElement()
+    {
+        Structs = Types.OfType<StructDescElement>();
+        Enums = Types.OfType<EnumDescElement>();
+    }
+
+    [XmlElement("struct", typeof(StructDescElement))]
+    [XmlElement("enumeration", typeof(EnumDescElement))]
+    [XmlElement("delegate", typeof(DelegateDescElement))]
+    [XmlElement("class", typeof(MethodClassElement))]
+    public List<NamedAccessDescElement> Types { get; } = [];
+
+    [XmlIgnore]
+    public IEnumerable<StructDescElement> Structs { get; }
+
+    [XmlIgnore]
+    public IEnumerable<EnumDescElement> Enums { get; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/ParameterDescElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/ParameterDescElement.cs
@@ -1,0 +1,19 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class ParameterDescElement : NamedDescElement
+{
+    [XmlElement("attribute")]
+    public List<string> Attributes { get; } = [];
+
+    [XmlElement("type")]
+    public required string Type { get; init; }
+
+    [XmlElement("init")]
+    public ValueDescValueElement? DefaultValue { get; init; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/PropertyAccessorElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/PropertyAccessorElement.cs
@@ -1,0 +1,15 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class PropertyAccessorElement
+{
+    [XmlAttribute("inlining")]
+    public string? Inlining { get; init; }
+
+    [XmlElement("code")]
+    public required CSharpCodeElement Code { get; init; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/StructDescElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/StructDescElement.cs
@@ -1,0 +1,93 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class StructDescElement : NamedAccessDescElement
+{
+    [XmlAttribute("native")]
+    public string? NativeTypeName { get; init; }
+
+    [XmlAttribute("parent")]
+    public string? NativeInheritance { get; init; }
+
+    [XmlAttribute("uuid")]
+    public string? Uuid { get; init; }
+
+    [XmlAttribute("vtbl")]
+    public bool HasVtbl { get; init; }
+
+    [XmlIgnore]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool HasVtblSpecified => HasVtbl;
+
+    [XmlAttribute("unsafe")]
+    public bool IsUnsafe { get; init; }
+
+    [XmlIgnore]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool IsUnsafeSpecified => IsUnsafe;
+
+    [XmlAttribute("layout")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public string? LayoutValue { get; init; }
+
+    [XmlIgnore]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool LayoutValueSpecified => !string.IsNullOrEmpty(LayoutValue);
+
+    [XmlIgnore]
+    public LayoutKind? LayoutKind
+    {
+        get
+        {
+            return LayoutValueSpecified
+                && Enum.TryParse(LayoutValue, out LayoutKind layout)
+                ? layout
+                : null;
+        }
+        init { LayoutValue = value.HasValue ? value.ToString() : null; }
+    }
+
+    [XmlAttribute("pack")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public string? PackValue { get; init; }
+
+    [XmlIgnore]
+    public int? Pack
+    {
+        get
+        {
+            return int.TryParse(PackValue, CultureInfo.InvariantCulture, out var pack)
+                ? pack
+                : null;
+        }
+
+        init
+        {
+            PackValue = value.HasValue
+                ? value.Value.ToString(CultureInfo.InvariantCulture)
+                : null;
+        }
+    }
+
+    [XmlElement("attribute")]
+    public List<string> Attributes { get; } = [];
+
+    [XmlElement("constant", typeof(ConstantDescElement))]
+    [XmlElement("field", typeof(FieldDescElement))]
+    [XmlElement("struct", typeof(StructDescElement))]
+    [XmlElement("indexer", typeof(IndexerDeclElement))]
+    [XmlElement("function", typeof(FunctionDescElement))]
+    [XmlElement("delegate", typeof(DelegateDescElement))]
+    [XmlElement("interface", typeof(InterfaceElement))]
+    [XmlElement("vtbl", typeof(VtblElement))]
+    public List<object> Decls { get; } = [];
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/TypeInitializationExpressionElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/TypeInitializationExpressionElement.cs
@@ -1,0 +1,15 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class TypeInitializationExpressionElement : FunctionBodyElement
+{
+    [XmlAttribute("field")]
+    public required string Field { get; init; }
+
+    [XmlAttribute("hint")]
+    public string? Hint { get; init; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/TypeWithNativeTypeNameElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/TypeWithNativeTypeNameElement.cs
@@ -1,0 +1,37 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+[DebuggerDisplay($"{{{nameof(TypeName)},nq}}")]
+public class TypeWithNativeTypeNameElement
+{
+    [XmlAttribute("primitive")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public string? PrimitiveValue { get; init; }
+
+    [XmlIgnore]
+    public bool IsPrimitive
+    {
+        get
+        {
+            _ = bool.TryParse(PrimitiveValue, out var primitive);
+            return primitive;
+        }
+
+        init
+        {
+            PrimitiveValue = value.ToString();
+        }
+    }
+
+    [XmlAttribute("native")]
+    public string? NativeTypeName { get; init; }
+
+    [XmlText]
+    public required string TypeName { get; init; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/ValueDescValueElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/ValueDescValueElement.cs
@@ -1,0 +1,21 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class ValueDescValueElement
+{
+    [XmlElement("unchecked")]
+    public ValueDescValueElement? Unchecked { get; init; }
+
+    [XmlElement("cast")]
+    public string? CastTargetTypeName { get; init; }
+
+    [XmlElement("value")]
+    public ValueDescValueElement? NestedValue { get; init; }
+
+    [XmlElement("code")]
+    public CSharpCodeElement? Code { get; init; }
+}

--- a/sources/ClangSharp.PInvokeGenerator/XML/VtblElement.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/VtblElement.cs
@@ -1,0 +1,13 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace ClangSharp.XML;
+
+[XmlType]
+public class VtblElement
+{
+    [XmlElement("field")]
+    public List<FieldDescElement> Fields { get; } = [];
+}


### PR DESCRIPTION
# XML Serialization

When the ClangSharp P/Invoke generator operates in output mode `Xml`, the generator outputs Xml data that includes the information the generator has inferred by processing the output from ClangSharp. As such the Xml data can be seen as an intermediate step to producing C# P/Invoke bindings for the C/C++ input.

This PR includes C# DTO-classes that can be used to deserialize the output generated by the ClangSharp P/Invoke generator. This is useful for tools down the line that want to create different code to the C# code generated by ClangSharp, e.g. in order to introduce some case-specific knowledge into the code generator that a general-purpose tool like the ClangSharp P/Invoke generator cannot have.

This PR is currently in draft-state to provide an example for a general for-or-against discussion originally posed by issue #550.

There are several aspects that should be adressed code-wise specifically in this PR:

## Where should the serialization classes be located?

1. The `ClangSharp.PInvokeGenerator` library and nuget package contains a namespace `XML` which is the current location of the `XmlOutputBuilder` class, the class that generates the XML output. Placing the serialization classes in the same namespace as the class that actually generates the XML keeps the code in the same place.
2. Create a new class library (and nuget package) purely meant to for deserialization of generated XML output. This would imply a shared contract and the `ClangSharp.PInvokeGenerator` could be a tool that creates data conforming to that contract whereas other applications could be designed to consume data conforming to that contract (without depending on the generator itself).

This PR chose option 1. of the options above for simplicit. Option 2 while having some benefits seems too heavy handed.

## Use `System.Xml.Serialization`

This PR uses annotations from the `System.Xml.Serialization` namespace. `System.Runtime.Serialization.DataContractAttribute` could possible be used as an alternative. Since the output mode is XML specific, using the XML-specific serialization technology seems like the better choice.

## Naming and class design

The classes in this PR are meant to act as DTO-types only, i.e. they only represent the data exacly as emitted in the generated XML. For that purpose I simply added the round-tripping code in the Unit test library and tweaked the classes until all Unit tests that involve XML generation passed with a round-trippable output.

However, naming things is hard, and I tried to follow naming inspired by the type names passed as input to the various methods on `XmlOutputBuilder` (`FieldDesc` is one example leading to the name `FieldDescElement` for the type representing the `<field>` element in the output XML). Some of the methods on `XmlOutputBuilder` are a little more complex however and create multiple elements as part of their implementation, which is why some classes don't have a corresponding type in the `Abstractions` namespace.

We should have a discussion on what a reasonable naming scheme should be here and make the serialization classes be named consistently. One possiblity could be to just simply make the types be named by their XML-element name (e.g. `ConstantElement` for the `<constant>` tag).

I have also introduced some hierarchical structure to the types and created common base types in an attempt to de-duplicate some aspects of the generated XML (e.g. `NamedAccessDescElement` which describes an Element with a `name` and `access` attribute).

In order to guarantee round-trippable XML in the unit tests the serialization types needed to structure some properties in a way that guarateed identical ordering of XML elements (e.g. in the `NamespaceElement` class). Obviously fields in structs, v-tables and interfaces need to preserve ordering, but in other situations the ordering from the XML output is probably not required.

### The `<value>` and `<code>` elements

A tricky part in the serialization classes are the `<value>` and `<code>` elements in the XML output. Currently, this PR exposes this by simply having a `List<XmlNode>` property on the `CSharpCodeElement` class which may not be ideal. Given that the generator code emits these elements with mixed XML Text and element contents we should discuss the level of detail that should be represented in the serialization types and how to best expose this. Especially code related to bitfields contains a lot of extra elements that might occur as descandants to `<code>`.

## Should `XmlOutputBuilder` re-use the serialization classes to generate XML?

Currently the ClangSharp P/Invoke generator uses a simple `StringBuilder` approach to generate the XML output. The generated output contains no XML namespaces and the generated XML is fairly simple. However, once you have serialization types available that other applications make use of, there is the question of how to enforce that the serialization types match the generated output produced by the generator? Sure, the Unit tests do help in that regard, but an argument can be made that the `XmlOutputBuilder` should re-use the serialization types to procude the XML. That way it would become very unlikely that the `XmlOutputBuilder` generates something that is not losslessly deserializable with the serialization types.