### PR TITLE
Fixes name generation for nested anonymous types

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -3160,9 +3160,19 @@ public sealed partial class PInvokeGenerator : IDisposable
             Debug.Assert(parent is not null);
             remappedName = GetRemappedCursorName(parent);
         }
-        else if (namedDecl is FieldDecl fieldDecl)
+        else if ((namedDecl is FieldDecl fieldDecl) && name.StartsWith("__AnonymousFieldDecl_", StringComparison.Ordinal))
         {
-            if (name.StartsWith("__AnonymousFieldDecl_", StringComparison.Ordinal))
+            if (fieldDecl.Type.AsCXXRecordDecl?.IsAnonymous == true)
+            {
+                // For fields of anonymous types, use the name of the type but clean off the type
+                // kind tag at the end.
+                var typeName = GetRemappedNameForAnonymousRecord(fieldDecl.Type.AsCXXRecordDecl);
+                var tagIndex = typeName.LastIndexOf("_e__", StringComparison.Ordinal);
+                Debug.Assert(typeName[0] == '_');
+                Debug.Assert(tagIndex >= 0);
+                remappedName = typeName.Substring(1, tagIndex - 1);
+            }
+            else
             {
                 remappedName = "Anonymous";
 
@@ -3178,28 +3188,62 @@ public sealed partial class PInvokeGenerator : IDisposable
         }
         else if ((namedDecl is RecordDecl recordDecl) && name.StartsWith("__AnonymousRecord_", StringComparison.Ordinal))
         {
-            if (recordDecl.Parent is RecordDecl parentRecordDecl)
-            {
-                remappedName = "_Anonymous";
-
-                var matchingField = parentRecordDecl.Fields.Where((fieldDecl) => fieldDecl.Type.CanonicalType == recordDecl.TypeForDecl.CanonicalType).FirstOrDefault();
-
-                if (matchingField is not null)
-                {
-                    remappedName = "_";
-                    remappedName += GetRemappedCursorName(matchingField);
-                }
-                else if (parentRecordDecl.AnonymousRecords.Count > 1)
-                {
-                    var index = parentRecordDecl.AnonymousRecords.IndexOf(recordDecl) + 1;
-                    remappedName += index.ToString(CultureInfo.InvariantCulture);
-                }
-
-                remappedName += $"_e__{(recordDecl.IsUnion ? "Union" : "Struct")}";
-            }
+            remappedName = GetRemappedNameForAnonymousRecord(recordDecl);
         }
 
         return remappedName;
+    }
+
+    private string GetRemappedNameForAnonymousRecord(RecordDecl recordDecl)
+    {
+        if (recordDecl.Parent is RecordDecl parentRecordDecl)
+        {
+            var remappedNameBuilder = new StringBuilder();
+            var matchingField = parentRecordDecl.Fields.Where((fieldDecl) => fieldDecl.Type.CanonicalType == recordDecl.TypeForDecl.CanonicalType).FirstOrDefault();
+
+            if ((matchingField is not null) && !matchingField.IsAnonymousField)
+            {
+                _ = remappedNameBuilder.Append('_');
+                _ = remappedNameBuilder.Append(GetRemappedCursorName(matchingField));
+            }
+            else
+            {
+                _ = remappedNameBuilder.Append("_Anonymous");
+
+                // If there is more than one anonymous type, then add a numeral to differentiate.
+                if (parentRecordDecl.AnonymousRecords.Count > 1)
+                {
+                    var index = parentRecordDecl.AnonymousRecords.IndexOf(recordDecl) + 1;
+                    Debug.Assert(index > 0);
+                    _ = remappedNameBuilder.Append(index);
+                }
+
+                // C# doesn't allow a nested type to have the same name as the parent, so if the
+                // parent is also anonymous, add the nesting depth as a way to avoid conflicts with
+                // the parent's name.
+                if (parentRecordDecl.IsAnonymous)
+                {
+                    var depth = 1;
+                    var currentParent = parentRecordDecl.Parent;
+                    while ((currentParent is RecordDecl currentParentRecordDecl) && currentParentRecordDecl.IsAnonymous)
+                    {
+                        depth++;
+                        currentParent = currentParentRecordDecl.Parent;
+                    }
+                    _ = remappedNameBuilder.Append('_');
+                    _ = remappedNameBuilder.Append(depth);
+                }
+            }
+
+            // Add the type kind tag.
+            _ = remappedNameBuilder.Append("_e__");
+            _ = remappedNameBuilder.Append(recordDecl.IsUnion ? "Union" : "Struct");
+            return remappedNameBuilder.ToString();
+        }
+        else
+        {
+            return $"_Anonymous_e__{(recordDecl.IsUnion ? "Union" : "Struct")}";
+        }
     }
 
     private string GetRemappedName(string name, Cursor? cursor, bool tryRemapOperatorName, out bool wasRemapped, bool skipUsing = false)
@@ -3298,48 +3342,7 @@ public sealed partial class PInvokeGenerator : IDisposable
                     if (IsType<RecordType>(cursor, type, out var recordType) && remappedName.StartsWith("__AnonymousRecord_", StringComparison.Ordinal))
                     {
                         var recordDecl = recordType.Decl;
-                        remappedName = "_Anonymous";
-
-                        if (recordDecl.Parent is RecordDecl parentRecordDecl)
-                        {
-                            var matchingField = parentRecordDecl.Fields.Where((fieldDecl) => fieldDecl.Type.CanonicalType == recordType).FirstOrDefault();
-
-                            if (matchingField is not null)
-                            {
-                                remappedName = "_";
-                                remappedName += GetRemappedCursorName(matchingField);
-                            }
-                            else
-                            {
-                                var index = 0;
-
-                                if (parentRecordDecl.AnonymousRecords.Count > 1)
-                                {
-                                    index = parentRecordDecl.AnonymousRecords.IndexOf(cursor) + 1;
-                                }
-
-                                while (parentRecordDecl.IsAnonymousStructOrUnion && (parentRecordDecl.IsUnion == recordType.Decl.IsUnion))
-                                {
-                                    index += 1;
-
-                                    if (parentRecordDecl.Parent is RecordDecl parentRecordDeclParent)
-                                    {
-                                        if (parentRecordDeclParent.AnonymousRecords.Count > 0)
-                                        {
-                                            index += parentRecordDeclParent.AnonymousRecords.Count - 1;
-                                        }
-                                        parentRecordDecl = parentRecordDeclParent;
-                                    }
-                                }
-
-                                if (index != 0)
-                                {
-                                    remappedName += index.ToString(CultureInfo.InvariantCulture);
-                                }
-                            }
-                        }
-
-                        remappedName += $"_e__{(recordDecl.IsUnion ? "Union" : "Struct")}";
+                        remappedName = GetRemappedNameForAnonymousRecord(recordDecl);
                     }
                     else if (IsType<EnumType>(cursor, type, out var enumType) && remappedName.StartsWith("__AnonymousEnum_", StringComparison.Ordinal))
                     {
@@ -4566,7 +4569,7 @@ public sealed partial class PInvokeGenerator : IDisposable
 
     private bool HasField(RecordDecl recordDecl)
     {
-        var hasField = recordDecl.Fields.Any() || recordDecl.Decls.Any((decl) => (decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymousStructOrUnion && HasField(nestedRecordDecl));
+        var hasField = recordDecl.Fields.Any() || recordDecl.Decls.Any((decl) => (decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymous && HasField(nestedRecordDecl));
 
         if (!hasField && (recordDecl is CXXRecordDecl cxxRecordDecl))
         {
@@ -5117,7 +5120,7 @@ public sealed partial class PInvokeGenerator : IDisposable
 
             foreach (var decl in recordDecl.Decls)
             {
-                if ((decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymousStructOrUnion && !IsEmptyRecord(nestedRecordDecl))
+                if ((decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymous && !IsEmptyRecord(nestedRecordDecl))
                 {
                     return false;
                 }
@@ -6144,7 +6147,7 @@ public sealed partial class PInvokeGenerator : IDisposable
             {
                 return true;
             }
-            else if ((decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymousStructOrUnion && (IsUnsafe(nestedRecordDecl) || Config.GenerateCompatibleCode))
+            else if ((decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymous && (IsUnsafe(nestedRecordDecl) || Config.GenerateCompatibleCode))
             {
                 return true;
             }

--- a/sources/ClangSharp/Cursors/Decls/RecordDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/RecordDecl.cs
@@ -48,12 +48,12 @@ public class RecordDecl : TagDecl
         });
 
         _anonymousFields = new Lazy<IReadOnlyList<FieldDecl>>(() => Decls.OfType<FieldDecl>().Where(decl => decl.IsAnonymousField).ToList());
-        _anonymousRecords = new Lazy<IReadOnlyList<RecordDecl>>(() => Decls.OfType<RecordDecl>().Where(decl => decl.IsAnonymousStructOrUnion && !decl.IsInjectedClassName).ToList());
+        _anonymousRecords = new Lazy<IReadOnlyList<RecordDecl>>(() => Decls.OfType<RecordDecl>().Where(decl => decl.IsAnonymous && !decl.IsInjectedClassName).ToList());
         _indirectFields = new Lazy<IReadOnlyList<IndirectFieldDecl>>(() => Decls.OfType<IndirectFieldDecl>().ToList());
         _injectedClassName = new Lazy<RecordDecl?>(() => Decls.OfType<RecordDecl>().Where(decl => decl.IsInjectedClassName).SingleOrDefault());
     }
 
-    public bool IsAnonymousStructOrUnion => Handle.IsAnonymousStructOrUnion;
+    public bool IsAnonymous => Handle.IsAnonymous;
 
     public IReadOnlyList<FieldDecl> AnonymousFields => _anonymousFields.Value;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/StructDeclarationTest.cs
@@ -215,6 +215,21 @@ public abstract class StructDeclarationTest : PInvokeGeneratorTest
     [Test]
     public Task SourceLocationAttributeTest() => SourceLocationAttributeTestImpl();
 
+    // Regression test: the code that generated the name for anonymous types had a couple of
+    // bugs:
+    // * It would only append a numeral if the parent had more than one anonymous records,
+    //   but an anonymous typed array didn't count as a record resulting in multiple structs
+    //   named `_Anonymous_e__Struct`.
+    // * The code that remapped the name of anonymous types was different between the code that
+    //   generated the type definition and the code that defined fields in a FixedBuffer.
+    [Test]
+    public Task AnonStructAndAnonStructArray() => AnonStructAndAnonStructArrayImpl();
+
+    // Regression test: nested anonymous structs would result in:
+    // error CS0542: '_Anonymous_e__Struct': member names cannot be the same as their enclosing type
+    [Test]
+    public Task DeeplyNestedAnonStructs() => DeeplyNestedAnonStructsImpl();
+
     protected abstract Task IncompleteArraySizeTestImpl(string nativeType, string expectedManagedType);
 
     protected abstract Task BasicTestImpl(string nativeType, string expectedManagedType);
@@ -290,4 +305,8 @@ public abstract class StructDeclarationTest : PInvokeGeneratorTest
     protected abstract Task WithPackingTestImpl();
 
     protected abstract Task SourceLocationAttributeTestImpl();
+
+    protected abstract Task AnonStructAndAnonStructArrayImpl();
+
+    protected abstract Task DeeplyNestedAnonStructsImpl();
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
@@ -1161,7 +1161,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct* pField = &Anonymous.Anonymous1)
+                fixed (_Anonymous_e__Struct._Anonymous2_1_e__Struct* pField = &Anonymous.Anonymous2_1)
                 {{
                     return ref pField->value1;
                 }}
@@ -1172,7 +1172,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct._Anonymous_e__Struct* pField = &Anonymous.Anonymous1.Anonymous)
+                fixed (_Anonymous_e__Struct._Anonymous2_1_e__Struct._Anonymous_2_e__Struct* pField = &Anonymous.Anonymous2_1.Anonymous_2)
                 {{
                     return ref pField->value;
                 }}
@@ -1183,7 +1183,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous2_e__Union* pField = &Anonymous.Anonymous2)
+                fixed (_Anonymous_e__Struct._Anonymous3_1_e__Union* pField = &Anonymous.Anonymous3_1)
                 {{
                     return ref pField->value2;
                 }}
@@ -1231,10 +1231,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous1_e__Struct Anonymous1;
+            public _Anonymous2_1_e__Struct Anonymous2_1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous2_e__Union Anonymous2;
+            public _Anonymous3_1_e__Union Anonymous3_1;
 
             public MyUnion u;
 
@@ -1249,21 +1249,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public unsafe partial struct _Anonymous1_e__Struct
+            public unsafe partial struct _Anonymous2_1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_e__Struct Anonymous;
+                public _Anonymous_2_e__Struct Anonymous_2;
 
-                public partial struct _Anonymous_e__Struct
+                public partial struct _Anonymous_2_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous2_e__Union
+            public partial struct _Anonymous3_1_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1342,7 +1342,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous_e__Struct._Anonymous_e__Struct* pField = &Anonymous.Anonymous)
+                fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct* pField = &Anonymous.Anonymous_1)
                 {
                     return ref pField->w;
                 }
@@ -1353,12 +1353,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -1366,12 +1366,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -1380,9 +1380,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Struct Anonymous;
+            public _Anonymous_1_e__Struct Anonymous_1;
 
-            public partial struct _Anonymous_e__Struct
+            public partial struct _Anonymous_1_e__Struct
             {
                 public int w;
 
@@ -2017,5 +2017,137 @@ namespace ClangSharp.Test
 ";
 
         return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public unsafe partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous1_e__Struct Anonymous1;
+
+        [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
+        public _MyArray_e__FixedBuffer MyArray;
+
+        public ref int First
+        {
+            get
+            {
+                fixed (_Anonymous1_e__Struct* pField = &Anonymous1)
+                {
+                    return ref pField->First;
+                }
+            }
+        }
+
+        public partial struct _Anonymous1_e__Struct
+        {
+            public int First;
+        }
+
+        public partial struct _Anonymous2_e__Struct
+        {
+            public int Second;
+        }
+
+        public partial struct _MyArray_e__FixedBuffer
+        {
+            public _Anonymous2_e__Struct e0;
+            public _Anonymous2_e__Struct e1;
+
+            public unsafe ref _Anonymous2_e__Struct this[int index]
+            {
+                get
+                {
+                    fixed (_Anonymous2_e__Struct* pThis = &e0)
+                    {
+                        return ref pThis[index];
+                    }
+                }
+            }
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public unsafe partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        public ref int Value1
+        {
+            get
+            {
+                fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous1_2_e__Struct* pField = &Anonymous.Anonymous_1.Anonymous1_2)
+                {
+                    return ref pField->Value1;
+                }
+            }
+        }
+
+        public ref int Value2
+        {
+            get
+            {
+                fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous2_2_e__Struct* pField = &Anonymous.Anonymous_1.Anonymous2_2)
+                {
+                    return ref pField->Value2;
+                }
+            }
+        }
+
+        public unsafe partial struct _Anonymous_e__Struct
+        {
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
+            public _Anonymous_1_e__Struct Anonymous_1;
+
+            public unsafe partial struct _Anonymous_1_e__Struct
+            {
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
+                public _Anonymous1_2_e__Struct Anonymous1_2;
+
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
+                public _Anonymous2_2_e__Struct Anonymous2_2;
+
+                public partial struct _Anonymous1_2_e__Struct
+                {
+                    public int Value1;
+                }
+
+                public partial struct _Anonymous2_2_e__Struct
+                {
+                    public int Value2;
+                }
+            }
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/UnionDeclarationTest.cs
@@ -918,7 +918,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous_e__Union._Anonymous_e__Union* pField = &Anonymous.Anonymous)
+                fixed (_Anonymous_e__Union._Anonymous_1_e__Union* pField = &Anonymous.Anonymous_1)
                 {
                     return ref pField->w;
                 }
@@ -929,12 +929,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -942,12 +942,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -959,10 +959,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1504,22 +1504,22 @@ namespace ClangSharp.Test
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &Anonymous.Anonymous)
+                fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &Anonymous.Anonymous_1)
                 {{
                     return ref pField->A;
                 }}
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &Anonymous.Anonymous)
+                fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &Anonymous.Anonymous_1)
                 {{
                     return ref pField->B;
                 }}
@@ -1532,10 +1532,10 @@ namespace ClangSharp.Test
             public IntPtr First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public unsafe partial struct _Anonymous_1_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
@@ -1169,7 +1169,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct* pField = &Anonymous.Anonymous1)
+                fixed (_Anonymous_e__Struct._Anonymous2_1_e__Struct* pField = &Anonymous.Anonymous2_1)
                 {{
                     return ref pField->value1;
                 }}
@@ -1180,7 +1180,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct._Anonymous_e__Struct* pField = &Anonymous.Anonymous1.Anonymous)
+                fixed (_Anonymous_e__Struct._Anonymous2_1_e__Struct._Anonymous_2_e__Struct* pField = &Anonymous.Anonymous2_1.Anonymous_2)
                 {{
                     return ref pField->value;
                 }}
@@ -1191,7 +1191,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous2_e__Union* pField = &Anonymous.Anonymous2)
+                fixed (_Anonymous_e__Struct._Anonymous3_1_e__Union* pField = &Anonymous.Anonymous3_1)
                 {{
                     return ref pField->value2;
                 }}
@@ -1239,10 +1239,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous1_e__Struct Anonymous1;
+            public _Anonymous2_1_e__Struct Anonymous2_1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous2_e__Union Anonymous2;
+            public _Anonymous3_1_e__Union Anonymous3_1;
 
             public MyUnion u;
 
@@ -1257,21 +1257,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public unsafe partial struct _Anonymous1_e__Struct
+            public unsafe partial struct _Anonymous2_1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_e__Struct Anonymous;
+                public _Anonymous_2_e__Struct Anonymous_2;
 
-                public partial struct _Anonymous_e__Struct
+                public partial struct _Anonymous_2_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous2_e__Union
+            public partial struct _Anonymous3_1_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1350,7 +1350,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous_e__Struct._Anonymous_e__Struct* pField = &Anonymous.Anonymous)
+                fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct* pField = &Anonymous.Anonymous_1)
                 {
                     return ref pField->w;
                 }
@@ -1361,12 +1361,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -1374,12 +1374,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -1388,9 +1388,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Struct Anonymous;
+            public _Anonymous_1_e__Struct Anonymous_1;
 
-            public partial struct _Anonymous_e__Struct
+            public partial struct _Anonymous_1_e__Struct
             {
                 public int w;
 
@@ -2023,5 +2023,137 @@ namespace ClangSharp.Test
 ";
 
         return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public unsafe partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous1_e__Struct Anonymous1;
+
+        [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
+        public _MyArray_e__FixedBuffer MyArray;
+
+        public ref int First
+        {
+            get
+            {
+                fixed (_Anonymous1_e__Struct* pField = &Anonymous1)
+                {
+                    return ref pField->First;
+                }
+            }
+        }
+
+        public partial struct _Anonymous1_e__Struct
+        {
+            public int First;
+        }
+
+        public partial struct _Anonymous2_e__Struct
+        {
+            public int Second;
+        }
+
+        public partial struct _MyArray_e__FixedBuffer
+        {
+            public _Anonymous2_e__Struct e0;
+            public _Anonymous2_e__Struct e1;
+
+            public unsafe ref _Anonymous2_e__Struct this[int index]
+            {
+                get
+                {
+                    fixed (_Anonymous2_e__Struct* pThis = &e0)
+                    {
+                        return ref pThis[index];
+                    }
+                }
+            }
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public unsafe partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        public ref int Value1
+        {
+            get
+            {
+                fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous1_2_e__Struct* pField = &Anonymous.Anonymous_1.Anonymous1_2)
+                {
+                    return ref pField->Value1;
+                }
+            }
+        }
+
+        public ref int Value2
+        {
+            get
+            {
+                fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous2_2_e__Struct* pField = &Anonymous.Anonymous_1.Anonymous2_2)
+                {
+                    return ref pField->Value2;
+                }
+            }
+        }
+
+        public unsafe partial struct _Anonymous_e__Struct
+        {
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
+            public _Anonymous_1_e__Struct Anonymous_1;
+
+            public unsafe partial struct _Anonymous_1_e__Struct
+            {
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
+                public _Anonymous1_2_e__Struct Anonymous1_2;
+
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
+                public _Anonymous2_2_e__Struct Anonymous2_2;
+
+                public partial struct _Anonymous1_2_e__Struct
+                {
+                    public int Value1;
+                }
+
+                public partial struct _Anonymous2_2_e__Struct
+                {
+                    public int Value2;
+                }
+            }
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/UnionDeclarationTest.cs
@@ -925,7 +925,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous_e__Union._Anonymous_e__Union* pField = &Anonymous.Anonymous)
+                fixed (_Anonymous_e__Union._Anonymous_1_e__Union* pField = &Anonymous.Anonymous_1)
                 {
                     return ref pField->w;
                 }
@@ -936,12 +936,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -949,12 +949,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -966,10 +966,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1510,22 +1510,22 @@ namespace ClangSharp.Test
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &Anonymous.Anonymous)
+                fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &Anonymous.Anonymous_1)
                 {{
                     return ref pField->A;
                 }}
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &Anonymous.Anonymous)
+                fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &Anonymous.Anonymous_1)
                 {{
                     return ref pField->B;
                 }}
@@ -1538,10 +1538,10 @@ namespace ClangSharp.Test
             public int First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public unsafe partial struct _Anonymous_1_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/StructDeclarationTest.cs
@@ -1163,7 +1163,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.value1, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous2_1.value1, 1));
             }}
         }}
 
@@ -1171,7 +1171,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.Anonymous.value, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous2_1.Anonymous_2.value, 1));
             }}
         }}
 
@@ -1179,7 +1179,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous2.value2, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous3_1.value2, 1));
             }}
         }}
 
@@ -1215,10 +1215,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous1_e__Struct Anonymous1;
+            public _Anonymous2_1_e__Struct Anonymous2_1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous2_e__Union Anonymous2;
+            public _Anonymous3_1_e__Union Anonymous3_1;
 
             public MyUnion u;
 
@@ -1233,21 +1233,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous1_e__Struct
+            public partial struct _Anonymous2_1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_e__Struct Anonymous;
+                public _Anonymous_2_e__Struct Anonymous_2;
 
-                public partial struct _Anonymous_e__Struct
+                public partial struct _Anonymous_2_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous2_e__Union
+            public partial struct _Anonymous3_1_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1324,7 +1324,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.w, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));
             }
         }
 
@@ -1332,12 +1332,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -1345,12 +1345,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -1359,9 +1359,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Struct Anonymous;
+            public _Anonymous_1_e__Struct Anonymous_1;
 
-            public partial struct _Anonymous_e__Struct
+            public partial struct _Anonymous_1_e__Struct
             {
                 public int w;
 
@@ -1994,5 +1994,132 @@ namespace ClangSharp.Test
 ";
 
         return ValidateGeneratedCSharpDefaultUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;";
+
+        var expectedOutputContents = @"using System;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous1_e__Struct Anonymous1;
+
+        [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
+        public _MyArray_e__FixedBuffer MyArray;
+
+        public ref int First
+        {
+            get
+            {
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous1.First, 1));
+            }
+        }
+
+        public partial struct _Anonymous1_e__Struct
+        {
+            public int First;
+        }
+
+        public partial struct _Anonymous2_e__Struct
+        {
+            public int Second;
+        }
+
+        public partial struct _MyArray_e__FixedBuffer
+        {
+            public _Anonymous2_e__Struct e0;
+            public _Anonymous2_e__Struct e1;
+
+            public ref _Anonymous2_e__Struct this[int index]
+            {
+                get
+                {
+                    return ref AsSpan()[index];
+                }
+            }
+
+            public Span<_Anonymous2_e__Struct> AsSpan() => MemoryMarshal.CreateSpan(ref e0, 2);
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpDefaultUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        public ref int Value1
+        {
+            get
+            {
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous1_2.Value1, 1));
+            }
+        }
+
+        public ref int Value2
+        {
+            get
+            {
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous2_2.Value2, 1));
+            }
+        }
+
+        public partial struct _Anonymous_e__Struct
+        {
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
+            public _Anonymous_1_e__Struct Anonymous_1;
+
+            public partial struct _Anonymous_1_e__Struct
+            {
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
+                public _Anonymous1_2_e__Struct Anonymous1_2;
+
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
+                public _Anonymous2_2_e__Struct Anonymous2_2;
+
+                public partial struct _Anonymous1_2_e__Struct
+                {
+                    public int Value1;
+                }
+
+                public partial struct _Anonymous2_2_e__Struct
+                {
+                    public int Value2;
+                }
+            }
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpDefaultUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/UnionDeclarationTest.cs
@@ -908,7 +908,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.w, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));
             }
         }
 
@@ -916,12 +916,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -929,12 +929,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -946,10 +946,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1485,19 +1485,19 @@ namespace ClangSharp.Test
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.A, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.A, 1));
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.B, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.B, 1));
             }}
         }}
 
@@ -1507,10 +1507,10 @@ namespace ClangSharp.Test
             public nint First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/StructDeclarationTest.cs
@@ -1171,7 +1171,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.value1, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous2_1.value1, 1));
             }}
         }}
 
@@ -1179,7 +1179,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.Anonymous.value, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous2_1.Anonymous_2.value, 1));
             }}
         }}
 
@@ -1187,7 +1187,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous2.value2, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous3_1.value2, 1));
             }}
         }}
 
@@ -1223,10 +1223,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous1_e__Struct Anonymous1;
+            public _Anonymous2_1_e__Struct Anonymous2_1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous2_e__Union Anonymous2;
+            public _Anonymous3_1_e__Union Anonymous3_1;
 
             public MyUnion u;
 
@@ -1241,21 +1241,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous1_e__Struct
+            public partial struct _Anonymous2_1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_e__Struct Anonymous;
+                public _Anonymous_2_e__Struct Anonymous_2;
 
-                public partial struct _Anonymous_e__Struct
+                public partial struct _Anonymous_2_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous2_e__Union
+            public partial struct _Anonymous3_1_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1332,7 +1332,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.w, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));
             }
         }
 
@@ -1340,12 +1340,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -1353,12 +1353,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -1367,9 +1367,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Struct Anonymous;
+            public _Anonymous_1_e__Struct Anonymous_1;
 
-            public partial struct _Anonymous_e__Struct
+            public partial struct _Anonymous_1_e__Struct
             {
                 public int w;
 
@@ -2000,5 +2000,132 @@ namespace ClangSharp.Test
 ";
 
         return ValidateGeneratedCSharpDefaultWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;";
+
+        var expectedOutputContents = @"using System;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous1_e__Struct Anonymous1;
+
+        [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
+        public _MyArray_e__FixedBuffer MyArray;
+
+        public ref int First
+        {
+            get
+            {
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous1.First, 1));
+            }
+        }
+
+        public partial struct _Anonymous1_e__Struct
+        {
+            public int First;
+        }
+
+        public partial struct _Anonymous2_e__Struct
+        {
+            public int Second;
+        }
+
+        public partial struct _MyArray_e__FixedBuffer
+        {
+            public _Anonymous2_e__Struct e0;
+            public _Anonymous2_e__Struct e1;
+
+            public ref _Anonymous2_e__Struct this[int index]
+            {
+                get
+                {
+                    return ref AsSpan()[index];
+                }
+            }
+
+            public Span<_Anonymous2_e__Struct> AsSpan() => MemoryMarshal.CreateSpan(ref e0, 2);
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpDefaultWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        public ref int Value1
+        {
+            get
+            {
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous1_2.Value1, 1));
+            }
+        }
+
+        public ref int Value2
+        {
+            get
+            {
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous2_2.Value2, 1));
+            }
+        }
+
+        public partial struct _Anonymous_e__Struct
+        {
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
+            public _Anonymous_1_e__Struct Anonymous_1;
+
+            public partial struct _Anonymous_1_e__Struct
+            {
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
+                public _Anonymous1_2_e__Struct Anonymous1_2;
+
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
+                public _Anonymous2_2_e__Struct Anonymous2_2;
+
+                public partial struct _Anonymous1_2_e__Struct
+                {
+                    public int Value1;
+                }
+
+                public partial struct _Anonymous2_2_e__Struct
+                {
+                    public int Value2;
+                }
+            }
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpDefaultWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/UnionDeclarationTest.cs
@@ -914,7 +914,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.w, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));
             }
         }
 
@@ -922,12 +922,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -935,12 +935,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -952,10 +952,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1490,19 +1490,19 @@ namespace ClangSharp.Test
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.A, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.A, 1));
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.B, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.B, 1));
             }}
         }}
 
@@ -1512,10 +1512,10 @@ namespace ClangSharp.Test
             public int First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
@@ -1133,7 +1133,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous1.value1;
+                return ref Anonymous.Anonymous2_1.value1;
             }}
         }}
 
@@ -1142,7 +1142,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous1.Anonymous.value;
+                return ref Anonymous.Anonymous2_1.Anonymous_2.value;
             }}
         }}
 
@@ -1151,7 +1151,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous2.value2;
+                return ref Anonymous.Anonymous3_1.value2;
             }}
         }}
 
@@ -1190,10 +1190,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous1_e__Struct Anonymous1;
+            public _Anonymous2_1_e__Struct Anonymous2_1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous2_e__Union Anonymous2;
+            public _Anonymous3_1_e__Union Anonymous3_1;
 
             public MyUnion u;
 
@@ -1208,21 +1208,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous1_e__Struct
+            public partial struct _Anonymous2_1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_e__Struct Anonymous;
+                public _Anonymous_2_e__Struct Anonymous_2;
 
-                public partial struct _Anonymous_e__Struct
+                public partial struct _Anonymous_2_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous2_e__Union
+            public partial struct _Anonymous3_1_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1295,7 +1295,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous.w;
+                return ref Anonymous.Anonymous_1.w;
             }
         }
 
@@ -1303,12 +1303,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -1316,12 +1316,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -1330,9 +1330,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Struct Anonymous;
+            public _Anonymous_1_e__Struct Anonymous_1;
 
-            public partial struct _Anonymous_e__Struct
+            public partial struct _Anonymous_1_e__Struct
             {
                 public int w;
 
@@ -1956,5 +1956,126 @@ namespace ClangSharp.Test
 ";
 
         return ValidateGeneratedCSharpLatestUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;
+";
+
+        var expectedOutputContents = @"using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous1_e__Struct Anonymous1;
+
+        [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
+        public _MyArray_e__FixedBuffer MyArray;
+
+        [UnscopedRef]
+        public ref int First
+        {
+            get
+            {
+                return ref Anonymous1.First;
+            }
+        }
+
+        public partial struct _Anonymous1_e__Struct
+        {
+            public int First;
+        }
+
+        public partial struct _Anonymous2_e__Struct
+        {
+            public int Second;
+        }
+
+        [InlineArray(2)]
+        public partial struct _MyArray_e__FixedBuffer
+        {
+            public _Anonymous2_e__Struct e0;
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"using System.Diagnostics.CodeAnalysis;
+
+namespace ClangSharp.Test
+{
+    public partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        [UnscopedRef]
+        public ref int Value1
+        {
+            get
+            {
+                return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;
+            }
+        }
+
+        [UnscopedRef]
+        public ref int Value2
+        {
+            get
+            {
+                return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;
+            }
+        }
+
+        public partial struct _Anonymous_e__Struct
+        {
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
+            public _Anonymous_1_e__Struct Anonymous_1;
+
+            public partial struct _Anonymous_1_e__Struct
+            {
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
+                public _Anonymous1_2_e__Struct Anonymous1_2;
+
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
+                public _Anonymous2_2_e__Struct Anonymous2_2;
+
+                public partial struct _Anonymous1_2_e__Struct
+                {
+                    public int Value1;
+                }
+
+                public partial struct _Anonymous2_2_e__Struct
+                {
+                    public int Value2;
+                }
+            }
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/UnionDeclarationTest.cs
@@ -867,7 +867,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous.w;
+                return ref Anonymous.Anonymous_1.w;
             }
         }
 
@@ -875,12 +875,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -888,12 +888,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -905,10 +905,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1449,20 +1449,20 @@ namespace ClangSharp.Test
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
         {{
             get
             {{
-                return ref Anonymous.Anonymous.A;
+                return ref Anonymous.Anonymous_1.A;
             }}
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
         {{
             get
             {{
-                return ref Anonymous.Anonymous.B;
+                return ref Anonymous.Anonymous_1.B;
             }}
         }}
 
@@ -1472,10 +1472,10 @@ namespace ClangSharp.Test
             public nint First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
@@ -1141,7 +1141,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous1.value1;
+                return ref Anonymous.Anonymous2_1.value1;
             }}
         }}
 
@@ -1150,7 +1150,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous1.Anonymous.value;
+                return ref Anonymous.Anonymous2_1.Anonymous_2.value;
             }}
         }}
 
@@ -1159,7 +1159,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous2.value2;
+                return ref Anonymous.Anonymous3_1.value2;
             }}
         }}
 
@@ -1198,10 +1198,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous1_e__Struct Anonymous1;
+            public _Anonymous2_1_e__Struct Anonymous2_1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous2_e__Union Anonymous2;
+            public _Anonymous3_1_e__Union Anonymous3_1;
 
             public MyUnion u;
 
@@ -1216,21 +1216,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous1_e__Struct
+            public partial struct _Anonymous2_1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_e__Struct Anonymous;
+                public _Anonymous_2_e__Struct Anonymous_2;
 
-                public partial struct _Anonymous_e__Struct
+                public partial struct _Anonymous_2_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous2_e__Union
+            public partial struct _Anonymous3_1_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1303,7 +1303,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous.w;
+                return ref Anonymous.Anonymous_1.w;
             }
         }
 
@@ -1311,12 +1311,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -1324,12 +1324,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -1338,9 +1338,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Struct Anonymous;
+            public _Anonymous_1_e__Struct Anonymous_1;
 
-            public partial struct _Anonymous_e__Struct
+            public partial struct _Anonymous_1_e__Struct
             {
                 public int w;
 
@@ -1962,5 +1962,126 @@ namespace ClangSharp.Test
 ";
 
         return ValidateGeneratedCSharpLatestWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;
+";
+
+        var expectedOutputContents = @"using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous1_e__Struct Anonymous1;
+
+        [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
+        public _MyArray_e__FixedBuffer MyArray;
+
+        [UnscopedRef]
+        public ref int First
+        {
+            get
+            {
+                return ref Anonymous1.First;
+            }
+        }
+
+        public partial struct _Anonymous1_e__Struct
+        {
+            public int First;
+        }
+
+        public partial struct _Anonymous2_e__Struct
+        {
+            public int Second;
+        }
+
+        [InlineArray(2)]
+        public partial struct _MyArray_e__FixedBuffer
+        {
+            public _Anonymous2_e__Struct e0;
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"using System.Diagnostics.CodeAnalysis;
+
+namespace ClangSharp.Test
+{
+    public partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        [UnscopedRef]
+        public ref int Value1
+        {
+            get
+            {
+                return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;
+            }
+        }
+
+        [UnscopedRef]
+        public ref int Value2
+        {
+            get
+            {
+                return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;
+            }
+        }
+
+        public partial struct _Anonymous_e__Struct
+        {
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
+            public _Anonymous_1_e__Struct Anonymous_1;
+
+            public partial struct _Anonymous_1_e__Struct
+            {
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
+                public _Anonymous1_2_e__Struct Anonymous1_2;
+
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
+                public _Anonymous2_2_e__Struct Anonymous2_2;
+
+                public partial struct _Anonymous1_2_e__Struct
+                {
+                    public int Value1;
+                }
+
+                public partial struct _Anonymous2_2_e__Struct
+                {
+                    public int Value2;
+                }
+            }
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/UnionDeclarationTest.cs
@@ -873,7 +873,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous.w;
+                return ref Anonymous.Anonymous_1.w;
             }
         }
 
@@ -881,12 +881,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -894,12 +894,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -911,10 +911,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1455,20 +1455,20 @@ namespace ClangSharp.Test
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
         {{
             get
             {{
-                return ref Anonymous.Anonymous.A;
+                return ref Anonymous.Anonymous_1.A;
             }}
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
         {{
             get
             {{
-                return ref Anonymous.Anonymous.B;
+                return ref Anonymous.Anonymous_1.B;
             }}
         }}
 
@@ -1478,10 +1478,10 @@ namespace ClangSharp.Test
             public int First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/StructDeclarationTest.cs
@@ -1133,7 +1133,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous1.value1;
+                return ref Anonymous.Anonymous2_1.value1;
             }}
         }}
 
@@ -1142,7 +1142,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous1.Anonymous.value;
+                return ref Anonymous.Anonymous2_1.Anonymous_2.value;
             }}
         }}
 
@@ -1151,7 +1151,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous2.value2;
+                return ref Anonymous.Anonymous3_1.value2;
             }}
         }}
 
@@ -1190,10 +1190,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous1_e__Struct Anonymous1;
+            public _Anonymous2_1_e__Struct Anonymous2_1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous2_e__Union Anonymous2;
+            public _Anonymous3_1_e__Union Anonymous3_1;
 
             public MyUnion u;
 
@@ -1208,21 +1208,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous1_e__Struct
+            public partial struct _Anonymous2_1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_e__Struct Anonymous;
+                public _Anonymous_2_e__Struct Anonymous_2;
 
-                public partial struct _Anonymous_e__Struct
+                public partial struct _Anonymous_2_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous2_e__Union
+            public partial struct _Anonymous3_1_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1295,7 +1295,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous.w;
+                return ref Anonymous.Anonymous_1.w;
             }
         }
 
@@ -1303,12 +1303,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -1316,12 +1316,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -1330,9 +1330,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Struct Anonymous;
+            public _Anonymous_1_e__Struct Anonymous_1;
 
-            public partial struct _Anonymous_e__Struct
+            public partial struct _Anonymous_1_e__Struct
             {
                 public int w;
 
@@ -1956,5 +1956,125 @@ namespace ClangSharp.Test
 ";
 
         return ValidateGeneratedCSharpPreviewUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;";
+
+        var expectedOutputContents = @"using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous1_e__Struct Anonymous1;
+
+        [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
+        public _MyArray_e__FixedBuffer MyArray;
+
+        [UnscopedRef]
+        public ref int First
+        {
+            get
+            {
+                return ref Anonymous1.First;
+            }
+        }
+
+        public partial struct _Anonymous1_e__Struct
+        {
+            public int First;
+        }
+
+        public partial struct _Anonymous2_e__Struct
+        {
+            public int Second;
+        }
+
+        [InlineArray(2)]
+        public partial struct _MyArray_e__FixedBuffer
+        {
+            public _Anonymous2_e__Struct e0;
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpPreviewUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"using System.Diagnostics.CodeAnalysis;
+
+namespace ClangSharp.Test
+{
+    public partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        [UnscopedRef]
+        public ref int Value1
+        {
+            get
+            {
+                return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;
+            }
+        }
+
+        [UnscopedRef]
+        public ref int Value2
+        {
+            get
+            {
+                return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;
+            }
+        }
+
+        public partial struct _Anonymous_e__Struct
+        {
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
+            public _Anonymous_1_e__Struct Anonymous_1;
+
+            public partial struct _Anonymous_1_e__Struct
+            {
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
+                public _Anonymous1_2_e__Struct Anonymous1_2;
+
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
+                public _Anonymous2_2_e__Struct Anonymous2_2;
+
+                public partial struct _Anonymous1_2_e__Struct
+                {
+                    public int Value1;
+                }
+
+                public partial struct _Anonymous2_2_e__Struct
+                {
+                    public int Value2;
+                }
+            }
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpPreviewUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/UnionDeclarationTest.cs
@@ -867,7 +867,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous.w;
+                return ref Anonymous.Anonymous_1.w;
             }
         }
 
@@ -875,12 +875,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -888,12 +888,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -905,10 +905,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1449,20 +1449,20 @@ namespace ClangSharp.Test
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
         {{
             get
             {{
-                return ref Anonymous.Anonymous.A;
+                return ref Anonymous.Anonymous_1.A;
             }}
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
         {{
             get
             {{
-                return ref Anonymous.Anonymous.B;
+                return ref Anonymous.Anonymous_1.B;
             }}
         }}
 
@@ -1472,10 +1472,10 @@ namespace ClangSharp.Test
             public nint First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/StructDeclarationTest.cs
@@ -1141,7 +1141,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous1.value1;
+                return ref Anonymous.Anonymous2_1.value1;
             }}
         }}
 
@@ -1150,7 +1150,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous1.Anonymous.value;
+                return ref Anonymous.Anonymous2_1.Anonymous_2.value;
             }}
         }}
 
@@ -1159,7 +1159,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous2.value2;
+                return ref Anonymous.Anonymous3_1.value2;
             }}
         }}
 
@@ -1198,10 +1198,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous1_e__Struct Anonymous1;
+            public _Anonymous2_1_e__Struct Anonymous2_1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous2_e__Union Anonymous2;
+            public _Anonymous3_1_e__Union Anonymous3_1;
 
             public MyUnion u;
 
@@ -1216,21 +1216,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous1_e__Struct
+            public partial struct _Anonymous2_1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_e__Struct Anonymous;
+                public _Anonymous_2_e__Struct Anonymous_2;
 
-                public partial struct _Anonymous_e__Struct
+                public partial struct _Anonymous_2_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous2_e__Union
+            public partial struct _Anonymous3_1_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1303,7 +1303,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous.w;
+                return ref Anonymous.Anonymous_1.w;
             }
         }
 
@@ -1311,12 +1311,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -1324,12 +1324,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -1338,9 +1338,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Struct Anonymous;
+            public _Anonymous_1_e__Struct Anonymous_1;
 
-            public partial struct _Anonymous_e__Struct
+            public partial struct _Anonymous_1_e__Struct
             {
                 public int w;
 
@@ -1962,5 +1962,125 @@ namespace ClangSharp.Test
 ";
 
         return ValidateGeneratedCSharpPreviewWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;";
+
+        var expectedOutputContents = @"using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous1_e__Struct Anonymous1;
+
+        [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
+        public _MyArray_e__FixedBuffer MyArray;
+
+        [UnscopedRef]
+        public ref int First
+        {
+            get
+            {
+                return ref Anonymous1.First;
+            }
+        }
+
+        public partial struct _Anonymous1_e__Struct
+        {
+            public int First;
+        }
+
+        public partial struct _Anonymous2_e__Struct
+        {
+            public int Second;
+        }
+
+        [InlineArray(2)]
+        public partial struct _MyArray_e__FixedBuffer
+        {
+            public _Anonymous2_e__Struct e0;
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpPreviewWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"using System.Diagnostics.CodeAnalysis;
+
+namespace ClangSharp.Test
+{
+    public partial struct _MyStruct
+    {
+        [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
+        public _Anonymous_e__Struct Anonymous;
+
+        [UnscopedRef]
+        public ref int Value1
+        {
+            get
+            {
+                return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;
+            }
+        }
+
+        [UnscopedRef]
+        public ref int Value2
+        {
+            get
+            {
+                return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;
+            }
+        }
+
+        public partial struct _Anonymous_e__Struct
+        {
+            [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
+            public _Anonymous_1_e__Struct Anonymous_1;
+
+            public partial struct _Anonymous_1_e__Struct
+            {
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
+                public _Anonymous1_2_e__Struct Anonymous1_2;
+
+                [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
+                public _Anonymous2_2_e__Struct Anonymous2_2;
+
+                public partial struct _Anonymous1_2_e__Struct
+                {
+                    public int Value1;
+                }
+
+                public partial struct _Anonymous2_2_e__Struct
+                {
+                    public int Value2;
+                }
+            }
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpPreviewWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/UnionDeclarationTest.cs
@@ -873,7 +873,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous.w;
+                return ref Anonymous.Anonymous_1.w;
             }
         }
 
@@ -881,12 +881,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b0_16;
+                return Anonymous.Anonymous_1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b0_16 = value;
+                Anonymous.Anonymous_1.o0_b0_16 = value;
             }
         }
 
@@ -894,12 +894,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous.o0_b16_4;
+                return Anonymous.Anonymous_1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous.o0_b16_4 = value;
+                Anonymous.Anonymous_1.o0_b16_4 = value;
             }
         }
 
@@ -911,10 +911,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1455,20 +1455,20 @@ namespace ClangSharp.Test
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
         {{
             get
             {{
-                return ref Anonymous.Anonymous.A;
+                return ref Anonymous.Anonymous_1.A;
             }}
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
         {{
             get
             {{
-                return ref Anonymous.Anonymous.B;
+                return ref Anonymous.Anonymous_1.B;
             }}
         }}
 
@@ -1478,10 +1478,10 @@ namespace ClangSharp.Test
             public int First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_e__Union Anonymous;
+            public _Anonymous_1_e__Union Anonymous_1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_e__Union
+            public partial struct _Anonymous_1_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -197,7 +197,7 @@ namespace ClangSharp.Test
         }
     }
 
-    public partial struct _MyStructWithAnonymousUnion
+    public unsafe partial struct _MyStructWithAnonymousUnion
     {
         [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L21_C5"")]
         public _union1_e__Union union1;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
@@ -1280,7 +1280,7 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Struct* pField = &amp;Anonymous.Anonymous)
+          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct* pField = &amp;Anonymous.Anonymous_1)
     {
         return ref pField-&gt;w;
     }</code>
@@ -1289,29 +1289,29 @@ struct MyStruct
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"" unsafe=""true"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Struct</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1982,5 +1982,136 @@ struct MyStruct
 ";
 
         return ValidateGeneratedXmlCompatibleUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"" unsafe=""true"">
+      <field name=""Anonymous1"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      </field>
+      <field name=""MyArray"" access=""public"">
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>fixed (_Anonymous1_e__Struct* pField = &amp;Anonymous1)
+    {
+        return ref pField-&gt;First;
+    }</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+        <field name=""Second"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
+        <field name=""e0"" access=""public"">
+          <type>_Anonymous2_e__Struct</type>
+        </field>
+        <field name=""e1"" access=""public"">
+          <type>_Anonymous2_e__Struct</type>
+        </field>
+        <indexer access=""public"" unsafe=""true"">
+          <type>ref _Anonymous2_e__Struct</type>
+          <param name=""index"">
+            <type>int</type>
+          </param>
+          <get>
+            <code>fixed (_Anonymous2_e__Struct* pThis = &amp;e0)
+    {
+        return ref pThis[index];
+    }</code>
+          </get>
+        </indexer>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"" unsafe=""true"">
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""Value1"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous1_2_e__Struct* pField = &amp;Anonymous.Anonymous_1.Anonymous1_2)
+    {
+        return ref pField-&gt;Value1;
+    }</code>
+        </get>
+      </field>
+      <field name=""Value2"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous2_2_e__Struct* pField = &amp;Anonymous.Anonymous_1.Anonymous2_2)
+    {
+        return ref pField-&gt;Value2;
+    }</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"" unsafe=""true"">
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        </field>
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"" unsafe=""true"">
+          <field name=""Anonymous1_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+          </field>
+          <field name=""Anonymous2_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          </field>
+          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+            <field name=""Value1"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+            <field name=""Value2"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/UnionDeclarationTest.cs
@@ -868,7 +868,7 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous_e__Union._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
+          <code>fixed (_Anonymous_e__Union._Anonymous_1_e__Union* pField = &amp;Anonymous.Anonymous_1)
     {
         return ref pField-&gt;w;
     }</code>
@@ -877,29 +877,29 @@ union MyUnion
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" unsafe=""true"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1386,18 +1386,18 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
+          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &amp;Anonymous.Anonymous_1)
     {{
         return ref pField-&gt;A;
     }}</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
+          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &amp;Anonymous.Anonymous_1)
     {{
         return ref pField-&gt;B;
     }}</code>
@@ -1407,10 +1407,10 @@ union MyUnion
         <field name=""First"" access=""public"">
           <type native=""long"">IntPtr</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" unsafe=""true"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
@@ -1292,7 +1292,7 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Struct* pField = &amp;Anonymous.Anonymous)
+          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct* pField = &amp;Anonymous.Anonymous_1)
     {
         return ref pField-&gt;w;
     }</code>
@@ -1301,29 +1301,29 @@ struct MyStruct
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"" unsafe=""true"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Struct</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1991,5 +1991,136 @@ struct MyStruct3
 ";
 
         return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"" unsafe=""true"">
+      <field name=""Anonymous1"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      </field>
+      <field name=""MyArray"" access=""public"">
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>fixed (_Anonymous1_e__Struct* pField = &amp;Anonymous1)
+    {
+        return ref pField-&gt;First;
+    }</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+        <field name=""Second"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
+        <field name=""e0"" access=""public"">
+          <type>_Anonymous2_e__Struct</type>
+        </field>
+        <field name=""e1"" access=""public"">
+          <type>_Anonymous2_e__Struct</type>
+        </field>
+        <indexer access=""public"" unsafe=""true"">
+          <type>ref _Anonymous2_e__Struct</type>
+          <param name=""index"">
+            <type>int</type>
+          </param>
+          <get>
+            <code>fixed (_Anonymous2_e__Struct* pThis = &amp;e0)
+    {
+        return ref pThis[index];
+    }</code>
+          </get>
+        </indexer>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"" unsafe=""true"">
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""Value1"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous1_2_e__Struct* pField = &amp;Anonymous.Anonymous_1.Anonymous1_2)
+    {
+        return ref pField-&gt;Value1;
+    }</code>
+        </get>
+      </field>
+      <field name=""Value2"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous2_2_e__Struct* pField = &amp;Anonymous.Anonymous_1.Anonymous2_2)
+    {
+        return ref pField-&gt;Value2;
+    }</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"" unsafe=""true"">
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        </field>
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"" unsafe=""true"">
+          <field name=""Anonymous1_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+          </field>
+          <field name=""Anonymous2_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          </field>
+          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+            <field name=""Value1"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+            <field name=""Value2"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/UnionDeclarationTest.cs
@@ -874,7 +874,7 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous_e__Union._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
+          <code>fixed (_Anonymous_e__Union._Anonymous_1_e__Union* pField = &amp;Anonymous.Anonymous_1)
     {
         return ref pField-&gt;w;
     }</code>
@@ -883,29 +883,29 @@ union MyUnion
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" unsafe=""true"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1392,18 +1392,18 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
+          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &amp;Anonymous.Anonymous_1)
     {{
         return ref pField-&gt;A;
     }}</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
+          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &amp;Anonymous.Anonymous_1)
     {{
         return ref pField-&gt;B;
     }}</code>
@@ -1413,10 +1413,10 @@ union MyUnion
         <field name=""First"" access=""public"">
           <type native=""long"">int</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" unsafe=""true"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/StructDeclarationTest.cs
@@ -1267,35 +1267,35 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.w, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Struct</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1963,5 +1963,128 @@ struct MyStruct
 ";
 
         return ValidateGeneratedXmlDefaultUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"">
+      <field name=""Anonymous1"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      </field>
+      <field name=""MyArray"" access=""public"">
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous1.First, 1));</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+        <field name=""Second"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
+        <field name=""e0"" access=""public"">
+          <type>_Anonymous2_e__Struct</type>
+        </field>
+        <field name=""e1"" access=""public"">
+          <type>_Anonymous2_e__Struct</type>
+        </field>
+        <indexer access=""public"">
+          <type>ref _Anonymous2_e__Struct</type>
+          <param name=""index"">
+            <type>int</type>
+          </param>
+          <get>
+            <code>return ref AsSpan()[index];</code>
+          </get>
+        </indexer>
+        <function name=""AsSpan"" access=""public"">
+          <type>Span&lt;_Anonymous2_e__Struct&gt;</type>
+          <code>MemoryMarshal.CreateSpan(ref e0, 2);</code>
+        </function>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlDefaultUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"">
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""Value1"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous1_2.Value1, 1));</code>
+        </get>
+      </field>
+      <field name=""Value2"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous2_2.Value2, 1));</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        </field>
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+          <field name=""Anonymous1_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+          </field>
+          <field name=""Anonymous2_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          </field>
+          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+            <field name=""Value1"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+            <field name=""Value2"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlDefaultUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/UnionDeclarationTest.cs
@@ -860,35 +860,35 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.w, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1369,25 +1369,25 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.A, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.A, 1));</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.B, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.B, 1));</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type native=""long"">nint</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/StructDeclarationTest.cs
@@ -1279,35 +1279,35 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.w, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Struct</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1973,5 +1973,128 @@ struct MyStruct3
 ";
 
         return ValidateGeneratedXmlDefaultWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"">
+      <field name=""Anonymous1"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      </field>
+      <field name=""MyArray"" access=""public"">
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous1.First, 1));</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+        <field name=""Second"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
+        <field name=""e0"" access=""public"">
+          <type>_Anonymous2_e__Struct</type>
+        </field>
+        <field name=""e1"" access=""public"">
+          <type>_Anonymous2_e__Struct</type>
+        </field>
+        <indexer access=""public"">
+          <type>ref _Anonymous2_e__Struct</type>
+          <param name=""index"">
+            <type>int</type>
+          </param>
+          <get>
+            <code>return ref AsSpan()[index];</code>
+          </get>
+        </indexer>
+        <function name=""AsSpan"" access=""public"">
+          <type>Span&lt;_Anonymous2_e__Struct&gt;</type>
+          <code>MemoryMarshal.CreateSpan(ref e0, 2);</code>
+        </function>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlDefaultWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"">
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""Value1"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous1_2.Value1, 1));</code>
+        </get>
+      </field>
+      <field name=""Value2"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous2_2.Value2, 1));</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        </field>
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+          <field name=""Anonymous1_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+          </field>
+          <field name=""Anonymous2_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          </field>
+          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+            <field name=""Value1"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+            <field name=""Value2"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlDefaultWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/UnionDeclarationTest.cs
@@ -866,35 +866,35 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.w, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1375,25 +1375,25 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.A, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.A, 1));</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.B, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.B, 1));</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type native=""long"">int</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
@@ -1156,35 +1156,35 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous.w;</code>
+          <code>return ref Anonymous.Anonymous_1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Struct</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1837,5 +1837,115 @@ struct MyStruct
 ";
 
         return ValidateGeneratedXmlLatestUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"">
+      <field name=""Anonymous1"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      </field>
+      <field name=""MyArray"" access=""public"">
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous1.First;</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+        <field name=""Second"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
+        <attribute>InlineArray(2)</attribute>
+        <field name=""e0"" access=""public"">
+          <type>_Anonymous2_e__Struct</type>
+        </field>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"">
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""Value1"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;</code>
+        </get>
+      </field>
+      <field name=""Value2"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        </field>
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+          <field name=""Anonymous1_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+          </field>
+          <field name=""Anonymous2_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          </field>
+          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+            <field name=""Value1"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+            <field name=""Value2"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/UnionDeclarationTest.cs
@@ -749,35 +749,35 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous.w;</code>
+          <code>return ref Anonymous.Anonymous_1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1258,25 +1258,25 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous.A;</code>
+          <code>return ref Anonymous.Anonymous_1.A;</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous.B;</code>
+          <code>return ref Anonymous.Anonymous_1.B;</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type native=""long"">nint</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
@@ -1168,35 +1168,35 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous.w;</code>
+          <code>return ref Anonymous.Anonymous_1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Struct</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1847,5 +1847,115 @@ struct MyStruct3
 ";
 
         return ValidateGeneratedXmlLatestWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"">
+      <field name=""Anonymous1"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      </field>
+      <field name=""MyArray"" access=""public"">
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous1.First;</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+        <field name=""Second"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
+        <attribute>InlineArray(2)</attribute>
+        <field name=""e0"" access=""public"">
+          <type>_Anonymous2_e__Struct</type>
+        </field>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;
+";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"">
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""Value1"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;</code>
+        </get>
+      </field>
+      <field name=""Value2"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        </field>
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+          <field name=""Anonymous1_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+          </field>
+          <field name=""Anonymous2_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          </field>
+          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+            <field name=""Value1"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+            <field name=""Value2"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/UnionDeclarationTest.cs
@@ -755,35 +755,35 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous.w;</code>
+          <code>return ref Anonymous.Anonymous_1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1264,25 +1264,25 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous.A;</code>
+          <code>return ref Anonymous.Anonymous_1.A;</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous.B;</code>
+          <code>return ref Anonymous.Anonymous_1.B;</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type native=""long"">int</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/StructDeclarationTest.cs
@@ -1156,35 +1156,35 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous.w;</code>
+          <code>return ref Anonymous.Anonymous_1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Struct</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1837,5 +1837,113 @@ struct MyStruct
 ";
 
         return ValidateGeneratedXmlPreviewUnixBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"">
+      <field name=""Anonymous1"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      </field>
+      <field name=""MyArray"" access=""public"">
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous1.First;</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+        <field name=""Second"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
+        <attribute>InlineArray(2)</attribute>
+        <field name=""e0"" access=""public"">
+          <type>_Anonymous2_e__Struct</type>
+        </field>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlPreviewUnixBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"">
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""Value1"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;</code>
+        </get>
+      </field>
+      <field name=""Value2"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        </field>
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+          <field name=""Anonymous1_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+          </field>
+          <field name=""Anonymous2_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          </field>
+          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+            <field name=""Value1"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+            <field name=""Value2"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlPreviewUnixBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/UnionDeclarationTest.cs
@@ -749,35 +749,35 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous.w;</code>
+          <code>return ref Anonymous.Anonymous_1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1258,25 +1258,25 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous.A;</code>
+          <code>return ref Anonymous.Anonymous_1.A;</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous.B;</code>
+          <code>return ref Anonymous.Anonymous_1.B;</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type native=""long"">nint</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/StructDeclarationTest.cs
@@ -1168,35 +1168,35 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous.w;</code>
+          <code>return ref Anonymous.Anonymous_1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Struct</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1847,5 +1847,113 @@ struct MyStruct3
 ";
 
         return ValidateGeneratedXmlPreviewWindowsBindingsAsync(InputContents, ExpectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateSourceLocationAttribute);
+    }
+
+    protected override Task AnonStructAndAnonStructArrayImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { int First; };
+    struct { int Second; } MyArray[2];
+} MyStruct;";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"">
+      <field name=""Anonymous1"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      </field>
+      <field name=""MyArray"" access=""public"">
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+      </field>
+      <field name=""First"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous1.First;</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+        <field name=""First"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+        <field name=""Second"" access=""public"">
+          <type>int</type>
+        </field>
+      </struct>
+      <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
+        <attribute>InlineArray(2)</attribute>
+        <field name=""e0"" access=""public"">
+          <type>_Anonymous2_e__Struct</type>
+        </field>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlPreviewWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
+
+    protected override Task DeeplyNestedAnonStructsImpl()
+    {
+        var inputContents = @"typedef struct _MyStruct
+{
+    struct { struct {
+        struct { int Value1; };
+        struct { int Value2; };
+    }; };
+} MyStruct;";
+
+        var expectedOutputContents = @"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>
+<bindings>
+  <namespace name=""ClangSharp.Test"">
+    <struct name=""_MyStruct"" access=""public"">
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
+      </field>
+      <field name=""Value1"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;</code>
+        </get>
+      </field>
+      <field name=""Value2"" access=""public"">
+        <type>ref int</type>
+        <get>
+          <code>return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;</code>
+        </get>
+      </field>
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        </field>
+        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+          <field name=""Anonymous1_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+          </field>
+          <field name=""Anonymous2_2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          </field>
+          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+            <field name=""Value1"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+            <field name=""Value2"" access=""public"">
+              <type>int</type>
+            </field>
+          </struct>
+        </struct>
+      </struct>
+    </struct>
+  </namespace>
+</bindings>
+";
+
+        return ValidateGeneratedXmlPreviewWindowsBindingsAsync(inputContents, expectedOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/UnionDeclarationTest.cs
@@ -755,35 +755,35 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous.w;</code>
+          <code>return ref Anonymous.Anonymous_1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1264,25 +1264,25 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous.A;</code>
+          <code>return ref Anonymous.Anonymous_1.A;</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous.B;</code>
+          <code>return ref Anonymous.Anonymous_1.B;</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type native=""long"">int</type>
         </field>
-        <field name=""Anonymous"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
+        <field name=""Anonymous_1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>


### PR DESCRIPTION
Fixes the following issues with name generation for nested anonymous types:
* A numeral would only be appended if the parent had more than one anonymous records, but an anonymous typed array didn't count as a record resulting in multiple structs named `_Anonymous_e__Struct`.
* The code that remapped the name of anonymous types was different between the code that generated the type definition and the code that defined fields in a `FixedBuffer`.
* When nesting more than one level of anonymous types, the name of the nested type could be the same as the parent type which is not permitted in C# (`error CS0542: '_Anonymous_e__Struct': member names cannot be the same as their enclosing type`).