### PR TITLE
Fix compile error when generating code involving unsigned int bitshifts

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -42,7 +42,7 @@ public partial class PInvokeGenerator
         outputBuilder.Write(binaryOperator.OpcodeStr);
         outputBuilder.Write(' ');
 
-        if (binaryOperator.IsShiftOp || binaryOperator.IsShiftAssignOp)
+        if ((binaryOperator.IsShiftOp || binaryOperator.IsShiftAssignOp) && binaryOperator.RHS.Type.Kind != CXType_Int)
         {
             // RHS of shift operation in C# must be an int
             outputBuilder.Write("(int)");

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -41,7 +41,22 @@ public partial class PInvokeGenerator
         outputBuilder.Write(' ');
         outputBuilder.Write(binaryOperator.OpcodeStr);
         outputBuilder.Write(' ');
-        Visit(binaryOperator.RHS);
+
+        if (binaryOperator.IsShiftOp || binaryOperator.IsShiftAssignOp)
+        {
+            // RHS of shift operation in C# must be an int
+            outputBuilder.Write("(int)");
+            outputBuilder.Write('(');
+
+            Visit(binaryOperator.RHS);
+
+            outputBuilder.Write(')');
+        }
+        else
+        {
+            Visit(binaryOperator.RHS);
+        }
+
         StopCSharpCode();
     }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -45,21 +45,49 @@ public partial class PInvokeGenerator
         if (binaryOperator.IsShiftOp || binaryOperator.IsShiftAssignOp)
         {
             // RHS of shift operation in C# must be an int
-            if (binaryOperator.RHS.Type.Kind is CXType_Int || (binaryOperator.RHS.Type.Kind is CXType_Long && !_config.GenerateUnixTypes))
-            {
-                Visit(binaryOperator.RHS);
-            }
-            else if (binaryOperator.RHS is IntegerLiteral literal)
-            {
-                outputBuilder.Write(literal.Value);
-            }
-            else
-            {
-                outputBuilder.Write("(int)");
 
-                outputBuilder.Write('(');
-                Visit(binaryOperator.RHS);
-                outputBuilder.Write(')');
+            // Negative shifts are undefined behavior in C/C++, but still needs to have a compilable output
+            var isNegated = binaryOperator.RHS is UnaryOperator { Opcode: CXUnaryOperator_Minus };
+            var sign = isNegated ? -1 : 1;
+
+            var rhs = isNegated ? ((UnaryOperator)binaryOperator.RHS).SubExpr : binaryOperator.RHS;
+            switch (rhs)
+            {
+                case IntegerLiteral literal:
+                {
+                    var value = sign * literal.Value;
+                    if (value is > int.MaxValue or < int.MinValue)
+                    {
+                        // Literal is in int32 range
+                        outputBuilder.Write("(int)(");
+                        outputBuilder.Write(sign * literal.Value);
+                        outputBuilder.Write(")");
+                    }
+                    else
+                    {
+                        // Literal is not in int32 range
+                        outputBuilder.Write(sign * literal.Value);
+                    }
+
+                    break;
+                }
+                // Already the correct type or implicitly castable
+                case { Type.Kind: CXType_Int or CXType_UShort or CXType_Short or CXType_Char_U or CXType_Char_S or CXType_UChar or CXType_SChar }:
+                case { Type.Kind: CXType_Long } when _config is { GenerateUnixTypes: false }:
+                case { Type.Kind: CXType_Char16 } when _config is { GenerateDisableRuntimeMarshalling: false }:
+                case { Type.Kind: CXType_WChar } when _config is { GenerateDisableRuntimeMarshalling: false, GenerateUnixTypes: false }:
+                {
+                    Visit(binaryOperator.RHS);
+                    break;
+                }
+                // Fallback
+                default:
+                {
+                    outputBuilder.Write("(int)(");
+                    Visit(binaryOperator.RHS);
+                    outputBuilder.Write(")");
+                    break;
+                }
             }
         }
         else

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -45,7 +45,7 @@ public partial class PInvokeGenerator
         if (binaryOperator.IsShiftOp || binaryOperator.IsShiftAssignOp)
         {
             // RHS of shift operation in C# must be an int
-            if (binaryOperator.RHS.Type.Kind is CXType_Int or CXType_Long)
+            if (binaryOperator.RHS.Type.Kind is CXType_Int || (binaryOperator.RHS.Type.Kind is CXType_Long && !_config.GenerateUnixTypes))
             {
                 Visit(binaryOperator.RHS);
             }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -42,15 +42,25 @@ public partial class PInvokeGenerator
         outputBuilder.Write(binaryOperator.OpcodeStr);
         outputBuilder.Write(' ');
 
-        if ((binaryOperator.IsShiftOp || binaryOperator.IsShiftAssignOp) && binaryOperator.RHS.Type.Kind != CXType_Int)
+        if (binaryOperator.IsShiftOp || binaryOperator.IsShiftAssignOp)
         {
             // RHS of shift operation in C# must be an int
-            outputBuilder.Write("(int)");
-            outputBuilder.Write('(');
+            if (binaryOperator.RHS.Type.Kind is CXType_Int or CXType_Long)
+            {
+                Visit(binaryOperator.RHS);
+            }
+            else if (binaryOperator.RHS is IntegerLiteral literal)
+            {
+                outputBuilder.Write(literal.Value);
+            }
+            else
+            {
+                outputBuilder.Write("(int)");
 
-            Visit(binaryOperator.RHS);
-
-            outputBuilder.Write(')');
+                outputBuilder.Write('(');
+                Visit(binaryOperator.RHS);
+                outputBuilder.Write(')');
+            }
         }
         else
         {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -283,39 +283,67 @@ namespace ClangSharp.Test
     [Test]
     public Task UnsignedIntBitshiftTest()
     {
-        var inputContents = @"#define LEFT 1 << 1U
-#define RIGHT 1 >> 1U
-#define INT 1 << 1
-#define LONG 1 << 1L
-#define LONGLONG 1 << 1LL
-#define ULONG 1 << 1UL
-#define ULONGLONG 1 << 1ULL
+        var inputContents = @"
+const int Signed = 1;
+const unsigned int Unsigned = 1U;
+
+const int ShiftSigned = 1 << Signed;
+const int ShiftUnsigned = 1 << Unsigned;
+
+const int CInt = 1 << 1;
+const int CUint = 1 << 1U;
+
+#define Left 1 << 1U
+#define Right 1 >> 1U
+#define Int 1 << 1
+#define Long 1 << 1L
+#define LongLong 1 << 1LL
+#define ULong 1 << 1UL
+#define ULongLong 1 << 1ULL
 ";
 
         var expectedOutputContents = @"namespace ClangSharp.Test
 {
     public static partial class Methods
     {
-        [NativeTypeName(""#define LEFT 1 << 1U"")]
-        public const int LEFT = 1 << (int)(1U);
+        [NativeTypeName(""const int"")]
+        public const int Signed = 1;
 
-        [NativeTypeName(""#define RIGHT 1 >> 1U"")]
-        public const int RIGHT = 1 >> (int)(1U);
+        [NativeTypeName(""const unsigned int"")]
+        public const uint Unsigned = 1U;
 
-        [NativeTypeName(""#define INT 1 << 1"")]
-        public const int INT = 1 << 1;
+        [NativeTypeName(""const int"")]
+        public const int ShiftSigned = 1 << Signed;
 
-        [NativeTypeName(""#define LONG 1 << 1L"")]
-        public const int LONG = 1 << (int)(1);
+        [NativeTypeName(""const int"")]
+        public const int ShiftUnsigned = 1 << (int)(Unsigned);
 
-        [NativeTypeName(""#define LONGLONG 1 << 1LL"")]
-        public const int LONGLONG = 1 << (int)(1L);
+        [NativeTypeName(""const int"")]
+        public const int CInt = 1 << 1;
 
-        [NativeTypeName(""#define ULONG 1 << 1UL"")]
-        public const int ULONG = 1 << (int)(1U);
+        [NativeTypeName(""const int"")]
+        public const int CUint = 1 << (int)(1U);
 
-        [NativeTypeName(""#define ULONGLONG 1 << 1ULL"")]
-        public const int ULONGLONG = 1 << (int)(1UL);
+        [NativeTypeName(""#define Left 1 << 1U"")]
+        public const int Left = 1 << (int)(1U);
+
+        [NativeTypeName(""#define Right 1 >> 1U"")]
+        public const int Right = 1 >> (int)(1U);
+
+        [NativeTypeName(""#define Int 1 << 1"")]
+        public const int Int = 1 << 1;
+
+        [NativeTypeName(""#define Long 1 << 1L"")]
+        public const int Long = 1 << (int)(1);
+
+        [NativeTypeName(""#define LongLong 1 << 1LL"")]
+        public const int LongLong = 1 << (int)(1L);
+
+        [NativeTypeName(""#define ULong 1 << 1UL"")]
+        public const int ULong = 1 << (int)(1U);
+
+        [NativeTypeName(""#define ULongLong 1 << 1ULL"")]
+        public const int ULongLong = 1 << (int)(1UL);
     }
 }
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -283,14 +283,18 @@ namespace ClangSharp.Test
     [Test]
     public Task UnsignedIntBitshiftTest()
     {
-        var inputContents = @"#define BITSHIFT 1 << 1U";
+        var inputContents = @"#define LEFT 1 << 1U
+#define RIGHT 1 >> 1U";
 
         var expectedOutputContents = @"namespace ClangSharp.Test
 {
     public static partial class Methods
     {
-        [NativeTypeName(""#define BITSHIFT 1 << 1U"")]
-        public const int BITSHIFT = 1 << (int)(1U);
+        [NativeTypeName(""#define LEFT 1 << 1U"")]
+        public const int LEFT = 1 << (int)(1U);
+
+        [NativeTypeName(""#define RIGHT 1 >> 1U"")]
+        public const int RIGHT = 1 >> (int)(1U);
     }
 }
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -328,7 +328,7 @@ const int Hexadecimal = 1 << 0x01;
 ";
 
         // Non-ideal cases:
-        // UChar
+        // UByte
         // IntMin
         // ULongMax
         // Hexadecimal

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -297,11 +297,14 @@ const int CUint = 1 << 1U;
 
 #define Left 1 << 1U
 #define Right 1 >> 1U
+
 #define Int 1 << 1
 #define Long 1 << 1L
 #define LongLong 1 << 1LL
 #define ULong 1 << 1UL
 #define ULongLong 1 << 1ULL
+
+#define Complex ((((unsigned int)(0)) << 29U) | (((unsigned int)(1)) << 22U) | (((unsigned int)(0)) << 12U) | ((unsigned int)(0)))
 ";
 
         var expectedOutputContents = @"namespace ClangSharp.Test
@@ -352,6 +355,9 @@ const int CUint = 1 << 1U;
 
         [NativeTypeName(""#define ULongLong 1 << 1ULL"")]
         public const int ULongLong = 1 << 1;
+
+        [NativeTypeName(""#define Complex ((((unsigned int)(0)) << 29U) | (((unsigned int)(1)) << 22U) | (((unsigned int)(0)) << 12U) | ((unsigned int)(0)))"")]
+        public const uint Complex = ((((uint)(0)) << 29) | (((uint)(1)) << 22) | (((uint)(0)) << 12) | ((uint)(0)));
     }
 }
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -292,8 +292,26 @@ const int ShiftSigned = 1 << Signed;
 const int ShiftSignedLong = 1 << SignedLong;
 const int ShiftUnsigned = 1 << Unsigned;
 
+const int Char = 1 << (signed char)1;
+const int UChar = 1 << (unsigned char)1;
+
 const int CInt = 1 << 1;
 const int CUint = 1 << 1U;
+
+const int Negative = 1 << -1;
+
+const int OutOfRangePos = 1 << 10000000000;
+const int OutOfRangeNeg = 1 << -10000000000;
+
+const int IntMax = 1 << 2147483647;
+const int IntMin = 1 << -2147483648;
+
+const int LongMax = 1 << 9223372036854775807;
+const int LongMin = 1 << -9223372036854775808;
+
+const int ULongMax = 1 << 18446744073709551615;
+
+const int Hexadecimal = 1 << 0x01;
 
 #define Left 1 << 1U
 #define Right 1 >> 1U
@@ -307,6 +325,11 @@ const int CUint = 1 << 1U;
 #define Complex ((((unsigned int)(0)) << 29U) | (((unsigned int)(1)) << 22U) | (((unsigned int)(0)) << 12U) | ((unsigned int)(0)))
 ";
 
+        // Non-ideal cases:
+        // UChar
+        // IntMin
+        // ULongMax
+        // Hexadecimal
         var expectedOutputContents = @"namespace ClangSharp.Test
 {
     public static partial class Methods
@@ -330,10 +353,43 @@ const int CUint = 1 << 1U;
         public const int ShiftUnsigned = 1 << (int)(Unsigned);
 
         [NativeTypeName(""const int"")]
+        public const int Char = 1 << (sbyte)(1);
+
+        [NativeTypeName(""const int"")]
+        public const int UChar = unchecked(1 << (byte)(1));
+
+        [NativeTypeName(""const int"")]
         public const int CInt = 1 << 1;
 
         [NativeTypeName(""const int"")]
         public const int CUint = 1 << 1;
+
+        [NativeTypeName(""const int"")]
+        public const int Negative = 1 << -1;
+
+        [NativeTypeName(""const int"")]
+        public const int OutOfRangePos = unchecked(1 << (int)(10000000000));
+
+        [NativeTypeName(""const int"")]
+        public const int OutOfRangeNeg = unchecked(1 << (int)(-10000000000));
+
+        [NativeTypeName(""const int"")]
+        public const int IntMax = 1 << 2147483647;
+
+        [NativeTypeName(""const int"")]
+        public const int IntMin = unchecked(1 << -2147483648);
+
+        [NativeTypeName(""const int"")]
+        public const int LongMax = unchecked(1 << (int)(9223372036854775807));
+
+        [NativeTypeName(""const int"")]
+        public const int LongMin = unchecked(1 << (int)(-9223372036854775808));
+
+        [NativeTypeName(""const int"")]
+        public const int ULongMax = 1 << -1;
+
+        [NativeTypeName(""const int"")]
+        public const int Hexadecimal = 1 << 1;
 
         [NativeTypeName(""#define Left 1 << 1U"")]
         public const int Left = 1 << 1;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -279,4 +279,22 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, commandLineArgs: DefaultCClangCommandLineArgs, language: "c", languageStandard: DefaultCStandard);
     }
+
+    [Test]
+    public Task UnsignedIntBitshiftTest()
+    {
+        var inputContents = @"#define BITSHIFT 1 << 1U";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [NativeTypeName(""#define BITSHIFT 1 << 1U"")]
+        public const int BITSHIFT = 1 << (int)(1U);
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, commandLineArgs: DefaultCClangCommandLineArgs, language: "c", languageStandard: DefaultCStandard);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -284,7 +284,13 @@ namespace ClangSharp.Test
     public Task UnsignedIntBitshiftTest()
     {
         var inputContents = @"#define LEFT 1 << 1U
-#define RIGHT 1 >> 1U";
+#define RIGHT 1 >> 1U
+#define INT 1 << 1
+#define LONG 1 << 1L
+#define LONGLONG 1 << 1LL
+#define ULONG 1 << 1UL
+#define ULONGLONG 1 << 1ULL
+";
 
         var expectedOutputContents = @"namespace ClangSharp.Test
 {
@@ -295,6 +301,21 @@ namespace ClangSharp.Test
 
         [NativeTypeName(""#define RIGHT 1 >> 1U"")]
         public const int RIGHT = 1 >> (int)(1U);
+
+        [NativeTypeName(""#define INT 1 << 1"")]
+        public const int INT = 1 << 1;
+
+        [NativeTypeName(""#define LONG 1 << 1L"")]
+        public const int LONG = 1 << (int)(1);
+
+        [NativeTypeName(""#define LONGLONG 1 << 1LL"")]
+        public const int LONGLONG = 1 << (int)(1L);
+
+        [NativeTypeName(""#define ULONG 1 << 1UL"")]
+        public const int ULONG = 1 << (int)(1U);
+
+        [NativeTypeName(""#define ULONGLONG 1 << 1ULL"")]
+        public const int ULONGLONG = 1 << (int)(1UL);
     }
 }
 ";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -425,4 +425,29 @@ const int Hexadecimal = 1 << 0x01;
 
         return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, commandLineArgs: DefaultCClangCommandLineArgs, language: "c", languageStandard: DefaultCStandard);
     }
+
+
+    [Test]
+    public Task UnsignedIntBitshiftTestUnix()
+    {
+        var inputContents = @"
+const long SignedLong = 1;
+const int ShiftSignedLong = 1 << SignedLong;
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [NativeTypeName(""const long"")]
+        public const nint SignedLong = 1;
+
+        [NativeTypeName(""const int"")]
+        public const int ShiftSignedLong = 1 << (int)(SignedLong);
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents, commandLineArgs: DefaultCClangCommandLineArgs, language: "c", languageStandard: DefaultCStandard);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -292,8 +292,10 @@ const int ShiftSigned = 1 << Signed;
 const int ShiftSignedLong = 1 << SignedLong;
 const int ShiftUnsigned = 1 << Unsigned;
 
-const int Char = 1 << (signed char)1;
-const int UChar = 1 << (unsigned char)1;
+const int Char = 1 << 'a';
+
+const int Byte = 1 << (signed char)1;
+const int UByte = 1 << (unsigned char)1;
 
 const int CInt = 1 << 1;
 const int CUint = 1 << 1U;
@@ -353,10 +355,13 @@ const int Hexadecimal = 1 << 0x01;
         public const int ShiftUnsigned = 1 << (int)(Unsigned);
 
         [NativeTypeName(""const int"")]
-        public const int Char = 1 << (sbyte)(1);
+        public const int Char = 1 << (sbyte)('a');
 
         [NativeTypeName(""const int"")]
-        public const int UChar = unchecked(1 << (byte)(1));
+        public const int Byte = 1 << (sbyte)(1);
+
+        [NativeTypeName(""const int"")]
+        public const int UByte = unchecked(1 << (byte)(1));
 
         [NativeTypeName(""const int"")]
         public const int CInt = 1 << 1;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -285,9 +285,11 @@ namespace ClangSharp.Test
     {
         var inputContents = @"
 const int Signed = 1;
-const unsigned int Unsigned = 1U;
+const long SignedLong = 1;
+const unsigned int Unsigned = 1;
 
 const int ShiftSigned = 1 << Signed;
+const int ShiftSignedLong = 1 << SignedLong;
 const int ShiftUnsigned = 1 << Unsigned;
 
 const int CInt = 1 << 1;
@@ -309,11 +311,17 @@ const int CUint = 1 << 1U;
         [NativeTypeName(""const int"")]
         public const int Signed = 1;
 
+        [NativeTypeName(""const long"")]
+        public const int SignedLong = 1;
+
         [NativeTypeName(""const unsigned int"")]
-        public const uint Unsigned = 1U;
+        public const uint Unsigned = 1;
 
         [NativeTypeName(""const int"")]
         public const int ShiftSigned = 1 << Signed;
+
+        [NativeTypeName(""const int"")]
+        public const int ShiftSignedLong = 1 << SignedLong;
 
         [NativeTypeName(""const int"")]
         public const int ShiftUnsigned = 1 << (int)(Unsigned);
@@ -322,28 +330,28 @@ const int CUint = 1 << 1U;
         public const int CInt = 1 << 1;
 
         [NativeTypeName(""const int"")]
-        public const int CUint = 1 << (int)(1U);
+        public const int CUint = 1 << 1;
 
         [NativeTypeName(""#define Left 1 << 1U"")]
-        public const int Left = 1 << (int)(1U);
+        public const int Left = 1 << 1;
 
         [NativeTypeName(""#define Right 1 >> 1U"")]
-        public const int Right = 1 >> (int)(1U);
+        public const int Right = 1 >> 1;
 
         [NativeTypeName(""#define Int 1 << 1"")]
         public const int Int = 1 << 1;
 
         [NativeTypeName(""#define Long 1 << 1L"")]
-        public const int Long = 1 << (int)(1);
+        public const int Long = 1 << 1;
 
         [NativeTypeName(""#define LongLong 1 << 1LL"")]
-        public const int LongLong = 1 << (int)(1L);
+        public const int LongLong = 1 << 1;
 
         [NativeTypeName(""#define ULong 1 << 1UL"")]
-        public const int ULong = 1 << (int)(1U);
+        public const int ULong = 1 << 1;
 
         [NativeTypeName(""#define ULongLong 1 << 1ULL"")]
-        public const int ULongLong = 1 << (int)(1UL);
+        public const int ULongLong = 1 << 1;
     }
 }
 ";


### PR DESCRIPTION
This fixes https://github.com/dotnet/ClangSharp/issues/611.

~~This changes it so that the right-hand side of bitshifts always gets casted to an int.
This works because C# only accepts ints as the RHS of bitshifts: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/expressions#1211-shift-operators~~

~~Note: This leads to widespread changes in how the bitshift operator is output (see test cases). If necessary, I can look into a less invasive approach. The reasoning for doing this globally is to keep things consistent and the extra cast shouldn't affect anything other than adding a bit of bloat to the generated code.~~

This now casts only if the RHS is a non-literal, non-`int` expression. Otherwise, the literal or expression is used directly.

