### PR TITLE
Fix incorrect template argument kind

### DIFF
--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -26,10 +26,38 @@ using namespace clang::cxstring;
 using namespace clang::cxtu;
 using namespace clang::cxtype;
 
+CXTemplateArgumentKind ConvertTemplateArgumentKind(TemplateArgument::ArgKind kind) {
+    switch (kind) {
+    case TemplateArgument::Null:
+        return CXTemplateArgumentKind_Null;
+    case TemplateArgument::Type:
+        return CXTemplateArgumentKind_Type;
+    case TemplateArgument::Declaration:
+        return CXTemplateArgumentKind_Declaration;
+    case TemplateArgument::NullPtr:
+        return CXTemplateArgumentKind_NullPtr;
+    case TemplateArgument::Integral:
+        return CXTemplateArgumentKind_Integral;
+    case TemplateArgument::StructuralValue:
+        // Does not exist in CXTemplateArgumentKind
+        return CXTemplateArgumentKind_Invalid;
+    case TemplateArgument::Template:
+        return CXTemplateArgumentKind_Template;
+    case TemplateArgument::TemplateExpansion:
+        return CXTemplateArgumentKind_TemplateExpansion;
+    case TemplateArgument::Expression:
+        return CXTemplateArgumentKind_Expression;
+    case TemplateArgument::Pack:
+        return CXTemplateArgumentKind_Pack;
+    default:
+        return CXTemplateArgumentKind_Invalid;
+    }
+}
+
 CX_TemplateArgument MakeCXTemplateArgument(const TemplateArgument* TA, CXTranslationUnit TU, bool needsDispose = false) {
     if (TA) {
         assert(TU && "Invalid arguments!");
-        return { static_cast<CXTemplateArgumentKind>(TA->getKind()), (needsDispose ? 1 : 0), TA, TU };
+        return { ConvertTemplateArgumentKind(TA->getKind()), (needsDispose ? 1 : 0), TA, TU };
     }
 
     return { };

--- a/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
@@ -74,4 +74,26 @@ class MyClass<int, U>
         var templateParameter = classTemplatePartialSpecializationDecl.TemplateParameters.Single();
         Assert.That(templateParameter.Name, Is.EqualTo("U"));
     }
+
+    [Test]
+    public void TemplateParameterPackTest()
+    {
+        var inputContents = $@"template<class... Types>
+class tuple;
+
+tuple<int, long> SomeFunction();
+";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var functionDecl = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>().Single();
+        var tupleDecl = functionDecl.ReturnType.AsCXXRecordDecl as ClassTemplateSpecializationDecl;
+        Assert.That(tupleDecl, Is.Not.Null);
+        Assert.That(tupleDecl!.TemplateArgs.Count, Is.EqualTo(1));
+
+        var packElements = tupleDecl.TemplateArgs[0].PackElements;
+        Assert.That(packElements.Count, Is.EqualTo(2));
+        Assert.That(packElements[0].AsType.AsString, Is.EqualTo("int"));
+        Assert.That(packElements[1].AsType.AsString, Is.EqualTo("long"));
+    }
 }

--- a/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
@@ -76,6 +76,7 @@ class MyClass<int, U>
     }
 
     [Test]
+    [Ignore("TODO: LibClangSharp needs to be recompiled first")]
     public void TemplateParameterPackTest()
     {
         var inputContents = $@"template<class... Types>


### PR DESCRIPTION
This PR fixes wrong template argument kinds being returned from `MakeCXTemplateArgument()`.

It turns out that `TemplateArgument::ArgKind` and `CXTemplateArgumentKind` have different values, with `StructuralValue` present in the former but not the latter.

LLVM maps this explicitly: https://github.com/llvm/llvm-project/blob/00a1f1ab71302d190f8059d86a53ec62485fbce9/clang/tools/libclang/CXCursor.cpp#L1474-L1506. This PR now does the same.

I've found this issue while trying to read elements from a parameter pack (`std::tuple`). `TemplateArgument::Pack` in this case was mapped directly to `CXTemplateArgumentKind::Invalid`, making it impossible to retrieve the underlying elements. 

A unit test has been added for this case.