### PR TITLE
Fix wildcard support for --with-attributes option.

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -6765,7 +6765,7 @@ public sealed partial class PInvokeGenerator : IDisposable
         var outputBuilder = isTestOutput ? _testOutputBuilder : _outputBuilder;
         Debug.Assert(outputBuilder is not null);
 
-        if (TryGetRemappedValue(namedDecl, _config.WithAttributes, out var attributes))
+        if (TryGetRemappedValue(namedDecl, _config.WithAttributes, out var attributes, matchStar: true))
         {
             foreach (var attribute in attributes.Where((a) => !onlySupportedOSPlatform || a.StartsWith("SupportedOSPlatform(", StringComparison.Ordinal)))
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/OptionsTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/OptionsTest.cs
@@ -54,4 +54,41 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, withUsings: withUsings);
     }
+
+    [Test]
+    public Task WithAttributes()
+    {
+        var inputContents = @"struct StructA {}; struct StructB {}; struct StructC {}; struct StructD {};";
+        var expectedOutputContents =
+@"namespace ClangSharp.Test
+{
+    [A]
+    public partial struct StructA
+    {
+    }
+
+    [B]
+    public partial struct StructB
+    {
+    }
+
+    [Star]
+    public partial struct StructC
+    {
+    }
+
+    [Star]
+    public partial struct StructD
+    {
+    }
+}
+";
+        var withAttributes = new Dictionary<string, IReadOnlyList<string>> {
+            ["StructA"] = [@"A"],
+            ["StructB"] = [@"B"],
+            ["*"] = [@"Star"],
+        };
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, withAttributes: withAttributes);
+    }
 }


### PR DESCRIPTION
According to the help text the --with-attribute options supports wildcards:.
`-wa, --with-attribute <with-attribute>`

`An attribute to be added to the given remapped declaration name during binding generation. Supports wildcards. []`

However, the method `void WithAttributes(...)` invokes `TryGetMappedValue(...)` with `matchStar` set to `false` instead of `true`. This PR fixes that so that `--with-attributes *=<attribute>` will add `[<attribute>]` to all remapped declaration names during binding generation that don't have a more specific mapping (i.e. `--with-attribute X=<attribute>` will take precedence over `--with-attribute *=<attribute>`.