### PR TITLE
Added special handling of bool to byte remapping in indirect fields. …

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -923,6 +923,19 @@ public partial class PInvokeGenerator
         var accessSpecifier = GetAccessSpecifier(anonymousRecordDecl, matchStar: true);
 
         var typeName = GetRemappedTypeName(fieldDecl, context: null, type, out _);
+
+        if (!_config.GenerateDisableRuntimeMarshalling && typeName.Equals("bool", StringComparison.Ordinal))
+        {
+            // bool is not blittable when DisableRuntimeMarshalling is not specified, so we shouldn't use it for structs that may be in P/Invoke signatures
+            typeName = "byte";
+        }
+
+        if (_config.GenerateCompatibleCode && typeName.StartsWith("bool*", StringComparison.Ordinal))
+        {
+            // bool* is not blittable in compat mode, so we shouldn't use it for structs that may be in P/Invoke signatures
+            typeName = typeName.Replace("bool*", "byte*", StringComparison.Ordinal);
+        }
+
         var name = GetRemappedCursorName(fieldDecl);
         var escapedName = EscapeName(name);
 


### PR DESCRIPTION
Fixes #658.

I could not find any existing UT that test for the case where union memeber require [NativeTypeName] attribute, Probably new `NestedAnonymousWithNativeTypeNameTestImpl` would be needed to cover this, I only tested the codegen when generating PInvokes for llama.cpp locally.

