### PR TITLE
Add DontUseUsingStaticsForGuidMember

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1411,7 +1411,15 @@ public partial class PInvokeGenerator
                     var className = GetClass(uuidName);
 
                     _testOutputBuilder.AddUsingDirective("System");
-                    _testOutputBuilder.AddUsingDirective($"static {GetNamespace(className)}.{className}");
+
+                    if (_config.DontUseUsingStaticsForGuidMember)
+                    {
+                        _testOutputBuilder.AddUsingDirective($"{GetNamespace(className)}");
+                    }
+                    else
+                    {
+                        _testOutputBuilder.AddUsingDirective($"static {GetNamespace(className)}.{className}");
+                    }
 
                     _testOutputBuilder.WriteIndented("/// <summary>Validates that the <see cref=\"Guid\" /> of the <see cref=\"");
                     _testOutputBuilder.Write(escapedName);
@@ -1440,7 +1448,13 @@ public partial class PInvokeGenerator
                         _testOutputBuilder.Write("Is.EqualTo(");
                     }
 
-                    _testOutputBuilder.Write(uuidName);
+                    var usableUuidName = uuidName;
+                    if (_config.DontUseUsingStaticsForGuidMember)
+                    {
+                        usableUuidName = $"{className}.{usableUuidName}";
+                    }
+
+                    _testOutputBuilder.Write(usableUuidName);
 
                     if (_config.GenerateTestsNUnit)
                     {
@@ -1626,12 +1640,26 @@ public partial class PInvokeGenerator
                 _outputBuilder.EmitUsingDirective("System");
                 _outputBuilder.EmitUsingDirective("System.Runtime.CompilerServices");
 
-                _outputBuilder.EmitUsingDirective($"static {GetNamespace(uuidClassName)}.{uuidClassName}");
+                if (_config.DontUseUsingStaticsForGuidMember)
+                {
+                    _outputBuilder.EmitUsingDirective($"{GetNamespace(uuidClassName)}");
+                }
+                else
+                {
+                    _outputBuilder.EmitUsingDirective($"static {GetNamespace(uuidClassName)}.{uuidClassName}");
+                }
+
+                var usableUuidName = uuidName;
+                if (_config.DontUseUsingStaticsForGuidMember)
+                {
+                    usableUuidName = $"{uuidClassName}.{usableUuidName}";
+                }
+
                 _outputBuilder.BeginValue(in valueDesc);
 
                 var code = _outputBuilder.BeginCSharpCode();
                 code.Write("(Guid*)Unsafe.AsPointer(ref Unsafe.AsRef(in ");
-                code.Write(uuidName);
+                code.Write(usableUuidName);
                 code.Write("))");
                 _outputBuilder.EndCSharpCode(code);
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -267,6 +267,8 @@ public sealed class PInvokeGeneratorConfiguration
 
     public bool StripEnumMemberTypeName => _options.HasFlag(PInvokeGeneratorConfigurationOptions.StripEnumMemberTypeName);
 
+    public bool DontUseUsingStaticsForGuidMember => _options.HasFlag(PInvokeGeneratorConfigurationOptions.DontUseUsingStaticsForGuidMember);
+
     public string HeaderText => _headerText;
 
     [AllowNull]

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -88,4 +88,6 @@ public enum PInvokeGeneratorConfigurationOptions : long
     GenerateGenericPointerWrapper = 1L << 38,
 
     StripEnumMemberTypeName = 1L << 39,
+
+    DontUseUsingStaticsForGuidMember = 1L << 40,
 }

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -444,6 +444,13 @@ public static class Program
                     break;
                 }
 
+                case "exclude-using-statics-for-guid-members":
+                case "dont-use-using-statics-for-guid-members":
+                {
+                    configOptions |= PInvokeGeneratorConfigurationOptions.DontUseUsingStaticsForGuidMember;
+                    break;
+                }
+
                 // VTBL Options
 
                 case "explicit-vtbls":


### PR DESCRIPTION
This causes some issues with some renaming in Silk.NET and would like to toggle it off.