### PR TITLE
Fix compiler warning by always returning a value.

### DIFF
--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -5409,7 +5409,7 @@ CXCursor clangsharp_Type_getSubstTemplateTypeParamAssociatedDecl(CXType CT) {
         return MakeCXCursor(STTPT->getAssociatedDecl(), GetTypeTU(CT));
     }
 
-    clang_getNullCursor();
+    return clang_getNullCursor();
 }
 
 CXCursor clangsharp_Type_getOwnedTagDecl(CXType CT) {


### PR DESCRIPTION
Fixes:

```
ClangSharp/sources/libClangSharp/ClangSharp.cpp:5643:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
 5643 | }
```