### PR TITLE
Fix potential null dereference of ObjCTypeParamList in Cursor argument and type-param APIs

### DIFF
--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -131,7 +131,7 @@ CXCursor clangsharp_Cursor_getArgument(CXCursor C, unsigned i) {
         if (const ObjCCategoryDecl* OCCD = dyn_cast<ObjCCategoryDecl>(D)) {
             ObjCTypeParamList* typeParamList = OCCD->getTypeParamList();
 
-            if (i < typeParamList->size()) {
+            if (typeParamList != nullptr && i < typeParamList->size()) {
                 return MakeCXCursor(&typeParamList->front()[i], getCursorTU(C));
             }
         }
@@ -4969,7 +4969,7 @@ CXCursor clangsharp_Cursor_getTypeParam(CXCursor C, unsigned i) {
             ObjCTypeParamList* typeParamList = OCCD->getTypeParamList();
 
             unsigned int n = 0;
-            if (i < typeParamList->size()) {
+            if (typeParamList != nullptr && i < typeParamList->size()) {
                 for (auto d : *typeParamList) {
                     if (n == i) {
                         return MakeCXCursor(d, getCursorTU(C));
@@ -4983,7 +4983,7 @@ CXCursor clangsharp_Cursor_getTypeParam(CXCursor C, unsigned i) {
             ObjCTypeParamList* typeParamList = OCID->getTypeParamList();
 
             unsigned int n = 0;
-            if (i < typeParamList->size()) {
+            if (typeParamList != nullptr && i < typeParamList->size()) {
                 for (auto d : *typeParamList) {
                     if (n == i) {
                         return MakeCXCursor(d, getCursorTU(C));


### PR DESCRIPTION
`clangsharp_Cursor_getArgument` and `clangsharp_Cursor_getTypeParam` dereference the result of `ObjCCategoryDecl::getTypeParamList` / `ObjCInterfaceDecl::getTypeParamList` via `->size()` without a null check. These accessors return `null` for an ObjC category/interface that has no type-parameter list, so this is a latent null dereference.

The sibling `clangsharp_Cursor_getNumTypeParams` already guards the same accessor with a null check, so this is just a same-operation-implemented-two-ways inconsistency. This makes all three unchecked sites match that existing pattern (`if (typeParamList != nullptr && i < typeParamList->size())`).

Fixed sites in `sources/libClangSharp/ClangSharp.cpp`:
- `clangsharp_Cursor_getArgument` (`ObjCCategoryDecl`)
- `clangsharp_Cursor_getTypeParam` (`ObjCCategoryDecl`)
- `clangsharp_Cursor_getTypeParam` (`ObjCInterfaceDecl`)

Native-only change; no C# or generated files touched. Verified by inspection against the existing null-checked sibling code -- a full native build/test was not run locally as it requires the complete LLVM/Clang toolchain.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>