### PR TITLE
Make marker interfaces partial to support user extensions

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -826,7 +826,7 @@ internal partial class CSharpOutputBuilder : IOutputBuilder
 
     public void BeginMarkerInterface(string[]? baseTypeNames)
     {
-        WriteIndented("public interface Interface");
+        WriteIndented("public partial interface Interface");
 
         if (baseTypeNames is not null)
         {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/CXXMethodDeclarationTest.cs
@@ -633,7 +633,7 @@ namespace ClangSharp.Test
             }}
         }}
 
-        public interface Interface
+        public partial interface Interface
         {{
             int GetType(int obj);
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/CXXMethodDeclarationTest.cs
@@ -628,7 +628,7 @@ namespace ClangSharp.Test
             }}
         }}
 
-        public interface Interface
+        public partial interface Interface
         {{
             int GetType(int objA, int objB);
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/CXXMethodDeclarationTest.cs
@@ -571,7 +571,7 @@ namespace ClangSharp.Test
             return lpVtbl->GetType2((MyStruct*)Unsafe.AsPointer(ref this), objA, objB);
         }}
 
-        public interface Interface
+        public partial interface Interface
         {{
             int GetType(int obj);
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/CXXMethodDeclarationTest.cs
@@ -576,7 +576,7 @@ namespace ClangSharp.Test
             return lpVtbl->GetType2((MyStruct*)Unsafe.AsPointer(ref this), obj);
         }}
 
-        public interface Interface
+        public partial interface Interface
         {{
             int GetType(int objA, int objB);
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/CXXMethodDeclarationTest.cs
@@ -571,7 +571,7 @@ namespace ClangSharp.Test
             return lpVtbl->GetType2((MyStruct*)Unsafe.AsPointer(ref this), objA, objB);
         }}
 
-        public interface Interface
+        public partial interface Interface
         {{
             int GetType(int obj);
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/CXXMethodDeclarationTest.cs
@@ -571,7 +571,7 @@ namespace ClangSharp.Test
             return lpVtbl->GetType2((MyStruct*)Unsafe.AsPointer(ref this), obj);
         }}
 
-        public interface Interface
+        public partial interface Interface
         {{
             int GetType(int objA, int objB);
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/CXXMethodDeclarationTest.cs
@@ -571,7 +571,7 @@ namespace ClangSharp.Test
             return lpVtbl->GetType2((MyStruct*)Unsafe.AsPointer(ref this), objA, objB);
         }}
 
-        public interface Interface
+        public partial interface Interface
         {{
             int GetType(int obj);
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/CXXMethodDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/CXXMethodDeclarationTest.cs
@@ -571,7 +571,7 @@ namespace ClangSharp.Test
             return lpVtbl->GetType2((MyStruct*)Unsafe.AsPointer(ref this), obj);
         }}
 
-        public interface Interface
+        public partial interface Interface
         {{
             int GetType(int objA, int objB);
 


### PR DESCRIPTION
## Summary

Makes generated marker interfaces `partial` to allow users to manually extend them with custom implementations.

Fixes #647

## Changes

- Modified `CSharpOutputBuilder.VisitDecl.cs:829` to generate `public partial interface Interface` instead of `public interface Interface`

## Why

When `--generate-marker-interfaces` is enabled, users may want to manually add custom helper methods to the interface contract. Without the `partial` keyword, this is impossible.

## Impact

- **Non-breaking**: Adding `partial` to an interface is backward compatible
- **Consistent**: Matches the existing pattern where generated structs are already `partial`
- **Enables**: User extensions for excluded methods, custom helpers, or manual implementations of unsupported C++ constructs

## Testing

- Built successfully with `dotnet build`
- No compilation errors or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>