### PR TITLE
Fix incorrect 64-bit alignment computation for records with a vtable

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
@@ -926,7 +926,7 @@ public sealed partial class PInvokeGenerator
 
                     if (alignment64 < 4)
                     {
-                        alignment64 = Math.Max(Math.Min(alignment32, 8), 1);
+                        alignment64 = Math.Max(Math.Min(alignment64, 8), 1);
                     }
 
                     maxFieldSize32 = Math.Max(maxFieldSize32, 4);


### PR DESCRIPTION
`GetTypeSize` (in `PInvokeGenerator.TypeResolution.cs`) computed the 64-bit alignment for a record with a vtable by clamping `alignment32` instead of `alignment64`:

```csharp
if (alignment64 < 4)
{
    alignment64 = Math.Max(Math.Min(alignment32, 8), 1);   // used alignment32
}
```

The 32-bit sibling branch just above already uses `alignment32`; this makes the 64-bit branch use `alignment64` as intended.

This is latent in the covered configurations — `alignment32` and `alignment64` are equal on entry to this branch in the tested cases, so no golden output changes and the full suite passes unchanged. It's still an obvious correctness bug that bites once the two alignments diverge, hence the surgical fix. I couldn't construct a triggering golden-file case, so no test is added; happy to add one if you know a scenario that diverges them here.

Builds clean under `TreatWarningsAsErrors`.

----------

First in a small series coming out of an analysis pass. The redundant `IsVirtual && IsVirtual` in `HasVtbl` I also spotted was already fixed upstream, so it's dropped from this PR.