### PR TITLE
Fix nested type names for properties

### DIFF
--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/UnionDeclarationTest.cs
@@ -182,6 +182,9 @@ public abstract class UnionDeclarationTest : PInvokeGeneratorTest
     [TestCase("bool", "byte")]
     public Task TypedefTest(string nativeType, string expectedManagedType) => TypedefTestImpl(nativeType, expectedManagedType);
 
+    [Test]
+    public Task UnionWithAnonStructWithAnonUnion() => UnionWithAnonStructWithAnonUnionImpl();
+
     protected abstract Task BasicTestImpl(string nativeType, string expectedManagedType);
 
     protected abstract Task BasicTestInCModeImpl(string nativeType, string expectedManagedType);
@@ -237,4 +240,6 @@ public abstract class UnionDeclarationTest : PInvokeGeneratorTest
     protected abstract Task SkipNonDefinitionWithNativeTypeNameTestImpl(string nativeType, string expectedManagedType);
 
     protected abstract Task TypedefTestImpl(string nativeType, string expectedManagedType);
+
+    protected abstract Task UnionWithAnonStructWithAnonUnionImpl();
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/UnionDeclarationTest.cs
@@ -1453,4 +1453,132 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"using System;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [StructLayout(LayoutKind.Explicit)]
+    public unsafe partial struct _MY_UNION
+    {{
+        [FieldOffset(0)]
+        [NativeTypeName(""long[2]"")]
+        public _AsArray_e__FixedBuffer AsArray;
+
+        [FieldOffset(0)]
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        public ref IntPtr First
+        {{
+            get
+            {{
+                fixed (_Anonymous_e__Struct* pField = &Anonymous)
+                {{
+                    return ref pField->First;
+                }}
+            }}
+        }}
+
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        {{
+            get
+            {{
+                fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &Anonymous.Anonymous)
+                {{
+                    return ref pField->A;
+                }}
+            }}
+        }}
+
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        {{
+            get
+            {{
+                fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &Anonymous.Anonymous)
+                {{
+                    return ref pField->B;
+                }}
+            }}
+        }}
+
+        public unsafe partial struct _Anonymous_e__Struct
+        {{
+            [NativeTypeName(""long"")]
+            public IntPtr First;
+
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
+            public _Anonymous_e__Union Anonymous;
+
+            [StructLayout(LayoutKind.Explicit)]
+            public partial struct _Anonymous_e__Union
+            {{
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]
+                public _A_e__Struct A;
+
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L14_C13"")]
+                public _B_e__Struct B;
+
+                public partial struct _A_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public IntPtr Second;
+                }}
+
+                public partial struct _B_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public IntPtr Second;
+                }}
+            }}
+        }}
+
+        public partial struct _AsArray_e__FixedBuffer
+        {{
+            public IntPtr e0;
+            public IntPtr e1;
+
+            public unsafe ref IntPtr this[int index]
+            {{
+                get
+                {{
+                    fixed (IntPtr* pThis = &e0)
+                    {{
+                        return ref pThis[index];
+                    }}
+                }}
+            }}
+        }}
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/UnionDeclarationTest.cs
@@ -1460,4 +1460,114 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [StructLayout(LayoutKind.Explicit)]
+    public unsafe partial struct _MY_UNION
+    {{
+        [FieldOffset(0)]
+        [NativeTypeName(""long[2]"")]
+        public fixed int AsArray[2];
+
+        [FieldOffset(0)]
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        public ref int First
+        {{
+            get
+            {{
+                fixed (_Anonymous_e__Struct* pField = &Anonymous)
+                {{
+                    return ref pField->First;
+                }}
+            }}
+        }}
+
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        {{
+            get
+            {{
+                fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &Anonymous.Anonymous)
+                {{
+                    return ref pField->A;
+                }}
+            }}
+        }}
+
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        {{
+            get
+            {{
+                fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &Anonymous.Anonymous)
+                {{
+                    return ref pField->B;
+                }}
+            }}
+        }}
+
+        public unsafe partial struct _Anonymous_e__Struct
+        {{
+            [NativeTypeName(""long"")]
+            public int First;
+
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
+            public _Anonymous_e__Union Anonymous;
+
+            [StructLayout(LayoutKind.Explicit)]
+            public partial struct _Anonymous_e__Union
+            {{
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]
+                public _A_e__Struct A;
+
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L14_C13"")]
+                public _B_e__Struct B;
+
+                public partial struct _A_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public int Second;
+                }}
+
+                public partial struct _B_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public int Second;
+                }}
+            }}
+        }}
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/UnionDeclarationTest.cs
@@ -1437,4 +1437,122 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpDefaultUnixBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"using System;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [StructLayout(LayoutKind.Explicit)]
+    public partial struct _MY_UNION
+    {{
+        [FieldOffset(0)]
+        [NativeTypeName(""long[2]"")]
+        public _AsArray_e__FixedBuffer AsArray;
+
+        [FieldOffset(0)]
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        public ref nint First
+        {{
+            get
+            {{
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.First, 1));
+            }}
+        }}
+
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        {{
+            get
+            {{
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.A, 1));
+            }}
+        }}
+
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        {{
+            get
+            {{
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.B, 1));
+            }}
+        }}
+
+        public partial struct _Anonymous_e__Struct
+        {{
+            [NativeTypeName(""long"")]
+            public nint First;
+
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
+            public _Anonymous_e__Union Anonymous;
+
+            [StructLayout(LayoutKind.Explicit)]
+            public partial struct _Anonymous_e__Union
+            {{
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]
+                public _A_e__Struct A;
+
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L14_C13"")]
+                public _B_e__Struct B;
+
+                public partial struct _A_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public nint Second;
+                }}
+
+                public partial struct _B_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public nint Second;
+                }}
+            }}
+        }}
+
+        public partial struct _AsArray_e__FixedBuffer
+        {{
+            public nint e0;
+            public nint e1;
+
+            public ref nint this[int index]
+            {{
+                get
+                {{
+                    return ref AsSpan()[index];
+                }}
+            }}
+
+            public Span<nint> AsSpan() => MemoryMarshal.CreateSpan(ref e0, 2);
+        }}
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpDefaultUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/UnionDeclarationTest.cs
@@ -1443,4 +1443,105 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpDefaultWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [StructLayout(LayoutKind.Explicit)]
+    public unsafe partial struct _MY_UNION
+    {{
+        [FieldOffset(0)]
+        [NativeTypeName(""long[2]"")]
+        public fixed int AsArray[2];
+
+        [FieldOffset(0)]
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        public ref int First
+        {{
+            get
+            {{
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.First, 1));
+            }}
+        }}
+
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        {{
+            get
+            {{
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.A, 1));
+            }}
+        }}
+
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        {{
+            get
+            {{
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.B, 1));
+            }}
+        }}
+
+        public partial struct _Anonymous_e__Struct
+        {{
+            [NativeTypeName(""long"")]
+            public int First;
+
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
+            public _Anonymous_e__Union Anonymous;
+
+            [StructLayout(LayoutKind.Explicit)]
+            public partial struct _Anonymous_e__Union
+            {{
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]
+                public _A_e__Struct A;
+
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L14_C13"")]
+                public _B_e__Struct B;
+
+                public partial struct _A_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public int Second;
+                }}
+
+                public partial struct _B_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public int Second;
+                }}
+            }}
+        }}
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpDefaultWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/UnionDeclarationTest.cs
@@ -1398,4 +1398,116 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [StructLayout(LayoutKind.Explicit)]
+    public partial struct _MY_UNION
+    {{
+        [FieldOffset(0)]
+        [NativeTypeName(""long[2]"")]
+        public _AsArray_e__FixedBuffer AsArray;
+
+        [FieldOffset(0)]
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        [UnscopedRef]
+        public ref nint First
+        {{
+            get
+            {{
+                return ref Anonymous.First;
+            }}
+        }}
+
+        [UnscopedRef]
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        {{
+            get
+            {{
+                return ref Anonymous.Anonymous.A;
+            }}
+        }}
+
+        [UnscopedRef]
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        {{
+            get
+            {{
+                return ref Anonymous.Anonymous.B;
+            }}
+        }}
+
+        public partial struct _Anonymous_e__Struct
+        {{
+            [NativeTypeName(""long"")]
+            public nint First;
+
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
+            public _Anonymous_e__Union Anonymous;
+
+            [StructLayout(LayoutKind.Explicit)]
+            public partial struct _Anonymous_e__Union
+            {{
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]
+                public _A_e__Struct A;
+
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L14_C13"")]
+                public _B_e__Struct B;
+
+                public partial struct _A_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public nint Second;
+                }}
+
+                public partial struct _B_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public nint Second;
+                }}
+            }}
+        }}
+
+        [InlineArray(2)]
+        public partial struct _AsArray_e__FixedBuffer
+        {{
+            public nint e0;
+        }}
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/UnionDeclarationTest.cs
@@ -1404,4 +1404,116 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [StructLayout(LayoutKind.Explicit)]
+    public partial struct _MY_UNION
+    {{
+        [FieldOffset(0)]
+        [NativeTypeName(""long[2]"")]
+        public _AsArray_e__FixedBuffer AsArray;
+
+        [FieldOffset(0)]
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        [UnscopedRef]
+        public ref int First
+        {{
+            get
+            {{
+                return ref Anonymous.First;
+            }}
+        }}
+
+        [UnscopedRef]
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        {{
+            get
+            {{
+                return ref Anonymous.Anonymous.A;
+            }}
+        }}
+
+        [UnscopedRef]
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        {{
+            get
+            {{
+                return ref Anonymous.Anonymous.B;
+            }}
+        }}
+
+        public partial struct _Anonymous_e__Struct
+        {{
+            [NativeTypeName(""long"")]
+            public int First;
+
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
+            public _Anonymous_e__Union Anonymous;
+
+            [StructLayout(LayoutKind.Explicit)]
+            public partial struct _Anonymous_e__Union
+            {{
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]
+                public _A_e__Struct A;
+
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L14_C13"")]
+                public _B_e__Struct B;
+
+                public partial struct _A_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public int Second;
+                }}
+
+                public partial struct _B_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public int Second;
+                }}
+            }}
+        }}
+
+        [InlineArray(2)]
+        public partial struct _AsArray_e__FixedBuffer
+        {{
+            public int e0;
+        }}
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/UnionDeclarationTest.cs
@@ -1398,4 +1398,116 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpPreviewUnixBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [StructLayout(LayoutKind.Explicit)]
+    public partial struct _MY_UNION
+    {{
+        [FieldOffset(0)]
+        [NativeTypeName(""long[2]"")]
+        public _AsArray_e__FixedBuffer AsArray;
+
+        [FieldOffset(0)]
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        [UnscopedRef]
+        public ref nint First
+        {{
+            get
+            {{
+                return ref Anonymous.First;
+            }}
+        }}
+
+        [UnscopedRef]
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        {{
+            get
+            {{
+                return ref Anonymous.Anonymous.A;
+            }}
+        }}
+
+        [UnscopedRef]
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        {{
+            get
+            {{
+                return ref Anonymous.Anonymous.B;
+            }}
+        }}
+
+        public partial struct _Anonymous_e__Struct
+        {{
+            [NativeTypeName(""long"")]
+            public nint First;
+
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
+            public _Anonymous_e__Union Anonymous;
+
+            [StructLayout(LayoutKind.Explicit)]
+            public partial struct _Anonymous_e__Union
+            {{
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]
+                public _A_e__Struct A;
+
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L14_C13"")]
+                public _B_e__Struct B;
+
+                public partial struct _A_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public nint Second;
+                }}
+
+                public partial struct _B_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public nint Second;
+                }}
+            }}
+        }}
+
+        [InlineArray(2)]
+        public partial struct _AsArray_e__FixedBuffer
+        {{
+            public nint e0;
+        }}
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpPreviewUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/UnionDeclarationTest.cs
@@ -1404,4 +1404,116 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpPreviewWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{{
+    [StructLayout(LayoutKind.Explicit)]
+    public partial struct _MY_UNION
+    {{
+        [FieldOffset(0)]
+        [NativeTypeName(""long[2]"")]
+        public _AsArray_e__FixedBuffer AsArray;
+
+        [FieldOffset(0)]
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        [UnscopedRef]
+        public ref int First
+        {{
+            get
+            {{
+                return ref Anonymous.First;
+            }}
+        }}
+
+        [UnscopedRef]
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        {{
+            get
+            {{
+                return ref Anonymous.Anonymous.A;
+            }}
+        }}
+
+        [UnscopedRef]
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        {{
+            get
+            {{
+                return ref Anonymous.Anonymous.B;
+            }}
+        }}
+
+        public partial struct _Anonymous_e__Struct
+        {{
+            [NativeTypeName(""long"")]
+            public int First;
+
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
+            public _Anonymous_e__Union Anonymous;
+
+            [StructLayout(LayoutKind.Explicit)]
+            public partial struct _Anonymous_e__Union
+            {{
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]
+                public _A_e__Struct A;
+
+                [FieldOffset(0)]
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L14_C13"")]
+                public _B_e__Struct B;
+
+                public partial struct _A_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public int Second;
+                }}
+
+                public partial struct _B_e__Struct
+                {{
+                    [NativeTypeName(""long"")]
+                    public int Second;
+                }}
+            }}
+        }}
+
+        [InlineArray(2)]
+        public partial struct _AsArray_e__FixedBuffer
+        {{
+            public int e0;
+        }}
+    }}
+}}
+";
+
+        return ValidateGeneratedCSharpPreviewWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/UnionDeclarationTest.cs
@@ -1342,4 +1342,118 @@ union MyUnion
 
         return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MY_UNION"" access=""public"" unsafe=""true"" layout=""Explicit"">
+      <field name=""AsArray"" access=""public"" offset=""0"">
+        <type native=""long[2]"" count=""2"" fixed=""_AsArray_e__FixedBuffer"">IntPtr</type>
+      </field>
+      <field name=""Anonymous"" access=""public"" offset=""0"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref IntPtr</type>
+        <get>
+          <code>fixed (_Anonymous_e__Struct* pField = &amp;Anonymous)
+    {{
+        return ref pField-&gt;First;
+    }}</code>
+        </get>
+      </field>
+      <field name=""A"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <get>
+          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
+    {{
+        return ref pField-&gt;A;
+    }}</code>
+        </get>
+      </field>
+      <field name=""B"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <get>
+          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
+    {{
+        return ref pField-&gt;B;
+    }}</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"" unsafe=""true"">
+        <field name=""First"" access=""public"">
+          <type native=""long"">IntPtr</type>
+        </field>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        </field>
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+          <field name=""A"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
+          </field>
+          <field name=""B"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L14_C13"">_B_e__Struct</type>
+          </field>
+          <struct name=""_A_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">IntPtr</type>
+            </field>
+          </struct>
+          <struct name=""_B_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">IntPtr</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+      <struct name=""_AsArray_e__FixedBuffer"" access=""public"">
+        <field name=""e0"" access=""public"">
+          <type>IntPtr</type>
+        </field>
+        <field name=""e1"" access=""public"">
+          <type>IntPtr</type>
+        </field>
+        <indexer access=""public"" unsafe=""true"">
+          <type>ref IntPtr</type>
+          <param name=""index"">
+            <type>int</type>
+          </param>
+          <get>
+            <code>fixed (IntPtr* pThis = &amp;e0)
+    {{
+        return ref pThis[index];
+    }}</code>
+          </get>
+        </indexer>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/UnionDeclarationTest.cs
@@ -1348,4 +1348,98 @@ union MyUnion
 
         return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MY_UNION"" access=""public"" unsafe=""true"" layout=""Explicit"">
+      <field name=""AsArray"" access=""public"" offset=""0"">
+        <type native=""long[2]"" count=""2"" fixed=""_AsArray_e__FixedBuffer"">int</type>
+      </field>
+      <field name=""Anonymous"" access=""public"" offset=""0"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>fixed (_Anonymous_e__Struct* pField = &amp;Anonymous)
+    {{
+        return ref pField-&gt;First;
+    }}</code>
+        </get>
+      </field>
+      <field name=""A"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <get>
+          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
+    {{
+        return ref pField-&gt;A;
+    }}</code>
+        </get>
+      </field>
+      <field name=""B"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <get>
+          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
+    {{
+        return ref pField-&gt;B;
+    }}</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"" unsafe=""true"">
+        <field name=""First"" access=""public"">
+          <type native=""long"">int</type>
+        </field>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        </field>
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+          <field name=""A"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
+          </field>
+          <field name=""B"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L14_C13"">_B_e__Struct</type>
+          </field>
+          <struct name=""_A_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">int</type>
+            </field>
+          </struct>
+          <struct name=""_B_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">int</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/UnionDeclarationTest.cs
@@ -1328,4 +1328,110 @@ union MyUnion
 
         return ValidateGeneratedXmlDefaultUnixBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MY_UNION"" access=""public"" layout=""Explicit"">
+      <field name=""AsArray"" access=""public"" offset=""0"">
+        <type native=""long[2]"" count=""2"" fixed=""_AsArray_e__FixedBuffer"">nint</type>
+      </field>
+      <field name=""Anonymous"" access=""public"" offset=""0"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref nint</type>
+        <get>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.First, 1));</code>
+        </get>
+      </field>
+      <field name=""A"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <get>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.A, 1));</code>
+        </get>
+      </field>
+      <field name=""B"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <get>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.B, 1));</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type native=""long"">nint</type>
+        </field>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        </field>
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+          <field name=""A"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
+          </field>
+          <field name=""B"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L14_C13"">_B_e__Struct</type>
+          </field>
+          <struct name=""_A_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">nint</type>
+            </field>
+          </struct>
+          <struct name=""_B_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">nint</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+      <struct name=""_AsArray_e__FixedBuffer"" access=""public"">
+        <field name=""e0"" access=""public"">
+          <type>nint</type>
+        </field>
+        <field name=""e1"" access=""public"">
+          <type>nint</type>
+        </field>
+        <indexer access=""public"">
+          <type>ref nint</type>
+          <param name=""index"">
+            <type>int</type>
+          </param>
+          <get>
+            <code>return ref AsSpan()[index];</code>
+          </get>
+        </indexer>
+        <function name=""AsSpan"" access=""public"">
+          <type>Span&lt;nint&gt;</type>
+          <code>MemoryMarshal.CreateSpan(ref e0, 2);</code>
+        </function>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlDefaultUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/UnionDeclarationTest.cs
@@ -1334,4 +1334,89 @@ union MyUnion
 
         return ValidateGeneratedXmlDefaultWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MY_UNION"" access=""public"" unsafe=""true"" layout=""Explicit"">
+      <field name=""AsArray"" access=""public"" offset=""0"">
+        <type native=""long[2]"" count=""2"" fixed=""_AsArray_e__FixedBuffer"">int</type>
+      </field>
+      <field name=""Anonymous"" access=""public"" offset=""0"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.First, 1));</code>
+        </get>
+      </field>
+      <field name=""A"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <get>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.A, 1));</code>
+        </get>
+      </field>
+      <field name=""B"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <get>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.B, 1));</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type native=""long"">int</type>
+        </field>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        </field>
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+          <field name=""A"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
+          </field>
+          <field name=""B"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L14_C13"">_B_e__Struct</type>
+          </field>
+          <struct name=""_A_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">int</type>
+            </field>
+          </struct>
+          <struct name=""_B_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">int</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlDefaultWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/UnionDeclarationTest.cs
@@ -1217,4 +1217,95 @@ union MyUnion
 
         return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MY_UNION"" access=""public"" layout=""Explicit"">
+      <field name=""AsArray"" access=""public"" offset=""0"">
+        <type native=""long[2]"" count=""2"" fixed=""_AsArray_e__FixedBuffer"">nint</type>
+      </field>
+      <field name=""Anonymous"" access=""public"" offset=""0"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref nint</type>
+        <get>
+          <code>return ref Anonymous.First;</code>
+        </get>
+      </field>
+      <field name=""A"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <get>
+          <code>return ref Anonymous.Anonymous.A;</code>
+        </get>
+      </field>
+      <field name=""B"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <get>
+          <code>return ref Anonymous.Anonymous.B;</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type native=""long"">nint</type>
+        </field>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        </field>
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+          <field name=""A"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
+          </field>
+          <field name=""B"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L14_C13"">_B_e__Struct</type>
+          </field>
+          <struct name=""_A_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">nint</type>
+            </field>
+          </struct>
+          <struct name=""_B_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">nint</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+      <struct name=""_AsArray_e__FixedBuffer"" access=""public"">
+        <attribute>InlineArray(2)</attribute>
+        <field name=""e0"" access=""public"">
+          <type>nint</type>
+        </field>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/UnionDeclarationTest.cs
@@ -1223,4 +1223,95 @@ union MyUnion
 
         return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MY_UNION"" access=""public"" layout=""Explicit"">
+      <field name=""AsArray"" access=""public"" offset=""0"">
+        <type native=""long[2]"" count=""2"" fixed=""_AsArray_e__FixedBuffer"">int</type>
+      </field>
+      <field name=""Anonymous"" access=""public"" offset=""0"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous.First;</code>
+        </get>
+      </field>
+      <field name=""A"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <get>
+          <code>return ref Anonymous.Anonymous.A;</code>
+        </get>
+      </field>
+      <field name=""B"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <get>
+          <code>return ref Anonymous.Anonymous.B;</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type native=""long"">int</type>
+        </field>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        </field>
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+          <field name=""A"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
+          </field>
+          <field name=""B"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L14_C13"">_B_e__Struct</type>
+          </field>
+          <struct name=""_A_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">int</type>
+            </field>
+          </struct>
+          <struct name=""_B_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">int</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+      <struct name=""_AsArray_e__FixedBuffer"" access=""public"">
+        <attribute>InlineArray(2)</attribute>
+        <field name=""e0"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/UnionDeclarationTest.cs
@@ -1217,4 +1217,95 @@ union MyUnion
 
         return ValidateGeneratedXmlPreviewUnixBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MY_UNION"" access=""public"" layout=""Explicit"">
+      <field name=""AsArray"" access=""public"" offset=""0"">
+        <type native=""long[2]"" count=""2"" fixed=""_AsArray_e__FixedBuffer"">nint</type>
+      </field>
+      <field name=""Anonymous"" access=""public"" offset=""0"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref nint</type>
+        <get>
+          <code>return ref Anonymous.First;</code>
+        </get>
+      </field>
+      <field name=""A"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <get>
+          <code>return ref Anonymous.Anonymous.A;</code>
+        </get>
+      </field>
+      <field name=""B"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <get>
+          <code>return ref Anonymous.Anonymous.B;</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type native=""long"">nint</type>
+        </field>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        </field>
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+          <field name=""A"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
+          </field>
+          <field name=""B"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L14_C13"">_B_e__Struct</type>
+          </field>
+          <struct name=""_A_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">nint</type>
+            </field>
+          </struct>
+          <struct name=""_B_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">nint</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+      <struct name=""_AsArray_e__FixedBuffer"" access=""public"">
+        <attribute>InlineArray(2)</attribute>
+        <field name=""e0"" access=""public"">
+          <type>nint</type>
+        </field>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlPreviewUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/UnionDeclarationTest.cs
@@ -1223,4 +1223,95 @@ union MyUnion
 
         return ValidateGeneratedXmlPreviewWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
+
+    protected override Task UnionWithAnonStructWithAnonUnionImpl()
+    {
+        var inputContents = $@"typedef union _MY_UNION
+{{
+    long AsArray[2];
+    struct
+    {{
+        long First;
+        union
+        {{
+            struct
+            {{
+                long Second;
+            }} A;
+
+            struct
+            {{
+                long Second;
+            }} B;
+        }};
+    }};
+}} MY_UNION;";
+
+        var expectedOutputContents = $@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MY_UNION"" access=""public"" layout=""Explicit"">
+      <field name=""AsArray"" access=""public"" offset=""0"">
+        <type native=""long[2]"" count=""2"" fixed=""_AsArray_e__FixedBuffer"">int</type>
+      </field>
+      <field name=""Anonymous"" access=""public"" offset=""0"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous.First;</code>
+        </get>
+      </field>
+      <field name=""A"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <get>
+          <code>return ref Anonymous.Anonymous.A;</code>
+        </get>
+      </field>
+      <field name=""B"" access=""public"">
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <get>
+          <code>return ref Anonymous.Anonymous.B;</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type native=""long"">int</type>
+        </field>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        </field>
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+          <field name=""A"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
+          </field>
+          <field name=""B"" access=""public"" offset=""0"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L14_C13"">_B_e__Struct</type>
+          </field>
+          <struct name=""_A_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">int</type>
+            </field>
+          </struct>
+          <struct name=""_B_e__Struct"" access=""public"">
+            <field name=""Second"" access=""public"">
+              <type native=""long"">int</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+      <struct name=""_AsArray_e__FixedBuffer"" access=""public"">
+        <attribute>InlineArray(2)</attribute>
+        <field name=""e0"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlPreviewWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
 }


### PR DESCRIPTION
When ClangSharp generates the type name for a property, if the type of the property is a nested type, then it walks from the parent of the current type to the root type and appends the names as it goes. This means that if the nesting is more than one type deep, then the types will be backwards.

For example, given:
```cpp
typedef union _MY_UNION
{
    long AsArray[2];
    struct {
        long First;
        union {
            struct { long Second; } A;
            struct { long Second; } B;
        }};
    }};
}} MY_UNION;
```

ClangSharp generates:
```csharp
public ref _Anonymous_e__Union._Anonymous_e__Struct._B_e__Struct B {
    get {
        fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &Anonymous.Anonymous) {
            return ref pField->B;
        }
    }
}
```

So the type used when pinning the field is correct, but the type for the property itself is incorrect.

The fix is to prepend each type during the walk, then prepend the `ref` keyword as required.

I also switched the code to use a `StringBuilder`.