### PR TITLE
Fix a few compiler warnings.

### DIFF
--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -162,10 +162,10 @@ CXCursor clangsharp_Cursor_getArgument(CXCursor C, unsigned i) {
                 llvm::PointerUnion<BlockDecl*, CompoundLiteralExpr*> object = EWC->getObject(i);
 
                 if (isa<BlockDecl*>(object)) {
-                    return MakeCXCursor(object.get<BlockDecl*>(), getCursorTU(C));
+                    return MakeCXCursor(cast<BlockDecl*>(object), getCursorTU(C));
                 }
                 else {
-                    return MakeCXCursor(object.get<CompoundLiteralExpr*>(), getCursorDecl(C), getCursorTU(C));
+                    return MakeCXCursor(cast<CompoundLiteralExpr*>(object), getCursorDecl(C), getCursorTU(C));
                 }
             }
         }


### PR DESCRIPTION
* Use 'cast' instead of 'get'.

    Fixes:

    ```
    ClangSharp/ClangSharp/sources/libClangSharp/ClangSharp.cpp:166:48: warning: 'get' is deprecated: Use cast instead [-Wdeprecated-declarations]
      166 |                     return MakeCXCursor(object.get<BlockDecl*>(), getCursorTU(C));
          |                                                ^
    ClangSharp/artifacts/llvm/install/include/llvm/ADT/PointerUnion.h:161:12: note: 'get' has been explicitly marked deprecated here
      161 |   inline T get() const {
          |            ^
    ClangSharp/ClangSharp/sources/libClangSharp/ClangSharp.cpp:166:48: warning: 'get<clang::BlockDecl *>' is deprecated: Use cast instead [-Wdeprecated-declarations]
      166 |                     return MakeCXCursor(object.get<BlockDecl*>(), getCursorTU(C));
          |                                                ^
    ClangSharp/artifacts/llvm/install/include/llvm/ADT/PointerUnion.h:160:5: note: 'get<clang::BlockDecl *>' has been explicitly marked deprecated here
      160 |   [[deprecated("Use cast instead")]]
          |     ^
    ClangSharp/ClangSharp/sources/libClangSharp/ClangSharp.cpp:169:48: warning: 'get' is deprecated: Use cast instead [-Wdeprecated-declarations]
      169 |                     return MakeCXCursor(object.get<CompoundLiteralExpr*>(), getCursorDecl(C), getCursorTU(C));
          |                                                ^
    ClangSharp/artifacts/llvm/install/include/llvm/ADT/PointerUnion.h:161:12: note: 'get' has been explicitly marked deprecated here
      161 |   inline T get() const {
          |            ^
    ClangSharp/ClangSharp/sources/libClangSharp/ClangSharp.cpp:169:48: warning: 'get<clang::CompoundLiteralExpr *>' is deprecated: Use cast instead [-Wdeprecated-declarations]
      169 |                     return MakeCXCursor(object.get<CompoundLiteralExpr*>(), getCursorDecl(C), getCursorTU(C));
          |                                                ^
    ClangSharp/artifacts/llvm/install/include/llvm/ADT/PointerUnion.h:160:5: note: 'get<clang::CompoundLiteralExpr *>' has been explicitly marked deprecated here
      160 |   [[deprecated("Use cast instead")]]
          |     ^
    ```

* Use 'isa' instead of 'is'.

    Fixes:

    ```
    ClangSharp/ClangSharp/sources/libClangSharp/ClangSharp.cpp:165:28: warning: 'is' is deprecated: Use isa instead [-Wdeprecated-declarations]
      165 |                 if (object.is<BlockDecl*>()) {
          |                            ^
    ClangSharp/artifacts/llvm/install/include/llvm/ADT/PointerUnion.h:152:15: note: 'is' has been explicitly marked deprecated here
      152 |   inline bool is() const {
          |               ^
    ClangSharp/ClangSharp/sources/libClangSharp/ClangSharp.cpp:165:28: warning: 'is<clang::BlockDecl *>' is deprecated: Use isa instead [-Wdeprecated-declarations]
      165 |                 if (object.is<BlockDecl*>()) {
          |                            ^
    ClangSharp/artifacts/llvm/install/include/llvm/ADT/PointerUnion.h:151:5: note: 'is<clang::BlockDecl *>' has been explicitly marked deprecated here
      151 |   [[deprecated("Use isa instead")]]
          |     ^
    ```