### PR TITLE
Implement CXCursor.IsExternC for VarDecls.

### DIFF
--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -2237,6 +2237,10 @@ unsigned clangsharp_Cursor_getIsExternC(CXCursor C) {
         if (const FunctionDecl* FD = dyn_cast<FunctionDecl>(D)) {
             return FD->isExternC();
         }
+
+        if (const VarDecl* VD = dyn_cast<VarDecl>(D)) {
+            return VD->isExternC();
+        }
     }
 
     return 0;

--- a/tests/ClangSharp.UnitTests/CXCursor.cs
+++ b/tests/ClangSharp.UnitTests/CXCursor.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 
@@ -23,6 +24,40 @@ public class CXCursorTest : TranslationUnitTest
         Assert.That (functionDecls.Count, Is.GreaterThan (0), "Function");
         foreach (var functionDecl in functionDecls) {
             Assert.That (functionDecl.Handle.AttrKindSpelling, Is.Not.Null.Or.Empty, "AttrKindSpelling");
+        }
+    }
+
+    [Test]
+    public void IsExternC()
+    {
+        AssertNeedNewClangSharp();
+
+        var inputContents =
+    $$"""
+    extern "C" {
+        int theUniverseAndEverything = 0;
+        int hitchhike ();
+    }
+    """;
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var allDecls = new List<Decl>();
+        allDecls.AddRange(translationUnit.TranslationUnitDecl.Decls);
+        allDecls.AddRange(allDecls.OfType<LinkageSpecDecl>().SelectMany(v => v.Decls).ToList());
+
+        var functionDecls = allDecls.OfType<FunctionDecl>().ToList();
+        Assert.That(functionDecls.Count, Is.GreaterThan(0), "Function");
+        foreach (var decl in functionDecls)
+        {
+            Assert.That(decl.IsExternC, Is.True, "IsExternC function");
+        }
+
+        var varDecls = allDecls.OfType<VarDecl>().ToList();
+        Assert.That(varDecls.Count, Is.GreaterThan(0), "Var");
+        foreach (var decl in varDecls)
+        {
+            Assert.That(decl.IsExternC, Is.True, "IsExternC var");
         }
     }
 }


### PR DESCRIPTION
The property VarDecl.IsExternC already exists, so this just makes it work.