### PR TITLE
Ignore the NoInline attribute

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -6827,6 +6827,7 @@ public sealed partial class PInvokeGenerator : IDisposable
                     case CX_AttrKind_MSNoVTable:
                     case CX_AttrKind_MSAllocator:
                     case CX_AttrKind_MaxFieldAlignment:
+                    case CX_AttrKind_NoInline:
                     case CX_AttrKind_NoThrow:
                     case CX_AttrKind_SelectAny:
                     case CX_AttrKind_TypeVisibility:


### PR DESCRIPTION
The C++ NoInline attribute doesn't map to anything meaningful for C# or P/Invoke, so it can safely be ignored.