### PR TITLE
Add Parameter Types to InheritDoc comments

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/FunctionOrDelegateDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/FunctionOrDelegateDesc.cs
@@ -21,6 +21,7 @@ internal struct FunctionOrDelegateDesc
     public bool HasBody { get; set; }
     public bool IsInherited { get; set; }
     public bool NeedsUnscopedRef { get; set; }
+    public string[] ParameterTypes { get; set; }
 
     public bool IsVirtual
     {

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/FunctionOrDelegateDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/FunctionOrDelegateDesc.cs
@@ -21,7 +21,7 @@ internal struct FunctionOrDelegateDesc
     public bool HasBody { get; set; }
     public bool IsInherited { get; set; }
     public bool NeedsUnscopedRef { get; set; }
-    public string[] ParameterTypes { get; set; }
+    public string[]? ParameterTypes { get; set; }
 
     public bool IsVirtual
     {

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -372,6 +372,9 @@ internal partial class CSharpOutputBuilder : IOutputBuilder
                 Write(desc.ParentName);
                 Write('.');
                 Write(desc.EscapedName);
+                Write('(');
+                Write(string.Join(", ", desc.ParameterTypes));
+                Write(')');
                 WriteLine("\" />");
             }
             else

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -372,7 +372,7 @@ internal partial class CSharpOutputBuilder : IOutputBuilder
                 Write(desc.ParentName);
                 Write('.');
                 Write(desc.EscapedName);
-                if (desc.ParameterTypes is not null && desc.ParameterTypes.Length > 0)
+                if (desc.ParameterTypes is not null)
                 {
                     Write('(');
                     Write(string.Join(", ", desc.ParameterTypes));

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -372,9 +372,12 @@ internal partial class CSharpOutputBuilder : IOutputBuilder
                 Write(desc.ParentName);
                 Write('.');
                 Write(desc.EscapedName);
-                Write('(');
-                Write(string.Join(", ", desc.ParameterTypes));
-                Write(')');
+                if (desc.ParameterTypes is not null && desc.ParameterTypes.Length > 0)
+                {
+                    Write('(');
+                    Write(string.Join(", ", desc.ParameterTypes));
+                    Write(')');
+                }
                 WriteLine("\" />");
             }
             else

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -501,12 +501,15 @@ public partial class PInvokeGenerator
         var name = GetRemappedCursorName(functionDecl);
 
         var cxxMethodDecl = functionDecl as CXXMethodDecl;
+        uint overloadCount = 0;
 
         if (cxxMethodDecl is not null and CXXConstructorDecl)
         {
             var parent = cxxMethodDecl.Parent;
             Debug.Assert(parent is not null);
             name = GetRemappedCursorName(parent);
+
+            overloadCount = GetOverloadCount(cxxMethodDecl);
         }
 
         var isManualImport = _config.WithManualImports.Contains(name);
@@ -622,7 +625,7 @@ public partial class PInvokeGenerator
                 }
             },
             CustomAttrGeneratorData = (functionDecl, _outputBuilder, this),
-            ParameterTypes = functionDecl.Parameters.Select(param => GetTargetTypeName(param, out var _)).ToArray(),
+            ParameterTypes = overloadCount > 1 ? functionDecl.Parameters.Select(param => GetTargetTypeName(param, out var _)).ToArray() : null,
         };
         Debug.Assert(_outputBuilder is not null);
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -508,7 +508,10 @@ public partial class PInvokeGenerator
             var parent = cxxMethodDecl.Parent;
             Debug.Assert(parent is not null);
             name = GetRemappedCursorName(parent);
+        }
 
+        if (cxxMethodDecl is not null)
+        {
             overloadCount = GetOverloadCount(cxxMethodDecl);
         }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -622,6 +622,7 @@ public partial class PInvokeGenerator
                 }
             },
             CustomAttrGeneratorData = (functionDecl, _outputBuilder, this),
+            ParameterTypes = functionDecl.Parameters.Select(param => GetTargetTypeName(param, out var _)).ToArray(),
         };
         Debug.Assert(_outputBuilder is not null);
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -3096,6 +3096,39 @@ public sealed partial class PInvokeGenerator : IDisposable
         }
     }
 
+    private uint GetOverloadCount(CXXMethodDecl cxxMethodDeclToMatch)
+    {
+        var parent = cxxMethodDeclToMatch.Parent;
+        Debug.Assert(parent is not null);
+
+        return GetOverloadIndex(cxxMethodDeclToMatch, parent, baseCount: 0);
+
+        uint GetOverloadIndex(CXXMethodDecl cxxMethodDeclToMatch, CXXRecordDecl cxxRecordDecl, uint baseCount)
+        {
+            var count = baseCount;
+
+            foreach (var cxxBaseSpecifier in cxxRecordDecl.Bases)
+            {
+                var baseCxxRecordDecl = GetRecordDecl(cxxBaseSpecifier);
+                count = GetOverloadIndex(cxxMethodDeclToMatch, baseCxxRecordDecl, count);
+            }
+
+            foreach (var cxxMethodDecl in cxxRecordDecl.Methods)
+            {
+                if (IsExcluded(cxxMethodDecl))
+                {
+                    continue;
+                }
+                else if (cxxMethodDecl.Name == cxxMethodDeclToMatch.Name)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+    }
+
     private CXXRecordDecl GetRecordDecl(CXXBaseSpecifier cxxBaseSpecifier)
     {
         var baseType = cxxBaseSpecifier.Type;


### PR DESCRIPTION
InheritDoc comments were ambiguous between different overrides so this will specify which override we are to inherit from.