### PR TITLE
Escape strings in `annotate` attributes

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -6817,7 +6817,7 @@ public sealed partial class PInvokeGenerator : IDisposable
 
                     case CX_AttrKind_Annotate:
                     {
-                        var annotationText = attr.Spelling;
+                        var annotationText = EscapeString(attr.Spelling);
                         outputBuilder.WriteCustomAttribute($"""NativeAnnotation("{annotationText}")""");
                         break;
                     }


### PR DESCRIPTION
It's possible for C++ annotate attributes to contain strings literals, thus they should be correctly escaped before generating the corresponding C# attribute. The easiest way to do this is to use C# verbatim strings, and escape double-quotes (by adding a double-quote).