### PR TITLE
Adjust how nested anonymous record naming conflicts are resolved

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -872,7 +872,7 @@ public partial class PInvokeGenerator
             return;
         }
 
-        if (IsPrevContextDecl<RecordDecl>(out var prevContext, out _) && prevContext.IsAnonymous)
+        if (IsPrevContextDecl<RecordDecl>(out var prevContext, out _) && prevContext.IsAnonymousStructOrUnion)
         {
             // We shouldn't process indirect fields where the prev context is an anonymous record decl
             return;
@@ -887,7 +887,7 @@ public partial class PInvokeGenerator
         var contextNameParts = new Stack<string>();
         var contextTypeParts = new Stack<string>();
 
-        while (rootRecordDecl.IsAnonymous && (rootRecordDecl.Parent is RecordDecl parentRecordDecl))
+        while (rootRecordDecl.IsAnonymousStructOrUnion && (rootRecordDecl.Parent is RecordDecl parentRecordDecl))
         {
             // The name of a field of an anonymous type should be same as the type's name minus the
             // type kind tag at the end and the leading `_`.
@@ -1390,7 +1390,7 @@ public partial class PInvokeGenerator
             var maxAlignm = recordDecl.Fields.Any() ? recordDecl.Fields.Max((fieldDecl) => Math.Max(fieldDecl.Type.Handle.AlignOf, 1)) : alignment;
 
             var isTopLevelStruct = _config.WithTypes.TryGetValue(name, out var withType) && withType.Equals("struct", StringComparison.Ordinal);
-            var generateTestsClass = !recordDecl.IsAnonymous && recordDecl.DeclContext is not RecordDecl;
+            var generateTestsClass = !recordDecl.IsAnonymousStructOrUnion && recordDecl.DeclContext is not RecordDecl;
             var testOutputStarted = false;
 
             var nullableUuid = (Guid?)null;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -3210,7 +3210,7 @@ public sealed partial class PInvokeGenerator : IDisposable
         }
         else if ((namedDecl is FieldDecl fieldDecl) && name.StartsWith("__AnonymousFieldDecl_", StringComparison.Ordinal))
         {
-            if (fieldDecl.Type.AsCXXRecordDecl?.IsAnonymous == true)
+            if (fieldDecl.Type.AsCXXRecordDecl?.IsAnonymousStructOrUnion == true)
             {
                 // For fields of anonymous types, use the name of the type but clean off the type
                 // kind tag at the end.
@@ -3242,12 +3242,72 @@ public sealed partial class PInvokeGenerator : IDisposable
         return remappedName;
     }
 
+    private static int GetAnonymousRecordIndex(RecordDecl recordDecl, RecordDecl parentRecordDecl)
+    {
+        var index = -1;
+        var parentAnonRecordCount = parentRecordDecl.AnonymousRecords.Count;
+
+        if (parentAnonRecordCount != 0)
+        {
+            index = parentRecordDecl.AnonymousRecords.IndexOf(recordDecl);
+
+            if (index != -1)
+            {
+                if (parentAnonRecordCount > 1)
+                {
+                    index++;
+                }
+
+                if (parentRecordDecl.Parent is RecordDecl grandParentRecordDecl)
+                {
+                    var parentIndex = GetAnonymousRecordIndex(parentRecordDecl, grandParentRecordDecl);
+
+                    // We can't have the nested anonymous record have the same name as the parent
+                    // so skip that index and just go one higher instead. This could still conflict
+                    // with another anonymous record at a different level, but that is less likely
+                    // and will still be unambiguous in total.
+
+                    if (parentIndex == index)
+                    {
+                        if (recordDecl.IsUnion == parentRecordDecl.IsUnion)
+                        {
+                            index++;
+                        }
+                    }
+                    else if ((parentIndex != 0) && (index > parentIndex))
+                    {
+                        if (recordDecl.IsUnion == parentRecordDecl.AnonymousRecords[parentIndex].IsUnion)
+                        {
+                            index++;
+                        }
+                    }
+                }
+            }
+        }
+
+        return index;
+    }
+
     private string GetRemappedNameForAnonymousRecord(RecordDecl recordDecl)
     {
         if (recordDecl.Parent is RecordDecl parentRecordDecl)
         {
             var remappedNameBuilder = new StringBuilder();
-            var matchingField = parentRecordDecl.Fields.Where((fieldDecl) => fieldDecl.Type.CanonicalType == recordDecl.TypeForDecl.CanonicalType).FirstOrDefault();
+            var matchingField = null as FieldDecl;
+
+            if (!recordDecl.IsAnonymousStructOrUnion)
+            {
+                matchingField = parentRecordDecl.Fields.Where((fieldDecl) => {
+                    var fieldType = fieldDecl.Type.CanonicalType;
+
+                    if (fieldType is ArrayType arrayType)
+                    {
+                        fieldType = arrayType.ElementType.CanonicalType;
+                    }
+
+                    return fieldType == recordDecl.TypeForDecl.CanonicalType;
+                }).FirstOrDefault();
+            }
 
             if ((matchingField is not null) && !matchingField.IsAnonymousField)
             {
@@ -3258,28 +3318,11 @@ public sealed partial class PInvokeGenerator : IDisposable
             {
                 _ = remappedNameBuilder.Append("_Anonymous");
 
-                // If there is more than one anonymous type, then add a numeral to differentiate.
-                if (parentRecordDecl.AnonymousRecords.Count > 1)
-                {
-                    var index = parentRecordDecl.AnonymousRecords.IndexOf(recordDecl) + 1;
-                    Debug.Assert(index > 0);
-                    _ = remappedNameBuilder.Append(index);
-                }
+                var index = GetAnonymousRecordIndex(recordDecl, parentRecordDecl);
 
-                // C# doesn't allow a nested type to have the same name as the parent, so if the
-                // parent is also anonymous, add the nesting depth as a way to avoid conflicts with
-                // the parent's name.
-                if (parentRecordDecl.IsAnonymous)
+                if (index != 0)
                 {
-                    var depth = 1;
-                    var currentParent = parentRecordDecl.Parent;
-                    while ((currentParent is RecordDecl currentParentRecordDecl) && currentParentRecordDecl.IsAnonymous)
-                    {
-                        depth++;
-                        currentParent = currentParentRecordDecl.Parent;
-                    }
-                    _ = remappedNameBuilder.Append('_');
-                    _ = remappedNameBuilder.Append(depth);
+                    _ = remappedNameBuilder.Append(index);
                 }
             }
 
@@ -4625,7 +4668,7 @@ public sealed partial class PInvokeGenerator : IDisposable
 
     private bool HasField(RecordDecl recordDecl)
     {
-        var hasField = recordDecl.Fields.Any() || recordDecl.Decls.Any((decl) => (decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymous && HasField(nestedRecordDecl));
+        var hasField = recordDecl.Fields.Any() || recordDecl.Decls.Any((decl) => (decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymousStructOrUnion && HasField(nestedRecordDecl));
 
         if (!hasField && (recordDecl is CXXRecordDecl cxxRecordDecl))
         {
@@ -5170,7 +5213,7 @@ public sealed partial class PInvokeGenerator : IDisposable
 
             foreach (var decl in recordDecl.Decls)
             {
-                if ((decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymous && !IsEmptyRecord(nestedRecordDecl))
+                if ((decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymousStructOrUnion && !IsEmptyRecord(nestedRecordDecl))
                 {
                     return false;
                 }
@@ -6195,7 +6238,7 @@ public sealed partial class PInvokeGenerator : IDisposable
             {
                 return true;
             }
-            else if ((decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymous && (IsUnsafe(nestedRecordDecl) || Config.GenerateCompatibleCode))
+            else if ((decl is RecordDecl nestedRecordDecl) && nestedRecordDecl.IsAnonymousStructOrUnion && (IsUnsafe(nestedRecordDecl) || Config.GenerateCompatibleCode))
             {
                 return true;
             }

--- a/sources/ClangSharp/Cursors/Decls/RecordDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/RecordDecl.cs
@@ -36,12 +36,12 @@ public class RecordDecl : TagDecl
 
         _fields = LazyList.Create<FieldDecl>(Handle.NumFields, (i) => TranslationUnit.GetOrCreate<FieldDecl>(Handle.GetField(unchecked((uint)i))));
         _anonymousFields = new ValueLazy<List<FieldDecl>>(() => [.. Decls.OfType<FieldDecl>().Where(decl => decl.IsAnonymousField)]);
-        _anonymousRecords = new ValueLazy<List<RecordDecl>>(() => [.. Decls.OfType<RecordDecl>().Where(decl => decl.IsAnonymous && !decl.IsInjectedClassName)]);
+        _anonymousRecords = new ValueLazy<List<RecordDecl>>(() => [.. Decls.OfType<RecordDecl>().Where(decl => decl.IsAnonymousStructOrUnion && !decl.IsInjectedClassName)]);
         _indirectFields = new ValueLazy<List<IndirectFieldDecl>>(() => [.. Decls.OfType<IndirectFieldDecl>()]);
         _injectedClassName = new ValueLazy<RecordDecl?>(() => Decls.OfType<RecordDecl>().Where(decl => decl.IsInjectedClassName).SingleOrDefault());
     }
 
-    public bool IsAnonymous => Handle.IsAnonymous;
+    public bool IsAnonymousStructOrUnion => Handle.IsAnonymousStructOrUnion;
 
     public IReadOnlyList<FieldDecl> AnonymousFields => _anonymousFields.Value;
 

--- a/sources/ClangSharpPInvokeGenerator/Properties/launchSettings.json
+++ b/sources/ClangSharpPInvokeGenerator/Properties/launchSettings.json
@@ -12,7 +12,7 @@
     "GenerateLocal": {
       "commandName": "Project",
       "commandLineArgs": "@generate.rsp",
-      "workingDirectory": "D:\\Users\\tagoo\\source\\repos\\terrafx.interop.windows\\generation\\Windows\\um\\sapi"
+      "workingDirectory": "D:\\repos\\terrafx.interop.windows\\generation\\DirectX\\um\\dcommon"
     }
   }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/StructDeclarationTest.cs
@@ -1161,7 +1161,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous2_1_e__Struct* pField = &Anonymous.Anonymous2_1)
+                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct* pField = &Anonymous.Anonymous1)
                 {{
                     return ref pField->value1;
                 }}
@@ -1172,7 +1172,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous2_1_e__Struct._Anonymous_2_e__Struct* pField = &Anonymous.Anonymous2_1.Anonymous_2)
+                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct._Anonymous_e__Struct* pField = &Anonymous.Anonymous1.Anonymous)
                 {{
                     return ref pField->value;
                 }}
@@ -1183,7 +1183,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous3_1_e__Union* pField = &Anonymous.Anonymous3_1)
+                fixed (_Anonymous_e__Struct._Anonymous2_e__Union* pField = &Anonymous.Anonymous2)
                 {{
                     return ref pField->value2;
                 }}
@@ -1231,10 +1231,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous2_1_e__Struct Anonymous2_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous3_1_e__Union Anonymous3_1;
+            public _Anonymous2_e__Union Anonymous2;
 
             public MyUnion u;
 
@@ -1249,21 +1249,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public unsafe partial struct _Anonymous2_1_e__Struct
+            public unsafe partial struct _Anonymous1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_2_e__Struct Anonymous_2;
+                public _Anonymous_e__Struct Anonymous;
 
-                public partial struct _Anonymous_2_e__Struct
+                public partial struct _Anonymous_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous3_1_e__Union
+            public partial struct _Anonymous2_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1342,7 +1342,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct* pField = &Anonymous.Anonymous_1)
+                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct* pField = &Anonymous.Anonymous1)
                 {
                     return ref pField->w;
                 }
@@ -1353,12 +1353,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -1366,12 +1366,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -1380,9 +1380,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 public int w;
 
@@ -2032,7 +2032,7 @@ namespace ClangSharp.Test
     public unsafe partial struct _MyStruct
     {
         [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
-        public _Anonymous1_e__Struct Anonymous1;
+        public _Anonymous_e__Struct Anonymous;
 
         [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
         public _MyArray_e__FixedBuffer MyArray;
@@ -2041,33 +2041,33 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous1_e__Struct* pField = &Anonymous1)
+                fixed (_Anonymous_e__Struct* pField = &Anonymous)
                 {
                     return ref pField->First;
                 }
             }
         }
 
-        public partial struct _Anonymous1_e__Struct
+        public partial struct _Anonymous_e__Struct
         {
             public int First;
         }
 
-        public partial struct _Anonymous2_e__Struct
+        public partial struct _MyArray_e__Struct
         {
             public int Second;
         }
 
         public partial struct _MyArray_e__FixedBuffer
         {
-            public _Anonymous2_e__Struct e0;
-            public _Anonymous2_e__Struct e1;
+            public _MyArray_e__Struct e0;
+            public _MyArray_e__Struct e1;
 
-            public unsafe ref _Anonymous2_e__Struct this[int index]
+            public unsafe ref _MyArray_e__Struct this[int index]
             {
                 get
                 {
-                    fixed (_Anonymous2_e__Struct* pThis = &e0)
+                    fixed (_MyArray_e__Struct* pThis = &e0)
                     {
                         return ref pThis[index];
                     }
@@ -2102,7 +2102,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous1_2_e__Struct* pField = &Anonymous.Anonymous_1.Anonymous1_2)
+                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct._Anonymous2_e__Struct* pField = &Anonymous.Anonymous1.Anonymous2)
                 {
                     return ref pField->Value1;
                 }
@@ -2113,7 +2113,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous2_2_e__Struct* pField = &Anonymous.Anonymous_1.Anonymous2_2)
+                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct._Anonymous3_e__Struct* pField = &Anonymous.Anonymous1.Anonymous3)
                 {
                     return ref pField->Value2;
                 }
@@ -2123,22 +2123,22 @@ namespace ClangSharp.Test
         public unsafe partial struct _Anonymous_e__Struct
         {
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public unsafe partial struct _Anonymous_1_e__Struct
+            public unsafe partial struct _Anonymous1_e__Struct
             {
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
-                public _Anonymous1_2_e__Struct Anonymous1_2;
+                public _Anonymous2_e__Struct Anonymous2;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
-                public _Anonymous2_2_e__Struct Anonymous2_2;
+                public _Anonymous3_e__Struct Anonymous3;
 
-                public partial struct _Anonymous1_2_e__Struct
+                public partial struct _Anonymous2_e__Struct
                 {
                     public int Value1;
                 }
 
-                public partial struct _Anonymous2_2_e__Struct
+                public partial struct _Anonymous3_e__Struct
                 {
                     public int Value2;
                 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/UnionDeclarationTest.cs
@@ -918,7 +918,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous_e__Union._Anonymous_1_e__Union* pField = &Anonymous.Anonymous_1)
+                fixed (_Anonymous_e__Union._Anonymous1_e__Union* pField = &Anonymous.Anonymous1)
                 {
                     return ref pField->w;
                 }
@@ -929,12 +929,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -942,12 +942,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -959,10 +959,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous1_e__Union Anonymous1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1504,22 +1504,22 @@ namespace ClangSharp.Test
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &Anonymous.Anonymous_1)
+                fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &Anonymous.Anonymous)
                 {{
                     return ref pField->A;
                 }}
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &Anonymous.Anonymous_1)
+                fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &Anonymous.Anonymous)
                 {{
                     return ref pField->B;
                 }}
@@ -1532,10 +1532,10 @@ namespace ClangSharp.Test
             public IntPtr First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous_e__Union Anonymous;
 
             [StructLayout(LayoutKind.Explicit)]
-            public unsafe partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/StructDeclarationTest.cs
@@ -1169,7 +1169,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous2_1_e__Struct* pField = &Anonymous.Anonymous2_1)
+                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct* pField = &Anonymous.Anonymous1)
                 {{
                     return ref pField->value1;
                 }}
@@ -1180,7 +1180,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous2_1_e__Struct._Anonymous_2_e__Struct* pField = &Anonymous.Anonymous2_1.Anonymous_2)
+                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct._Anonymous_e__Struct* pField = &Anonymous.Anonymous1.Anonymous)
                 {{
                     return ref pField->value;
                 }}
@@ -1191,7 +1191,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous3_1_e__Union* pField = &Anonymous.Anonymous3_1)
+                fixed (_Anonymous_e__Struct._Anonymous2_e__Union* pField = &Anonymous.Anonymous2)
                 {{
                     return ref pField->value2;
                 }}
@@ -1239,10 +1239,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous2_1_e__Struct Anonymous2_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous3_1_e__Union Anonymous3_1;
+            public _Anonymous2_e__Union Anonymous2;
 
             public MyUnion u;
 
@@ -1257,21 +1257,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public unsafe partial struct _Anonymous2_1_e__Struct
+            public unsafe partial struct _Anonymous1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_2_e__Struct Anonymous_2;
+                public _Anonymous_e__Struct Anonymous;
 
-                public partial struct _Anonymous_2_e__Struct
+                public partial struct _Anonymous_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous3_1_e__Union
+            public partial struct _Anonymous2_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1350,7 +1350,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct* pField = &Anonymous.Anonymous_1)
+                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct* pField = &Anonymous.Anonymous1)
                 {
                     return ref pField->w;
                 }
@@ -1361,12 +1361,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -1374,12 +1374,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -1388,9 +1388,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 public int w;
 
@@ -2038,7 +2038,7 @@ namespace ClangSharp.Test
     public unsafe partial struct _MyStruct
     {
         [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
-        public _Anonymous1_e__Struct Anonymous1;
+        public _Anonymous_e__Struct Anonymous;
 
         [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
         public _MyArray_e__FixedBuffer MyArray;
@@ -2047,33 +2047,33 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous1_e__Struct* pField = &Anonymous1)
+                fixed (_Anonymous_e__Struct* pField = &Anonymous)
                 {
                     return ref pField->First;
                 }
             }
         }
 
-        public partial struct _Anonymous1_e__Struct
+        public partial struct _Anonymous_e__Struct
         {
             public int First;
         }
 
-        public partial struct _Anonymous2_e__Struct
+        public partial struct _MyArray_e__Struct
         {
             public int Second;
         }
 
         public partial struct _MyArray_e__FixedBuffer
         {
-            public _Anonymous2_e__Struct e0;
-            public _Anonymous2_e__Struct e1;
+            public _MyArray_e__Struct e0;
+            public _MyArray_e__Struct e1;
 
-            public unsafe ref _Anonymous2_e__Struct this[int index]
+            public unsafe ref _MyArray_e__Struct this[int index]
             {
                 get
                 {
-                    fixed (_Anonymous2_e__Struct* pThis = &e0)
+                    fixed (_MyArray_e__Struct* pThis = &e0)
                     {
                         return ref pThis[index];
                     }
@@ -2108,7 +2108,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous1_2_e__Struct* pField = &Anonymous.Anonymous_1.Anonymous1_2)
+                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct._Anonymous2_e__Struct* pField = &Anonymous.Anonymous1.Anonymous2)
                 {
                     return ref pField->Value1;
                 }
@@ -2119,7 +2119,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous2_2_e__Struct* pField = &Anonymous.Anonymous_1.Anonymous2_2)
+                fixed (_Anonymous_e__Struct._Anonymous1_e__Struct._Anonymous3_e__Struct* pField = &Anonymous.Anonymous1.Anonymous3)
                 {
                     return ref pField->Value2;
                 }
@@ -2129,22 +2129,22 @@ namespace ClangSharp.Test
         public unsafe partial struct _Anonymous_e__Struct
         {
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public unsafe partial struct _Anonymous_1_e__Struct
+            public unsafe partial struct _Anonymous1_e__Struct
             {
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
-                public _Anonymous1_2_e__Struct Anonymous1_2;
+                public _Anonymous2_e__Struct Anonymous2;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
-                public _Anonymous2_2_e__Struct Anonymous2_2;
+                public _Anonymous3_e__Struct Anonymous3;
 
-                public partial struct _Anonymous1_2_e__Struct
+                public partial struct _Anonymous2_e__Struct
                 {
                     public int Value1;
                 }
 
-                public partial struct _Anonymous2_2_e__Struct
+                public partial struct _Anonymous3_e__Struct
                 {
                     public int Value2;
                 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/UnionDeclarationTest.cs
@@ -925,7 +925,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                fixed (_Anonymous_e__Union._Anonymous_1_e__Union* pField = &Anonymous.Anonymous_1)
+                fixed (_Anonymous_e__Union._Anonymous1_e__Union* pField = &Anonymous.Anonymous1)
                 {
                     return ref pField->w;
                 }
@@ -936,12 +936,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -949,12 +949,12 @@ namespace ClangSharp.Test
         {
             get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -966,10 +966,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous1_e__Union Anonymous1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1510,22 +1510,22 @@ namespace ClangSharp.Test
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &Anonymous.Anonymous_1)
+                fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &Anonymous.Anonymous)
                 {{
                     return ref pField->A;
                 }}
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
         {{
             get
             {{
-                fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &Anonymous.Anonymous_1)
+                fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &Anonymous.Anonymous)
                 {{
                     return ref pField->B;
                 }}
@@ -1538,10 +1538,10 @@ namespace ClangSharp.Test
             public int First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous_e__Union Anonymous;
 
             [StructLayout(LayoutKind.Explicit)]
-            public unsafe partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/StructDeclarationTest.cs
@@ -1163,7 +1163,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous2_1.value1, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.value1, 1));
             }}
         }}
 
@@ -1171,7 +1171,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous2_1.Anonymous_2.value, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.Anonymous.value, 1));
             }}
         }}
 
@@ -1179,7 +1179,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous3_1.value2, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous2.value2, 1));
             }}
         }}
 
@@ -1215,10 +1215,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous2_1_e__Struct Anonymous2_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous3_1_e__Union Anonymous3_1;
+            public _Anonymous2_e__Union Anonymous2;
 
             public MyUnion u;
 
@@ -1233,21 +1233,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous2_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_2_e__Struct Anonymous_2;
+                public _Anonymous_e__Struct Anonymous;
 
-                public partial struct _Anonymous_2_e__Struct
+                public partial struct _Anonymous_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous3_1_e__Union
+            public partial struct _Anonymous2_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1324,7 +1324,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.w, 1));
             }
         }
 
@@ -1332,12 +1332,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -1345,12 +1345,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -1359,9 +1359,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 public int w;
 
@@ -2012,7 +2012,7 @@ namespace ClangSharp.Test
     public partial struct _MyStruct
     {
         [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
-        public _Anonymous1_e__Struct Anonymous1;
+        public _Anonymous_e__Struct Anonymous;
 
         [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
         public _MyArray_e__FixedBuffer MyArray;
@@ -2021,26 +2021,26 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous1.First, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.First, 1));
             }
         }
 
-        public partial struct _Anonymous1_e__Struct
+        public partial struct _Anonymous_e__Struct
         {
             public int First;
         }
 
-        public partial struct _Anonymous2_e__Struct
+        public partial struct _MyArray_e__Struct
         {
             public int Second;
         }
 
         public partial struct _MyArray_e__FixedBuffer
         {
-            public _Anonymous2_e__Struct e0;
-            public _Anonymous2_e__Struct e1;
+            public _MyArray_e__Struct e0;
+            public _MyArray_e__Struct e1;
 
-            public ref _Anonymous2_e__Struct this[int index]
+            public ref _MyArray_e__Struct this[int index]
             {
                 get
                 {
@@ -2048,7 +2048,7 @@ namespace ClangSharp.Test
                 }
             }
 
-            public Span<_Anonymous2_e__Struct> AsSpan() => MemoryMarshal.CreateSpan(ref e0, 2);
+            public Span<_MyArray_e__Struct> AsSpan() => MemoryMarshal.CreateSpan(ref e0, 2);
         }
     }
 }
@@ -2080,7 +2080,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous1_2.Value1, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.Anonymous2.Value1, 1));
             }
         }
 
@@ -2088,29 +2088,29 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous2_2.Value2, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.Anonymous3.Value2, 1));
             }
         }
 
         public partial struct _Anonymous_e__Struct
         {
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
-                public _Anonymous1_2_e__Struct Anonymous1_2;
+                public _Anonymous2_e__Struct Anonymous2;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
-                public _Anonymous2_2_e__Struct Anonymous2_2;
+                public _Anonymous3_e__Struct Anonymous3;
 
-                public partial struct _Anonymous1_2_e__Struct
+                public partial struct _Anonymous2_e__Struct
                 {
                     public int Value1;
                 }
 
-                public partial struct _Anonymous2_2_e__Struct
+                public partial struct _Anonymous3_e__Struct
                 {
                     public int Value2;
                 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/UnionDeclarationTest.cs
@@ -908,7 +908,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.w, 1));
             }
         }
 
@@ -916,12 +916,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -929,12 +929,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -946,10 +946,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous1_e__Union Anonymous1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1485,19 +1485,19 @@ namespace ClangSharp.Test
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.A, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.A, 1));
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.B, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.B, 1));
             }}
         }}
 
@@ -1507,10 +1507,10 @@ namespace ClangSharp.Test
             public nint First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous_e__Union Anonymous;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/StructDeclarationTest.cs
@@ -1171,7 +1171,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous2_1.value1, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.value1, 1));
             }}
         }}
 
@@ -1179,7 +1179,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous2_1.Anonymous_2.value, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.Anonymous.value, 1));
             }}
         }}
 
@@ -1187,7 +1187,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous3_1.value2, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous2.value2, 1));
             }}
         }}
 
@@ -1223,10 +1223,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous2_1_e__Struct Anonymous2_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous3_1_e__Union Anonymous3_1;
+            public _Anonymous2_e__Union Anonymous2;
 
             public MyUnion u;
 
@@ -1241,21 +1241,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous2_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_2_e__Struct Anonymous_2;
+                public _Anonymous_e__Struct Anonymous;
 
-                public partial struct _Anonymous_2_e__Struct
+                public partial struct _Anonymous_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous3_1_e__Union
+            public partial struct _Anonymous2_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1332,7 +1332,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.w, 1));
             }
         }
 
@@ -1340,12 +1340,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -1353,12 +1353,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -1367,9 +1367,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 public int w;
 
@@ -2018,7 +2018,7 @@ namespace ClangSharp.Test
     public partial struct _MyStruct
     {
         [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
-        public _Anonymous1_e__Struct Anonymous1;
+        public _Anonymous_e__Struct Anonymous;
 
         [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
         public _MyArray_e__FixedBuffer MyArray;
@@ -2027,26 +2027,26 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous1.First, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.First, 1));
             }
         }
 
-        public partial struct _Anonymous1_e__Struct
+        public partial struct _Anonymous_e__Struct
         {
             public int First;
         }
 
-        public partial struct _Anonymous2_e__Struct
+        public partial struct _MyArray_e__Struct
         {
             public int Second;
         }
 
         public partial struct _MyArray_e__FixedBuffer
         {
-            public _Anonymous2_e__Struct e0;
-            public _Anonymous2_e__Struct e1;
+            public _MyArray_e__Struct e0;
+            public _MyArray_e__Struct e1;
 
-            public ref _Anonymous2_e__Struct this[int index]
+            public ref _MyArray_e__Struct this[int index]
             {
                 get
                 {
@@ -2054,7 +2054,7 @@ namespace ClangSharp.Test
                 }
             }
 
-            public Span<_Anonymous2_e__Struct> AsSpan() => MemoryMarshal.CreateSpan(ref e0, 2);
+            public Span<_MyArray_e__Struct> AsSpan() => MemoryMarshal.CreateSpan(ref e0, 2);
         }
     }
 }
@@ -2086,7 +2086,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous1_2.Value1, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.Anonymous2.Value1, 1));
             }
         }
 
@@ -2094,29 +2094,29 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous2_2.Value2, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.Anonymous3.Value2, 1));
             }
         }
 
         public partial struct _Anonymous_e__Struct
         {
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
-                public _Anonymous1_2_e__Struct Anonymous1_2;
+                public _Anonymous2_e__Struct Anonymous2;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
-                public _Anonymous2_2_e__Struct Anonymous2_2;
+                public _Anonymous3_e__Struct Anonymous3;
 
-                public partial struct _Anonymous1_2_e__Struct
+                public partial struct _Anonymous2_e__Struct
                 {
                     public int Value1;
                 }
 
-                public partial struct _Anonymous2_2_e__Struct
+                public partial struct _Anonymous3_e__Struct
                 {
                     public int Value2;
                 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/UnionDeclarationTest.cs
@@ -914,7 +914,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.w, 1));
             }
         }
 
@@ -922,12 +922,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -935,12 +935,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -952,10 +952,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous1_e__Union Anonymous1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1490,19 +1490,19 @@ namespace ClangSharp.Test
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.A, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.A, 1));
             }}
         }}
 
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
         {{
             get
             {{
-                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.B, 1));
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.B, 1));
             }}
         }}
 
@@ -1512,10 +1512,10 @@ namespace ClangSharp.Test
             public int First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous_e__Union Anonymous;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/StructDeclarationTest.cs
@@ -1134,7 +1134,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous2_1.value1;
+                return ref Anonymous.Anonymous1.value1;
             }}
         }}
 
@@ -1143,7 +1143,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous2_1.Anonymous_2.value;
+                return ref Anonymous.Anonymous1.Anonymous.value;
             }}
         }}
 
@@ -1152,7 +1152,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous3_1.value2;
+                return ref Anonymous.Anonymous2.value2;
             }}
         }}
 
@@ -1191,10 +1191,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous2_1_e__Struct Anonymous2_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous3_1_e__Union Anonymous3_1;
+            public _Anonymous2_e__Union Anonymous2;
 
             public MyUnion u;
 
@@ -1209,21 +1209,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous2_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_2_e__Struct Anonymous_2;
+                public _Anonymous_e__Struct Anonymous;
 
-                public partial struct _Anonymous_2_e__Struct
+                public partial struct _Anonymous_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous3_1_e__Union
+            public partial struct _Anonymous2_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1296,7 +1296,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.w;
+                return ref Anonymous.Anonymous1.w;
             }
         }
 
@@ -1304,12 +1304,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -1317,12 +1317,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -1331,9 +1331,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 public int w;
 
@@ -1976,7 +1976,7 @@ namespace ClangSharp.Test
     public partial struct _MyStruct
     {
         [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
-        public _Anonymous1_e__Struct Anonymous1;
+        public _Anonymous_e__Struct Anonymous;
 
         [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
         public _MyArray_e__FixedBuffer MyArray;
@@ -1986,16 +1986,16 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous1.First;
+                return ref Anonymous.First;
             }
         }
 
-        public partial struct _Anonymous1_e__Struct
+        public partial struct _Anonymous_e__Struct
         {
             public int First;
         }
 
-        public partial struct _Anonymous2_e__Struct
+        public partial struct _MyArray_e__Struct
         {
             public int Second;
         }
@@ -2003,7 +2003,7 @@ namespace ClangSharp.Test
         [InlineArray(2)]
         public partial struct _MyArray_e__FixedBuffer
         {
-            public _Anonymous2_e__Struct e0;
+            public _MyArray_e__Struct e0;
         }
     }
 }
@@ -2036,7 +2036,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;
+                return ref Anonymous.Anonymous1.Anonymous2.Value1;
             }
         }
 
@@ -2045,29 +2045,29 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;
+                return ref Anonymous.Anonymous1.Anonymous3.Value2;
             }
         }
 
         public partial struct _Anonymous_e__Struct
         {
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
-                public _Anonymous1_2_e__Struct Anonymous1_2;
+                public _Anonymous2_e__Struct Anonymous2;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
-                public _Anonymous2_2_e__Struct Anonymous2_2;
+                public _Anonymous3_e__Struct Anonymous3;
 
-                public partial struct _Anonymous1_2_e__Struct
+                public partial struct _Anonymous2_e__Struct
                 {
                     public int Value1;
                 }
 
-                public partial struct _Anonymous2_2_e__Struct
+                public partial struct _Anonymous3_e__Struct
                 {
                     public int Value2;
                 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/UnionDeclarationTest.cs
@@ -867,7 +867,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.w;
+                return ref Anonymous.Anonymous1.w;
             }
         }
 
@@ -875,12 +875,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -888,12 +888,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -905,10 +905,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous1_e__Union Anonymous1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1449,20 +1449,20 @@ namespace ClangSharp.Test
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
         {{
             get
             {{
-                return ref Anonymous.Anonymous_1.A;
+                return ref Anonymous.Anonymous.A;
             }}
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
         {{
             get
             {{
-                return ref Anonymous.Anonymous_1.B;
+                return ref Anonymous.Anonymous.B;
             }}
         }}
 
@@ -1472,10 +1472,10 @@ namespace ClangSharp.Test
             public nint First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous_e__Union Anonymous;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/StructDeclarationTest.cs
@@ -1142,7 +1142,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous2_1.value1;
+                return ref Anonymous.Anonymous1.value1;
             }}
         }}
 
@@ -1151,7 +1151,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous2_1.Anonymous_2.value;
+                return ref Anonymous.Anonymous1.Anonymous.value;
             }}
         }}
 
@@ -1160,7 +1160,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous3_1.value2;
+                return ref Anonymous.Anonymous2.value2;
             }}
         }}
 
@@ -1199,10 +1199,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous2_1_e__Struct Anonymous2_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous3_1_e__Union Anonymous3_1;
+            public _Anonymous2_e__Union Anonymous2;
 
             public MyUnion u;
 
@@ -1217,21 +1217,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous2_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_2_e__Struct Anonymous_2;
+                public _Anonymous_e__Struct Anonymous;
 
-                public partial struct _Anonymous_2_e__Struct
+                public partial struct _Anonymous_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous3_1_e__Union
+            public partial struct _Anonymous2_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1304,7 +1304,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.w;
+                return ref Anonymous.Anonymous1.w;
             }
         }
 
@@ -1312,12 +1312,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -1325,12 +1325,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -1339,9 +1339,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 public int w;
 
@@ -1982,7 +1982,7 @@ namespace ClangSharp.Test
     public partial struct _MyStruct
     {
         [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
-        public _Anonymous1_e__Struct Anonymous1;
+        public _Anonymous_e__Struct Anonymous;
 
         [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
         public _MyArray_e__FixedBuffer MyArray;
@@ -1992,16 +1992,16 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous1.First;
+                return ref Anonymous.First;
             }
         }
 
-        public partial struct _Anonymous1_e__Struct
+        public partial struct _Anonymous_e__Struct
         {
             public int First;
         }
 
-        public partial struct _Anonymous2_e__Struct
+        public partial struct _MyArray_e__Struct
         {
             public int Second;
         }
@@ -2009,7 +2009,7 @@ namespace ClangSharp.Test
         [InlineArray(2)]
         public partial struct _MyArray_e__FixedBuffer
         {
-            public _Anonymous2_e__Struct e0;
+            public _MyArray_e__Struct e0;
         }
     }
 }
@@ -2042,7 +2042,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;
+                return ref Anonymous.Anonymous1.Anonymous2.Value1;
             }
         }
 
@@ -2051,29 +2051,29 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;
+                return ref Anonymous.Anonymous1.Anonymous3.Value2;
             }
         }
 
         public partial struct _Anonymous_e__Struct
         {
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
-                public _Anonymous1_2_e__Struct Anonymous1_2;
+                public _Anonymous2_e__Struct Anonymous2;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
-                public _Anonymous2_2_e__Struct Anonymous2_2;
+                public _Anonymous3_e__Struct Anonymous3;
 
-                public partial struct _Anonymous1_2_e__Struct
+                public partial struct _Anonymous2_e__Struct
                 {
                     public int Value1;
                 }
 
-                public partial struct _Anonymous2_2_e__Struct
+                public partial struct _Anonymous3_e__Struct
                 {
                     public int Value2;
                 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/UnionDeclarationTest.cs
@@ -873,7 +873,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.w;
+                return ref Anonymous.Anonymous1.w;
             }
         }
 
@@ -881,12 +881,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -894,12 +894,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -911,10 +911,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous1_e__Union Anonymous1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1455,20 +1455,20 @@ namespace ClangSharp.Test
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
         {{
             get
             {{
-                return ref Anonymous.Anonymous_1.A;
+                return ref Anonymous.Anonymous.A;
             }}
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
         {{
             get
             {{
-                return ref Anonymous.Anonymous_1.B;
+                return ref Anonymous.Anonymous.B;
             }}
         }}
 
@@ -1478,10 +1478,10 @@ namespace ClangSharp.Test
             public int First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous_e__Union Anonymous;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/StructDeclarationTest.cs
@@ -1134,7 +1134,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous2_1.value1;
+                return ref Anonymous.Anonymous1.value1;
             }}
         }}
 
@@ -1143,7 +1143,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous2_1.Anonymous_2.value;
+                return ref Anonymous.Anonymous1.Anonymous.value;
             }}
         }}
 
@@ -1152,7 +1152,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous3_1.value2;
+                return ref Anonymous.Anonymous2.value2;
             }}
         }}
 
@@ -1191,10 +1191,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous2_1_e__Struct Anonymous2_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous3_1_e__Union Anonymous3_1;
+            public _Anonymous2_e__Union Anonymous2;
 
             public MyUnion u;
 
@@ -1209,21 +1209,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous2_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_2_e__Struct Anonymous_2;
+                public _Anonymous_e__Struct Anonymous;
 
-                public partial struct _Anonymous_2_e__Struct
+                public partial struct _Anonymous_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous3_1_e__Union
+            public partial struct _Anonymous2_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1296,7 +1296,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.w;
+                return ref Anonymous.Anonymous1.w;
             }
         }
 
@@ -1304,12 +1304,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -1317,12 +1317,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -1331,9 +1331,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 public int w;
 
@@ -1975,7 +1975,7 @@ namespace ClangSharp.Test
     public partial struct _MyStruct
     {
         [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
-        public _Anonymous1_e__Struct Anonymous1;
+        public _Anonymous_e__Struct Anonymous;
 
         [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
         public _MyArray_e__FixedBuffer MyArray;
@@ -1985,16 +1985,16 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous1.First;
+                return ref Anonymous.First;
             }
         }
 
-        public partial struct _Anonymous1_e__Struct
+        public partial struct _Anonymous_e__Struct
         {
             public int First;
         }
 
-        public partial struct _Anonymous2_e__Struct
+        public partial struct _MyArray_e__Struct
         {
             public int Second;
         }
@@ -2002,7 +2002,7 @@ namespace ClangSharp.Test
         [InlineArray(2)]
         public partial struct _MyArray_e__FixedBuffer
         {
-            public _Anonymous2_e__Struct e0;
+            public _MyArray_e__Struct e0;
         }
     }
 }
@@ -2035,7 +2035,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;
+                return ref Anonymous.Anonymous1.Anonymous2.Value1;
             }
         }
 
@@ -2044,29 +2044,29 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;
+                return ref Anonymous.Anonymous1.Anonymous3.Value2;
             }
         }
 
         public partial struct _Anonymous_e__Struct
         {
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
-                public _Anonymous1_2_e__Struct Anonymous1_2;
+                public _Anonymous2_e__Struct Anonymous2;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
-                public _Anonymous2_2_e__Struct Anonymous2_2;
+                public _Anonymous3_e__Struct Anonymous3;
 
-                public partial struct _Anonymous1_2_e__Struct
+                public partial struct _Anonymous2_e__Struct
                 {
                     public int Value1;
                 }
 
-                public partial struct _Anonymous2_2_e__Struct
+                public partial struct _Anonymous3_e__Struct
                 {
                     public int Value2;
                 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/UnionDeclarationTest.cs
@@ -867,7 +867,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.w;
+                return ref Anonymous.Anonymous1.w;
             }
         }
 
@@ -875,12 +875,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -888,12 +888,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -905,10 +905,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous1_e__Union Anonymous1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1449,20 +1449,20 @@ namespace ClangSharp.Test
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
         {{
             get
             {{
-                return ref Anonymous.Anonymous_1.A;
+                return ref Anonymous.Anonymous.A;
             }}
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
         {{
             get
             {{
-                return ref Anonymous.Anonymous_1.B;
+                return ref Anonymous.Anonymous.B;
             }}
         }}
 
@@ -1472,10 +1472,10 @@ namespace ClangSharp.Test
             public nint First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous_e__Union Anonymous;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/StructDeclarationTest.cs
@@ -1142,7 +1142,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous2_1.value1;
+                return ref Anonymous.Anonymous1.value1;
             }}
         }}
 
@@ -1151,7 +1151,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous2_1.Anonymous_2.value;
+                return ref Anonymous.Anonymous1.Anonymous.value;
             }}
         }}
 
@@ -1160,7 +1160,7 @@ namespace ClangSharp.Test
         {{
             get
             {{
-                return ref Anonymous.Anonymous3_1.value2;
+                return ref Anonymous.Anonymous2.value2;
             }}
         }}
 
@@ -1199,10 +1199,10 @@ namespace ClangSharp.Test
             public _w_e__Struct w;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L19_C9"")]
-            public _Anonymous2_1_e__Struct Anonymous2_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L29_C9"")]
-            public _Anonymous3_1_e__Union Anonymous3_1;
+            public _Anonymous2_e__Union Anonymous2;
 
             public MyUnion u;
 
@@ -1217,21 +1217,21 @@ namespace ClangSharp.Test
                 public {expectedManagedType} value;
             }}
 
-            public partial struct _Anonymous2_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {{
                 public {expectedManagedType} value1;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L23_C13"")]
-                public _Anonymous_2_e__Struct Anonymous_2;
+                public _Anonymous_e__Struct Anonymous;
 
-                public partial struct _Anonymous_2_e__Struct
+                public partial struct _Anonymous_e__Struct
                 {{
                     public {expectedManagedType} value;
                 }}
             }}
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous3_1_e__Union
+            public partial struct _Anonymous2_e__Union
             {{
                 [FieldOffset(0)]
                 public {expectedManagedType} value2;
@@ -1304,7 +1304,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.w;
+                return ref Anonymous.Anonymous1.w;
             }
         }
 
@@ -1312,12 +1312,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -1325,12 +1325,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -1339,9 +1339,9 @@ namespace ClangSharp.Test
             public int z;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 public int w;
 
@@ -1981,7 +1981,7 @@ namespace ClangSharp.Test
     public partial struct _MyStruct
     {
         [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C5"")]
-        public _Anonymous1_e__Struct Anonymous1;
+        public _Anonymous_e__Struct Anonymous;
 
         [NativeTypeName(""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"")]
         public _MyArray_e__FixedBuffer MyArray;
@@ -1991,16 +1991,16 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous1.First;
+                return ref Anonymous.First;
             }
         }
 
-        public partial struct _Anonymous1_e__Struct
+        public partial struct _Anonymous_e__Struct
         {
             public int First;
         }
 
-        public partial struct _Anonymous2_e__Struct
+        public partial struct _MyArray_e__Struct
         {
             public int Second;
         }
@@ -2008,7 +2008,7 @@ namespace ClangSharp.Test
         [InlineArray(2)]
         public partial struct _MyArray_e__FixedBuffer
         {
-            public _Anonymous2_e__Struct e0;
+            public _MyArray_e__Struct e0;
         }
     }
 }
@@ -2041,7 +2041,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;
+                return ref Anonymous.Anonymous1.Anonymous2.Value1;
             }
         }
 
@@ -2050,29 +2050,29 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;
+                return ref Anonymous.Anonymous1.Anonymous3.Value2;
             }
         }
 
         public partial struct _Anonymous_e__Struct
         {
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L3_C14"")]
-            public _Anonymous_1_e__Struct Anonymous_1;
+            public _Anonymous1_e__Struct Anonymous1;
 
-            public partial struct _Anonymous_1_e__Struct
+            public partial struct _Anonymous1_e__Struct
             {
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L4_C9"")]
-                public _Anonymous1_2_e__Struct Anonymous1_2;
+                public _Anonymous2_e__Struct Anonymous2;
 
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L5_C9"")]
-                public _Anonymous2_2_e__Struct Anonymous2_2;
+                public _Anonymous3_e__Struct Anonymous3;
 
-                public partial struct _Anonymous1_2_e__Struct
+                public partial struct _Anonymous2_e__Struct
                 {
                     public int Value1;
                 }
 
-                public partial struct _Anonymous2_2_e__Struct
+                public partial struct _Anonymous3_e__Struct
                 {
                     public int Value2;
                 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/UnionDeclarationTest.cs
@@ -873,7 +873,7 @@ namespace ClangSharp.Test
         {
             get
             {
-                return ref Anonymous.Anonymous_1.w;
+                return ref Anonymous.Anonymous1.w;
             }
         }
 
@@ -881,12 +881,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b0_16;
+                return Anonymous.Anonymous1.o0_b0_16;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b0_16 = value;
+                Anonymous.Anonymous1.o0_b0_16 = value;
             }
         }
 
@@ -894,12 +894,12 @@ namespace ClangSharp.Test
         {
             readonly get
             {
-                return Anonymous.Anonymous_1.o0_b16_4;
+                return Anonymous.Anonymous1.o0_b16_4;
             }
 
             set
             {
-                Anonymous.Anonymous_1.o0_b16_4 = value;
+                Anonymous.Anonymous1.o0_b16_4 = value;
             }
         }
 
@@ -911,10 +911,10 @@ namespace ClangSharp.Test
 
             [FieldOffset(0)]
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L10_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous1_e__Union Anonymous1;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous1_e__Union
             {
                 [FieldOffset(0)]
                 public int w;
@@ -1455,20 +1455,20 @@ namespace ClangSharp.Test
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct A
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct A
         {{
             get
             {{
-                return ref Anonymous.Anonymous_1.A;
+                return ref Anonymous.Anonymous.A;
             }}
         }}
 
         [UnscopedRef]
-        public ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct B
+        public ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct B
         {{
             get
             {{
-                return ref Anonymous.Anonymous_1.B;
+                return ref Anonymous.Anonymous.B;
             }}
         }}
 
@@ -1478,10 +1478,10 @@ namespace ClangSharp.Test
             public int First;
 
             [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L7_C9"")]
-            public _Anonymous_1_e__Union Anonymous_1;
+            public _Anonymous_e__Union Anonymous;
 
             [StructLayout(LayoutKind.Explicit)]
-            public partial struct _Anonymous_1_e__Union
+            public partial struct _Anonymous_e__Union
             {{
                 [FieldOffset(0)]
                 [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L9_C13"")]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -197,7 +197,7 @@ namespace ClangSharp.Test
         }
     }
 
-    public unsafe partial struct _MyStructWithAnonymousUnion
+    public partial struct _MyStructWithAnonymousUnion
     {
         [NativeTypeName(""__AnonymousRecord_ClangUnsavedFile_L21_C5"")]
         public _union1_e__Union union1;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/StructDeclarationTest.cs
@@ -1280,7 +1280,7 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct* pField = &amp;Anonymous.Anonymous_1)
+          <code>fixed (_Anonymous_e__Struct._Anonymous1_e__Struct* pField = &amp;Anonymous.Anonymous1)
     {
         return ref pField-&gt;w;
     }</code>
@@ -1289,29 +1289,29 @@ struct MyStruct
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"" unsafe=""true"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1996,45 +1996,45 @@ struct MyStruct
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""_MyStruct"" access=""public"" unsafe=""true"">
-      <field name=""Anonymous1"" access=""public"">
-        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
       </field>
       <field name=""MyArray"" access=""public"">
-        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_MyArray_e__Struct</type>
       </field>
       <field name=""First"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous1_e__Struct* pField = &amp;Anonymous1)
+          <code>fixed (_Anonymous_e__Struct* pField = &amp;Anonymous)
     {
         return ref pField-&gt;First;
     }</code>
         </get>
       </field>
-      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type>int</type>
         </field>
       </struct>
-      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+      <struct name=""_MyArray_e__Struct"" access=""public"">
         <field name=""Second"" access=""public"">
           <type>int</type>
         </field>
       </struct>
       <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
         <field name=""e0"" access=""public"">
-          <type>_Anonymous2_e__Struct</type>
+          <type>_MyArray_e__Struct</type>
         </field>
         <field name=""e1"" access=""public"">
-          <type>_Anonymous2_e__Struct</type>
+          <type>_MyArray_e__Struct</type>
         </field>
         <indexer access=""public"" unsafe=""true"">
-          <type>ref _Anonymous2_e__Struct</type>
+          <type>ref _MyArray_e__Struct</type>
           <param name=""index"">
             <type>int</type>
           </param>
           <get>
-            <code>fixed (_Anonymous2_e__Struct* pThis = &amp;e0)
+            <code>fixed (_MyArray_e__Struct* pThis = &amp;e0)
     {
         return ref pThis[index];
     }</code>
@@ -2069,7 +2069,7 @@ struct MyStruct
       <field name=""Value1"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous1_2_e__Struct* pField = &amp;Anonymous.Anonymous_1.Anonymous1_2)
+          <code>fixed (_Anonymous_e__Struct._Anonymous1_e__Struct._Anonymous2_e__Struct* pField = &amp;Anonymous.Anonymous1.Anonymous2)
     {
         return ref pField-&gt;Value1;
     }</code>
@@ -2078,29 +2078,29 @@ struct MyStruct
       <field name=""Value2"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous2_2_e__Struct* pField = &amp;Anonymous.Anonymous_1.Anonymous2_2)
+          <code>fixed (_Anonymous_e__Struct._Anonymous1_e__Struct._Anonymous3_e__Struct* pField = &amp;Anonymous.Anonymous1.Anonymous3)
     {
         return ref pField-&gt;Value2;
     }</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"" unsafe=""true"">
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"" unsafe=""true"">
-          <field name=""Anonymous1_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+        <struct name=""_Anonymous1_e__Struct"" access=""public"" unsafe=""true"">
+          <field name=""Anonymous2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous2_e__Struct</type>
           </field>
-          <field name=""Anonymous2_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          <field name=""Anonymous3"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous3_e__Struct</type>
           </field>
-          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous2_e__Struct"" access=""public"">
             <field name=""Value1"" access=""public"">
               <type>int</type>
             </field>
           </struct>
-          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous3_e__Struct"" access=""public"">
             <field name=""Value2"" access=""public"">
               <type>int</type>
             </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/UnionDeclarationTest.cs
@@ -868,7 +868,7 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous_e__Union._Anonymous_1_e__Union* pField = &amp;Anonymous.Anonymous_1)
+          <code>fixed (_Anonymous_e__Union._Anonymous1_e__Union* pField = &amp;Anonymous.Anonymous1)
     {
         return ref pField-&gt;w;
     }</code>
@@ -877,29 +877,29 @@ union MyUnion
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" unsafe=""true"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1386,18 +1386,18 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &amp;Anonymous.Anonymous_1)
+          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
     {{
         return ref pField-&gt;A;
     }}</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &amp;Anonymous.Anonymous_1)
+          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
     {{
         return ref pField-&gt;B;
     }}</code>
@@ -1407,10 +1407,10 @@ union MyUnion
         <field name=""First"" access=""public"">
           <type native=""long"">IntPtr</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" unsafe=""true"" layout=""Explicit"">
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/StructDeclarationTest.cs
@@ -1292,7 +1292,7 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct* pField = &amp;Anonymous.Anonymous_1)
+          <code>fixed (_Anonymous_e__Struct._Anonymous1_e__Struct* pField = &amp;Anonymous.Anonymous1)
     {
         return ref pField-&gt;w;
     }</code>
@@ -1301,29 +1301,29 @@ struct MyStruct
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"" unsafe=""true"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -2005,45 +2005,45 @@ struct MyStruct3
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""_MyStruct"" access=""public"" unsafe=""true"">
-      <field name=""Anonymous1"" access=""public"">
-        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
       </field>
       <field name=""MyArray"" access=""public"">
-        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_MyArray_e__Struct</type>
       </field>
       <field name=""First"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous1_e__Struct* pField = &amp;Anonymous1)
+          <code>fixed (_Anonymous_e__Struct* pField = &amp;Anonymous)
     {
         return ref pField-&gt;First;
     }</code>
         </get>
       </field>
-      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type>int</type>
         </field>
       </struct>
-      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+      <struct name=""_MyArray_e__Struct"" access=""public"">
         <field name=""Second"" access=""public"">
           <type>int</type>
         </field>
       </struct>
       <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
         <field name=""e0"" access=""public"">
-          <type>_Anonymous2_e__Struct</type>
+          <type>_MyArray_e__Struct</type>
         </field>
         <field name=""e1"" access=""public"">
-          <type>_Anonymous2_e__Struct</type>
+          <type>_MyArray_e__Struct</type>
         </field>
         <indexer access=""public"" unsafe=""true"">
-          <type>ref _Anonymous2_e__Struct</type>
+          <type>ref _MyArray_e__Struct</type>
           <param name=""index"">
             <type>int</type>
           </param>
           <get>
-            <code>fixed (_Anonymous2_e__Struct* pThis = &amp;e0)
+            <code>fixed (_MyArray_e__Struct* pThis = &amp;e0)
     {
         return ref pThis[index];
     }</code>
@@ -2078,7 +2078,7 @@ struct MyStruct3
       <field name=""Value1"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous1_2_e__Struct* pField = &amp;Anonymous.Anonymous_1.Anonymous1_2)
+          <code>fixed (_Anonymous_e__Struct._Anonymous1_e__Struct._Anonymous2_e__Struct* pField = &amp;Anonymous.Anonymous1.Anonymous2)
     {
         return ref pField-&gt;Value1;
     }</code>
@@ -2087,29 +2087,29 @@ struct MyStruct3
       <field name=""Value2"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Struct._Anonymous2_2_e__Struct* pField = &amp;Anonymous.Anonymous_1.Anonymous2_2)
+          <code>fixed (_Anonymous_e__Struct._Anonymous1_e__Struct._Anonymous3_e__Struct* pField = &amp;Anonymous.Anonymous1.Anonymous3)
     {
         return ref pField-&gt;Value2;
     }</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"" unsafe=""true"">
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"" unsafe=""true"">
-          <field name=""Anonymous1_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+        <struct name=""_Anonymous1_e__Struct"" access=""public"" unsafe=""true"">
+          <field name=""Anonymous2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous2_e__Struct</type>
           </field>
-          <field name=""Anonymous2_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          <field name=""Anonymous3"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous3_e__Struct</type>
           </field>
-          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous2_e__Struct"" access=""public"">
             <field name=""Value1"" access=""public"">
               <type>int</type>
             </field>
           </struct>
-          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous3_e__Struct"" access=""public"">
             <field name=""Value2"" access=""public"">
               <type>int</type>
             </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/UnionDeclarationTest.cs
@@ -874,7 +874,7 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>fixed (_Anonymous_e__Union._Anonymous_1_e__Union* pField = &amp;Anonymous.Anonymous_1)
+          <code>fixed (_Anonymous_e__Union._Anonymous1_e__Union* pField = &amp;Anonymous.Anonymous1)
     {
         return ref pField-&gt;w;
     }</code>
@@ -883,29 +883,29 @@ union MyUnion
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" unsafe=""true"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1392,18 +1392,18 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &amp;Anonymous.Anonymous_1)
+          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
     {{
         return ref pField-&gt;A;
     }}</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
         <get>
-          <code>fixed (_Anonymous_e__Struct._Anonymous_1_e__Union* pField = &amp;Anonymous.Anonymous_1)
+          <code>fixed (_Anonymous_e__Struct._Anonymous_e__Union* pField = &amp;Anonymous.Anonymous)
     {{
         return ref pField-&gt;B;
     }}</code>
@@ -1413,10 +1413,10 @@ union MyUnion
         <field name=""First"" access=""public"">
           <type native=""long"">int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" unsafe=""true"" layout=""Explicit"">
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/StructDeclarationTest.cs
@@ -1267,35 +1267,35 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.w, 1));</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1977,37 +1977,37 @@ struct MyStruct
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""_MyStruct"" access=""public"">
-      <field name=""Anonymous1"" access=""public"">
-        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
       </field>
       <field name=""MyArray"" access=""public"">
-        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_MyArray_e__Struct</type>
       </field>
       <field name=""First"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous1.First, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.First, 1));</code>
         </get>
       </field>
-      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type>int</type>
         </field>
       </struct>
-      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+      <struct name=""_MyArray_e__Struct"" access=""public"">
         <field name=""Second"" access=""public"">
           <type>int</type>
         </field>
       </struct>
       <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
         <field name=""e0"" access=""public"">
-          <type>_Anonymous2_e__Struct</type>
+          <type>_MyArray_e__Struct</type>
         </field>
         <field name=""e1"" access=""public"">
-          <type>_Anonymous2_e__Struct</type>
+          <type>_MyArray_e__Struct</type>
         </field>
         <indexer access=""public"">
-          <type>ref _Anonymous2_e__Struct</type>
+          <type>ref _MyArray_e__Struct</type>
           <param name=""index"">
             <type>int</type>
           </param>
@@ -2016,7 +2016,7 @@ struct MyStruct
           </get>
         </indexer>
         <function name=""AsSpan"" access=""public"">
-          <type>Span&lt;_Anonymous2_e__Struct&gt;</type>
+          <type>Span&lt;_MyArray_e__Struct&gt;</type>
           <code>MemoryMarshal.CreateSpan(ref e0, 2);</code>
         </function>
       </struct>
@@ -2048,32 +2048,32 @@ struct MyStruct
       <field name=""Value1"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous1_2.Value1, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.Anonymous2.Value1, 1));</code>
         </get>
       </field>
       <field name=""Value2"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous2_2.Value2, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.Anonymous3.Value2, 1));</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
-          <field name=""Anonymous1_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
+          <field name=""Anonymous2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous2_e__Struct</type>
           </field>
-          <field name=""Anonymous2_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          <field name=""Anonymous3"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous3_e__Struct</type>
           </field>
-          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous2_e__Struct"" access=""public"">
             <field name=""Value1"" access=""public"">
               <type>int</type>
             </field>
           </struct>
-          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous3_e__Struct"" access=""public"">
             <field name=""Value2"" access=""public"">
               <type>int</type>
             </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/UnionDeclarationTest.cs
@@ -860,35 +860,35 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.w, 1));</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1369,25 +1369,25 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.A, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.A, 1));</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.B, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.B, 1));</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type native=""long"">nint</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/StructDeclarationTest.cs
@@ -1279,35 +1279,35 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.w, 1));</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1987,37 +1987,37 @@ struct MyStruct3
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""_MyStruct"" access=""public"">
-      <field name=""Anonymous1"" access=""public"">
-        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
       </field>
       <field name=""MyArray"" access=""public"">
-        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_MyArray_e__Struct</type>
       </field>
       <field name=""First"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous1.First, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.First, 1));</code>
         </get>
       </field>
-      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type>int</type>
         </field>
       </struct>
-      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+      <struct name=""_MyArray_e__Struct"" access=""public"">
         <field name=""Second"" access=""public"">
           <type>int</type>
         </field>
       </struct>
       <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
         <field name=""e0"" access=""public"">
-          <type>_Anonymous2_e__Struct</type>
+          <type>_MyArray_e__Struct</type>
         </field>
         <field name=""e1"" access=""public"">
-          <type>_Anonymous2_e__Struct</type>
+          <type>_MyArray_e__Struct</type>
         </field>
         <indexer access=""public"">
-          <type>ref _Anonymous2_e__Struct</type>
+          <type>ref _MyArray_e__Struct</type>
           <param name=""index"">
             <type>int</type>
           </param>
@@ -2026,7 +2026,7 @@ struct MyStruct3
           </get>
         </indexer>
         <function name=""AsSpan"" access=""public"">
-          <type>Span&lt;_Anonymous2_e__Struct&gt;</type>
+          <type>Span&lt;_MyArray_e__Struct&gt;</type>
           <code>MemoryMarshal.CreateSpan(ref e0, 2);</code>
         </function>
       </struct>
@@ -2058,32 +2058,32 @@ struct MyStruct3
       <field name=""Value1"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous1_2.Value1, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.Anonymous2.Value1, 1));</code>
         </get>
       </field>
       <field name=""Value2"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.Anonymous2_2.Value2, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.Anonymous3.Value2, 1));</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
-          <field name=""Anonymous1_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
+          <field name=""Anonymous2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous2_e__Struct</type>
           </field>
-          <field name=""Anonymous2_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          <field name=""Anonymous3"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous3_e__Struct</type>
           </field>
-          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous2_e__Struct"" access=""public"">
             <field name=""Value1"" access=""public"">
               <type>int</type>
             </field>
           </struct>
-          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous3_e__Struct"" access=""public"">
             <field name=""Value2"" access=""public"">
               <type>int</type>
             </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/UnionDeclarationTest.cs
@@ -866,35 +866,35 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.w, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous1.w, 1));</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1375,25 +1375,25 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.A, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.A, 1));</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
         <get>
-          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous_1.B, 1));</code>
+          <code>return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.Anonymous.B, 1));</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type native=""long"">int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/StructDeclarationTest.cs
@@ -1156,35 +1156,35 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.w;</code>
+          <code>return ref Anonymous.Anonymous1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1852,24 +1852,24 @@ struct MyStruct
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""_MyStruct"" access=""public"">
-      <field name=""Anonymous1"" access=""public"">
-        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
       </field>
       <field name=""MyArray"" access=""public"">
-        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_MyArray_e__Struct</type>
       </field>
       <field name=""First"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous1.First;</code>
+          <code>return ref Anonymous.First;</code>
         </get>
       </field>
-      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type>int</type>
         </field>
       </struct>
-      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+      <struct name=""_MyArray_e__Struct"" access=""public"">
         <field name=""Second"" access=""public"">
           <type>int</type>
         </field>
@@ -1877,7 +1877,7 @@ struct MyStruct
       <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
         <attribute>InlineArray(2)</attribute>
         <field name=""e0"" access=""public"">
-          <type>_Anonymous2_e__Struct</type>
+          <type>_MyArray_e__Struct</type>
         </field>
       </struct>
     </struct>
@@ -1909,32 +1909,32 @@ struct MyStruct
       <field name=""Value1"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;</code>
+          <code>return ref Anonymous.Anonymous1.Anonymous2.Value1;</code>
         </get>
       </field>
       <field name=""Value2"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;</code>
+          <code>return ref Anonymous.Anonymous1.Anonymous3.Value2;</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
-          <field name=""Anonymous1_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
+          <field name=""Anonymous2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous2_e__Struct</type>
           </field>
-          <field name=""Anonymous2_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          <field name=""Anonymous3"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous3_e__Struct</type>
           </field>
-          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous2_e__Struct"" access=""public"">
             <field name=""Value1"" access=""public"">
               <type>int</type>
             </field>
           </struct>
-          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous3_e__Struct"" access=""public"">
             <field name=""Value2"" access=""public"">
               <type>int</type>
             </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/UnionDeclarationTest.cs
@@ -749,35 +749,35 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.w;</code>
+          <code>return ref Anonymous.Anonymous1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1258,25 +1258,25 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.A;</code>
+          <code>return ref Anonymous.Anonymous.A;</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.B;</code>
+          <code>return ref Anonymous.Anonymous.B;</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type native=""long"">nint</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/StructDeclarationTest.cs
@@ -1168,35 +1168,35 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.w;</code>
+          <code>return ref Anonymous.Anonymous1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1862,24 +1862,24 @@ struct MyStruct3
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""_MyStruct"" access=""public"">
-      <field name=""Anonymous1"" access=""public"">
-        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
       </field>
       <field name=""MyArray"" access=""public"">
-        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_MyArray_e__Struct</type>
       </field>
       <field name=""First"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous1.First;</code>
+          <code>return ref Anonymous.First;</code>
         </get>
       </field>
-      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type>int</type>
         </field>
       </struct>
-      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+      <struct name=""_MyArray_e__Struct"" access=""public"">
         <field name=""Second"" access=""public"">
           <type>int</type>
         </field>
@@ -1887,7 +1887,7 @@ struct MyStruct3
       <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
         <attribute>InlineArray(2)</attribute>
         <field name=""e0"" access=""public"">
-          <type>_Anonymous2_e__Struct</type>
+          <type>_MyArray_e__Struct</type>
         </field>
       </struct>
     </struct>
@@ -1919,32 +1919,32 @@ struct MyStruct3
       <field name=""Value1"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;</code>
+          <code>return ref Anonymous.Anonymous1.Anonymous2.Value1;</code>
         </get>
       </field>
       <field name=""Value2"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;</code>
+          <code>return ref Anonymous.Anonymous1.Anonymous3.Value2;</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
-          <field name=""Anonymous1_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
+          <field name=""Anonymous2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous2_e__Struct</type>
           </field>
-          <field name=""Anonymous2_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          <field name=""Anonymous3"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous3_e__Struct</type>
           </field>
-          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous2_e__Struct"" access=""public"">
             <field name=""Value1"" access=""public"">
               <type>int</type>
             </field>
           </struct>
-          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous3_e__Struct"" access=""public"">
             <field name=""Value2"" access=""public"">
               <type>int</type>
             </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/UnionDeclarationTest.cs
@@ -755,35 +755,35 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.w;</code>
+          <code>return ref Anonymous.Anonymous1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1264,25 +1264,25 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.A;</code>
+          <code>return ref Anonymous.Anonymous.A;</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.B;</code>
+          <code>return ref Anonymous.Anonymous.B;</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type native=""long"">int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/StructDeclarationTest.cs
@@ -1156,35 +1156,35 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.w;</code>
+          <code>return ref Anonymous.Anonymous1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1851,24 +1851,24 @@ struct MyStruct
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""_MyStruct"" access=""public"">
-      <field name=""Anonymous1"" access=""public"">
-        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
       </field>
       <field name=""MyArray"" access=""public"">
-        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_MyArray_e__Struct</type>
       </field>
       <field name=""First"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous1.First;</code>
+          <code>return ref Anonymous.First;</code>
         </get>
       </field>
-      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type>int</type>
         </field>
       </struct>
-      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+      <struct name=""_MyArray_e__Struct"" access=""public"">
         <field name=""Second"" access=""public"">
           <type>int</type>
         </field>
@@ -1876,7 +1876,7 @@ struct MyStruct
       <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
         <attribute>InlineArray(2)</attribute>
         <field name=""e0"" access=""public"">
-          <type>_Anonymous2_e__Struct</type>
+          <type>_MyArray_e__Struct</type>
         </field>
       </struct>
     </struct>
@@ -1907,32 +1907,32 @@ struct MyStruct
       <field name=""Value1"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;</code>
+          <code>return ref Anonymous.Anonymous1.Anonymous2.Value1;</code>
         </get>
       </field>
       <field name=""Value2"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;</code>
+          <code>return ref Anonymous.Anonymous1.Anonymous3.Value2;</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
-          <field name=""Anonymous1_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
+          <field name=""Anonymous2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous2_e__Struct</type>
           </field>
-          <field name=""Anonymous2_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          <field name=""Anonymous3"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous3_e__Struct</type>
           </field>
-          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous2_e__Struct"" access=""public"">
             <field name=""Value1"" access=""public"">
               <type>int</type>
             </field>
           </struct>
-          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous3_e__Struct"" access=""public"">
             <field name=""Value2"" access=""public"">
               <type>int</type>
             </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/UnionDeclarationTest.cs
@@ -749,35 +749,35 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.w;</code>
+          <code>return ref Anonymous.Anonymous1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1258,25 +1258,25 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.A;</code>
+          <code>return ref Anonymous.Anonymous.A;</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.B;</code>
+          <code>return ref Anonymous.Anonymous.B;</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type native=""long"">nint</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/StructDeclarationTest.cs
@@ -1168,35 +1168,35 @@ struct MyStruct
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.w;</code>
+          <code>return ref Anonymous.Anonymous1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""z"" access=""public"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
           <field name=""w"" access=""public"">
             <type>int</type>
           </field>
@@ -1861,24 +1861,24 @@ struct MyStruct3
 <bindings>
   <namespace name=""ClangSharp.Test"">
     <struct name=""_MyStruct"" access=""public"">
-      <field name=""Anonymous1"" access=""public"">
-        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous1_e__Struct</type>
+      <field name=""Anonymous"" access=""public"">
+        <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C5"">_Anonymous_e__Struct</type>
       </field>
       <field name=""MyArray"" access=""public"">
-        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_Anonymous2_e__Struct</type>
+        <type native=""struct (anonymous struct at ClangUnsavedFile.h:4:5)[2]"" count=""2"" fixed=""_MyArray_e__FixedBuffer"">_MyArray_e__Struct</type>
       </field>
       <field name=""First"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous1.First;</code>
+          <code>return ref Anonymous.First;</code>
         </get>
       </field>
-      <struct name=""_Anonymous1_e__Struct"" access=""public"">
+      <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type>int</type>
         </field>
       </struct>
-      <struct name=""_Anonymous2_e__Struct"" access=""public"">
+      <struct name=""_MyArray_e__Struct"" access=""public"">
         <field name=""Second"" access=""public"">
           <type>int</type>
         </field>
@@ -1886,7 +1886,7 @@ struct MyStruct3
       <struct name=""_MyArray_e__FixedBuffer"" access=""public"">
         <attribute>InlineArray(2)</attribute>
         <field name=""e0"" access=""public"">
-          <type>_Anonymous2_e__Struct</type>
+          <type>_MyArray_e__Struct</type>
         </field>
       </struct>
     </struct>
@@ -1917,32 +1917,32 @@ struct MyStruct3
       <field name=""Value1"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.Anonymous1_2.Value1;</code>
+          <code>return ref Anonymous.Anonymous1.Anonymous2.Value1;</code>
         </get>
       </field>
       <field name=""Value2"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.Anonymous2_2.Value2;</code>
+          <code>return ref Anonymous.Anonymous1.Anonymous3.Value2;</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous_1_e__Struct</type>
+        <field name=""Anonymous1"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L3_C14"">_Anonymous1_e__Struct</type>
         </field>
-        <struct name=""_Anonymous_1_e__Struct"" access=""public"">
-          <field name=""Anonymous1_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous1_2_e__Struct</type>
+        <struct name=""_Anonymous1_e__Struct"" access=""public"">
+          <field name=""Anonymous2"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L4_C9"">_Anonymous2_e__Struct</type>
           </field>
-          <field name=""Anonymous2_2"" access=""public"">
-            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous2_2_e__Struct</type>
+          <field name=""Anonymous3"" access=""public"">
+            <type native=""__AnonymousRecord_ClangUnsavedFile_L5_C9"">_Anonymous3_e__Struct</type>
           </field>
-          <struct name=""_Anonymous1_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous2_e__Struct"" access=""public"">
             <field name=""Value1"" access=""public"">
               <type>int</type>
             </field>
           </struct>
-          <struct name=""_Anonymous2_2_e__Struct"" access=""public"">
+          <struct name=""_Anonymous3_e__Struct"" access=""public"">
             <field name=""Value2"" access=""public"">
               <type>int</type>
             </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/UnionDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/UnionDeclarationTest.cs
@@ -755,35 +755,35 @@ union MyUnion
       <field name=""w"" access=""public"">
         <type>ref int</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.w;</code>
+          <code>return ref Anonymous.Anonymous1.w;</code>
         </get>
       </field>
       <field name=""o0_b0_16"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b0_16;</code>
+          <code>return Anonymous.Anonymous1.o0_b0_16;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b0_16 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b0_16 = value;</code>
         </set>
       </field>
       <field name=""o0_b16_4"" access=""public"">
         <type>int</type>
         <get>
-          <code>return Anonymous.Anonymous_1.o0_b16_4;</code>
+          <code>return Anonymous.Anonymous1.o0_b16_4;</code>
         </get>
         <set>
-          <code>Anonymous.Anonymous_1.o0_b16_4 = value;</code>
+          <code>Anonymous.Anonymous1.o0_b16_4 = value;</code>
         </set>
       </field>
       <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
         <field name=""z"" access=""public"" offset=""0"">
           <type>int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"" offset=""0"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous1"" access=""public"" offset=""0"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L10_C9"">_Anonymous1_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous1_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""w"" access=""public"" offset=""0"">
             <type>int</type>
           </field>
@@ -1264,25 +1264,25 @@ union MyUnion
         </get>
       </field>
       <field name=""A"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._A_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._A_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.A;</code>
+          <code>return ref Anonymous.Anonymous.A;</code>
         </get>
       </field>
       <field name=""B"" access=""public"">
-        <type>ref _Anonymous_e__Struct._Anonymous_1_e__Union._B_e__Struct</type>
+        <type>ref _Anonymous_e__Struct._Anonymous_e__Union._B_e__Struct</type>
         <get>
-          <code>return ref Anonymous.Anonymous_1.B;</code>
+          <code>return ref Anonymous.Anonymous.B;</code>
         </get>
       </field>
       <struct name=""_Anonymous_e__Struct"" access=""public"">
         <field name=""First"" access=""public"">
           <type native=""long"">int</type>
         </field>
-        <field name=""Anonymous_1"" access=""public"">
-          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_1_e__Union</type>
+        <field name=""Anonymous"" access=""public"">
+          <type native=""__AnonymousRecord_ClangUnsavedFile_L7_C9"">_Anonymous_e__Union</type>
         </field>
-        <struct name=""_Anonymous_1_e__Union"" access=""public"" layout=""Explicit"">
+        <struct name=""_Anonymous_e__Union"" access=""public"" layout=""Explicit"">
           <field name=""A"" access=""public"" offset=""0"">
             <type native=""__AnonymousRecord_ClangUnsavedFile_L9_C13"">_A_e__Struct</type>
           </field>


### PR DESCRIPTION
This fixes `RecordDecl` to once again match the Clang C++ API surface and ensures we don't deviate from the previous naming strategy when no conflicts exist to avoid unnecessary churn.

This was broken in https://github.com/dotnet/ClangSharp/pull/587