### PR TITLE
Fix ValueLazy caching being defeated by readonly fields

### DIFF
--- a/sources/ClangSharp/Cursors/Cursor.cs
+++ b/sources/ClangSharp/Cursors/Cursor.cs
@@ -13,11 +13,11 @@ namespace ClangSharp;
 [DebuggerDisplay("{Handle.DebuggerDisplayString,nq}")]
 public unsafe class Cursor : IEquatable<Cursor>
 {
-    private readonly ValueLazy<string> _kindSpelling;
-    private readonly ValueLazy<Cursor?> _lexicalParentCursor;
-    private readonly ValueLazy<Cursor?> _semanticParentCursor;
-    private readonly ValueLazy<string> _spelling;
-    private readonly ValueLazy<TranslationUnit> _translationUnit;
+    private ValueLazy<string> _kindSpelling;
+    private ValueLazy<Cursor?> _lexicalParentCursor;
+    private ValueLazy<Cursor?> _semanticParentCursor;
+    private ValueLazy<string> _spelling;
+    private ValueLazy<TranslationUnit> _translationUnit;
     private List<Cursor>? _cursorChildren;
 
     private protected Cursor(CXCursor handle, CXCursorKind expectedCursorKind)

--- a/sources/ClangSharp/Cursors/Decls/BindingDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/BindingDecl.cs
@@ -8,9 +8,9 @@ namespace ClangSharp;
 
 public sealed class BindingDecl : ValueDecl
 {
-    private readonly ValueLazy<Expr> _binding;
-    private readonly ValueLazy<ValueDecl> _decomposedDecl;
-    private readonly ValueLazy<VarDecl> _holdingVar;
+    private ValueLazy<Expr> _binding;
+    private ValueLazy<ValueDecl> _decomposedDecl;
+    private ValueLazy<VarDecl> _holdingVar;
 
     internal BindingDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_Binding)
     {

--- a/sources/ClangSharp/Cursors/Decls/BlockDecl.Capture.cs
+++ b/sources/ClangSharp/Cursors/Decls/BlockDecl.Capture.cs
@@ -8,8 +8,8 @@ public partial class BlockDecl
     {
         private readonly Decl _parentDecl;
         private readonly uint _index;
-        private readonly ValueLazy<Expr> _copyExpr;
-        private readonly ValueLazy<VarDecl> _variable;
+        private ValueLazy<Expr> _copyExpr;
+        private ValueLazy<VarDecl> _variable;
 
         internal Capture(Decl parentDecl, uint index)
         {

--- a/sources/ClangSharp/Cursors/Decls/BlockDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/BlockDecl.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed partial class BlockDecl : Decl, IDeclContext
 {
-    private readonly ValueLazy<Decl> _blockManglingContextDecl;
+    private ValueLazy<Decl> _blockManglingContextDecl;
     private readonly LazyList<Capture> _captures;
     private readonly LazyList<ParmVarDecl> _parameters;
 

--- a/sources/ClangSharp/Cursors/Decls/CXXConstructorDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CXXConstructorDecl.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class CXXConstructorDecl : CXXMethodDecl
 {
-    private readonly ValueLazy<CXXConstructorDecl> _inheritedConstructor;
+    private ValueLazy<CXXConstructorDecl> _inheritedConstructor;
     private readonly LazyList<Expr> _initExprs;
 
     internal CXXConstructorDecl(CXCursor handle) : base(handle, CXCursor_Constructor, CX_DeclKind_CXXConstructor)

--- a/sources/ClangSharp/Cursors/Decls/CXXConversionDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CXXConversionDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class CXXConversionDecl : CXXMethodDecl
 {
-    private readonly ValueLazy<Type> _conversionType;
+    private ValueLazy<Type> _conversionType;
 
     internal CXXConversionDecl(CXCursor handle) : base(handle, CXCursor_ConversionFunction, CX_DeclKind_CXXConversion)
     {

--- a/sources/ClangSharp/Cursors/Decls/CXXDeductionGuideDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CXXDeductionGuideDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class CXXDeductionGuideDecl : FunctionDecl
 {
-    private readonly ValueLazy<TemplateDecl> _deducedTemplate;
+    private ValueLazy<TemplateDecl> _deducedTemplate;
 
     internal CXXDeductionGuideDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_CXXDeductionGuide)
     {

--- a/sources/ClangSharp/Cursors/Decls/CXXDestructorDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CXXDestructorDecl.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class CXXDestructorDecl : CXXMethodDecl
 {
-    private readonly ValueLazy<FunctionDecl> _operatorDelete;
-    private readonly ValueLazy<Expr> _operatorDeleteThisArg;
+    private ValueLazy<FunctionDecl> _operatorDelete;
+    private ValueLazy<Expr> _operatorDeleteThisArg;
 
     internal CXXDestructorDecl(CXCursor handle) : base(handle, CXCursor_Destructor, CX_DeclKind_CXXDestructor)
     {

--- a/sources/ClangSharp/Cursors/Decls/CXXMethodDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CXXMethodDecl.cs
@@ -11,8 +11,8 @@ namespace ClangSharp;
 public class CXXMethodDecl : FunctionDecl
 {
     private readonly LazyList<CXXMethodDecl> _overriddenMethods;
-    private readonly ValueLazy<Type> _thisType;
-    private readonly ValueLazy<Type> _thisObjectType;
+    private ValueLazy<Type> _thisType;
+    private ValueLazy<Type> _thisObjectType;
 
     internal CXXMethodDecl(CXCursor handle) : this(handle, CXCursor_CXXMethod, CX_DeclKind_CXXMethod)
     {

--- a/sources/ClangSharp/Cursors/Decls/CXXRecordDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CXXRecordDecl.cs
@@ -12,16 +12,16 @@ public class CXXRecordDecl : RecordDecl
 {
     private readonly LazyList<CXXBaseSpecifier> _bases;
     private readonly LazyList<CXXConstructorDecl> _ctors;
-    private readonly ValueLazy<FunctionTemplateDecl> _dependentLambdaCallOperator;
-    private readonly ValueLazy<ClassTemplateDecl> _describedClassTemplate;
-    private readonly ValueLazy<CXXDestructorDecl?> _destructor;
+    private ValueLazy<FunctionTemplateDecl> _dependentLambdaCallOperator;
+    private ValueLazy<ClassTemplateDecl> _describedClassTemplate;
+    private ValueLazy<CXXDestructorDecl?> _destructor;
     private readonly LazyList<FriendDecl> _friends;
-    private readonly ValueLazy<CXXRecordDecl> _instantiatedFromMemberClass;
-    private readonly ValueLazy<CXXMethodDecl> _lambdaCallOperator;
-    private readonly ValueLazy<Decl> _lambdaContextDecl;
-    private readonly ValueLazy<CXXMethodDecl> _lambdaStaticInvoker;
+    private ValueLazy<CXXRecordDecl> _instantiatedFromMemberClass;
+    private ValueLazy<CXXMethodDecl> _lambdaCallOperator;
+    private ValueLazy<Decl> _lambdaContextDecl;
+    private ValueLazy<CXXMethodDecl> _lambdaStaticInvoker;
     private readonly LazyList<CXXMethodDecl> _methods;
-    private readonly ValueLazy<CXXRecordDecl> _templateInstantiationPattern;
+    private ValueLazy<CXXRecordDecl> _templateInstantiationPattern;
     private readonly LazyList<CXXBaseSpecifier> _vbases;
 
     internal CXXRecordDecl(CXCursor handle) : this(handle, handle.Kind, CX_DeclKind_CXXRecord)

--- a/sources/ClangSharp/Cursors/Decls/CapturedDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CapturedDecl.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class CapturedDecl : Decl, IDeclContext
 {
-    private readonly ValueLazy<ImplicitParamDecl> _contextParam;
+    private ValueLazy<ImplicitParamDecl> _contextParam;
     private readonly LazyList<ImplicitParamDecl> _parameters;
 
     internal CapturedDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_Captured)

--- a/sources/ClangSharp/Cursors/Decls/ClassTemplateDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ClassTemplateDecl.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class ClassTemplateDecl : RedeclarableTemplateDecl
 {
-    private readonly ValueLazy<Type> _injectedClassNameSpecialization;
+    private ValueLazy<Type> _injectedClassNameSpecialization;
     private readonly LazyList<ClassTemplateSpecializationDecl> _specializations;
 
     internal ClassTemplateDecl(CXCursor handle) : base(handle, CXCursor_ClassTemplate, CX_DeclKind_ClassTemplate)

--- a/sources/ClangSharp/Cursors/Decls/ClassTemplatePartialSpecializationDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ClassTemplatePartialSpecializationDecl.cs
@@ -10,8 +10,8 @@ namespace ClangSharp;
 public sealed class ClassTemplatePartialSpecializationDecl : ClassTemplateSpecializationDecl
 {
     private readonly LazyList<Expr> _associatedConstraints;
-    private readonly ValueLazy<Type> _injectedSpecializationType;
-    private readonly ValueLazy<ClassTemplatePartialSpecializationDecl> _instantiatedFromMember;
+    private ValueLazy<Type> _injectedSpecializationType;
+    private ValueLazy<ClassTemplatePartialSpecializationDecl> _instantiatedFromMember;
     private readonly LazyList<NamedDecl> _templateParameters;
 
     internal ClassTemplatePartialSpecializationDecl(CXCursor handle) : base(handle, CXCursor_ClassTemplatePartialSpecialization, CX_DeclKind_ClassTemplatePartialSpecialization)

--- a/sources/ClangSharp/Cursors/Decls/ClassTemplateSpecializationDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ClassTemplateSpecializationDecl.cs
@@ -11,7 +11,7 @@ namespace ClangSharp;
 
 public class ClassTemplateSpecializationDecl : CXXRecordDecl
 {
-    private readonly ValueLazy<ClassTemplateDecl> _specializedTemplate;
+    private ValueLazy<ClassTemplateDecl> _specializedTemplate;
     private readonly LazyList<TemplateArgument> _templateArgs;
 
     internal ClassTemplateSpecializationDecl(CXCursor handle) : this(handle, handle.Kind, CX_DeclKind_ClassTemplateSpecialization)

--- a/sources/ClangSharp/Cursors/Decls/ConceptDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ConceptDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class ConceptDecl : TemplateDecl, IMergeable<ConceptDecl>
 {
-    private readonly ValueLazy<Expr> _constraintExpr;
+    private ValueLazy<Expr> _constraintExpr;
 
     internal ConceptDecl(CXCursor handle) : base(handle, CXCursor_ConceptDecl, CX_DeclKind_Concept)
     {

--- a/sources/ClangSharp/Cursors/Decls/ConstructorUsingShadowDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ConstructorUsingShadowDecl.cs
@@ -8,10 +8,10 @@ namespace ClangSharp;
 
 public sealed class ConstructorUsingShadowDecl : UsingShadowDecl
 {
-    private readonly ValueLazy<CXXRecordDecl> _constructedBaseClass;
-    private readonly ValueLazy<ConstructorUsingShadowDecl> _constructedBaseClassShadowDecl;
-    private readonly ValueLazy<CXXRecordDecl> _nominatedBaseClass;
-    private readonly ValueLazy<ConstructorUsingShadowDecl> _nominatedBaseClassShadowDecl;
+    private ValueLazy<CXXRecordDecl> _constructedBaseClass;
+    private ValueLazy<ConstructorUsingShadowDecl> _constructedBaseClassShadowDecl;
+    private ValueLazy<CXXRecordDecl> _nominatedBaseClass;
+    private ValueLazy<ConstructorUsingShadowDecl> _nominatedBaseClassShadowDecl;
 
     internal ConstructorUsingShadowDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_ConstructorUsingShadow)
     {

--- a/sources/ClangSharp/Cursors/Decls/Decl.cs
+++ b/sources/ClangSharp/Cursors/Decls/Decl.cs
@@ -10,19 +10,19 @@ namespace ClangSharp;
 
 public class Decl : Cursor
 {
-    private readonly ValueLazy<FunctionDecl> _asFunction;
+    private ValueLazy<FunctionDecl> _asFunction;
     private readonly LazyList<Attr> _attrs;
-    private readonly ValueLazy<Stmt?> _body;
-    private readonly ValueLazy<Decl> _canonicalDecl;
+    private ValueLazy<Stmt?> _body;
+    private ValueLazy<Decl> _canonicalDecl;
     private readonly LazyList<Decl> _decls;
-    private readonly ValueLazy<TemplateDecl?> _describedTemplate;
-    private readonly ValueLazy<Decl> _mostRecentDecl;
-    private readonly ValueLazy<Decl> _nextDeclInContext;
-    private readonly ValueLazy<Decl> _nonClosureContext;
-    private readonly ValueLazy<IDeclContext?> _parentFunctionOrMethod;
-    private readonly ValueLazy<Decl> _previousDecl;
-    private readonly ValueLazy<IDeclContext?> _redeclContext;
-    private readonly ValueLazy<TranslationUnitDecl> _translationUnitDecl;
+    private ValueLazy<TemplateDecl?> _describedTemplate;
+    private ValueLazy<Decl> _mostRecentDecl;
+    private ValueLazy<Decl> _nextDeclInContext;
+    private ValueLazy<Decl> _nonClosureContext;
+    private ValueLazy<IDeclContext?> _parentFunctionOrMethod;
+    private ValueLazy<Decl> _previousDecl;
+    private ValueLazy<IDeclContext?> _redeclContext;
+    private ValueLazy<TranslationUnitDecl> _translationUnitDecl;
 
     private protected Decl(CXCursor handle, CXCursorKind expectedCursorKind, CX_DeclKind expectedDeclKind) : base(handle, expectedCursorKind)
     {

--- a/sources/ClangSharp/Cursors/Decls/DeclaratorDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/DeclaratorDecl.cs
@@ -10,7 +10,7 @@ namespace ClangSharp;
 public class DeclaratorDecl : ValueDecl
 {
     private readonly LazyList<LazyList<NamedDecl>> _templateParameterLists;
-    private readonly ValueLazy<Expr> _trailingRequiresClause;
+    private ValueLazy<Expr> _trailingRequiresClause;
 
     private protected DeclaratorDecl(CXCursor handle, CXCursorKind expectedCursorKind, CX_DeclKind expectedDeclKind) : base(handle, expectedCursorKind, expectedDeclKind)
     {

--- a/sources/ClangSharp/Cursors/Decls/EnumConstantDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/EnumConstantDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class EnumConstantDecl : ValueDecl, IMergeable<EnumConstantDecl>
 {
-    private readonly ValueLazy<Expr?> _initExpr;
+    private ValueLazy<Expr?> _initExpr;
 
     internal EnumConstantDecl(CXCursor handle) : base(handle, CXCursor_EnumConstantDecl, CX_DeclKind_EnumConstant)
     {

--- a/sources/ClangSharp/Cursors/Decls/EnumDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/EnumDecl.cs
@@ -10,10 +10,10 @@ namespace ClangSharp;
 public sealed class EnumDecl : TagDecl
 {
     private readonly LazyList<EnumConstantDecl> _enumerators;
-    private readonly ValueLazy<EnumDecl> _instantiatedFromMemberEnum;
-    private readonly ValueLazy<Type> _integerType;
-    private readonly ValueLazy<Type> _promotionType;
-    private readonly ValueLazy<EnumDecl> _templateInstantiationPattern;
+    private ValueLazy<EnumDecl> _instantiatedFromMemberEnum;
+    private ValueLazy<Type> _integerType;
+    private ValueLazy<Type> _promotionType;
+    private ValueLazy<EnumDecl> _templateInstantiationPattern;
 
     internal EnumDecl(CXCursor handle) : base(handle, CXCursor_EnumDecl, CX_DeclKind_Enum)
     {

--- a/sources/ClangSharp/Cursors/Decls/FieldDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/FieldDecl.cs
@@ -10,9 +10,9 @@ namespace ClangSharp;
 
 public class FieldDecl : DeclaratorDecl, IMergeable<FieldDecl>
 {
-    private readonly ValueLazy<Expr> _bitWidth;
-    private readonly ValueLazy<Expr> _inClassInitializer;
-    private readonly ValueLazy<bool> _isAnonymousField;
+    private ValueLazy<Expr> _bitWidth;
+    private ValueLazy<Expr> _inClassInitializer;
+    private ValueLazy<bool> _isAnonymousField;
 
     internal FieldDecl(CXCursor handle) : this(handle, CXCursor_FieldDecl, CX_DeclKind_Field)
     {

--- a/sources/ClangSharp/Cursors/Decls/FriendDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/FriendDecl.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class FriendDecl : Decl
 {
-    private readonly ValueLazy<NamedDecl> _friendNamedDecl;
+    private ValueLazy<NamedDecl> _friendNamedDecl;
     private readonly LazyList<LazyList<NamedDecl>> _friendTypeTemplateParameterLists;
 
     internal FriendDecl(CXCursor handle) : base(handle, CXCursor_FriendDecl, CX_DeclKind_Friend)

--- a/sources/ClangSharp/Cursors/Decls/FriendTemplateDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/FriendTemplateDecl.cs
@@ -9,8 +9,8 @@ namespace ClangSharp;
 
 public sealed class FriendTemplateDecl : Decl
 {
-    private readonly ValueLazy<NamedDecl> _friendDecl;
-    private readonly ValueLazy<Type> _friendType;
+    private ValueLazy<NamedDecl> _friendDecl;
+    private ValueLazy<Type> _friendType;
     private readonly LazyList<LazyList<NamedDecl>> _templateParameterLists;
 
     internal FriendTemplateDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_FriendTemplate)

--- a/sources/ClangSharp/Cursors/Decls/FunctionDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/FunctionDecl.cs
@@ -10,15 +10,15 @@ namespace ClangSharp;
 
 public class FunctionDecl : DeclaratorDecl, IDeclContext, IRedeclarable<FunctionDecl>
 {
-    private readonly ValueLazy<Type> _callResultType;
-    private readonly ValueLazy<Type> _declaredReturnType;
-    private readonly ValueLazy<FunctionDecl> _definition;
-    private readonly ValueLazy<FunctionTemplateDecl> _describedFunctionDecl;
-    private readonly ValueLazy<FunctionDecl> _instantiatedFromMemberFunction;
+    private ValueLazy<Type> _callResultType;
+    private ValueLazy<Type> _declaredReturnType;
+    private ValueLazy<FunctionDecl> _definition;
+    private ValueLazy<FunctionTemplateDecl> _describedFunctionDecl;
+    private ValueLazy<FunctionDecl> _instantiatedFromMemberFunction;
     private readonly LazyList<ParmVarDecl> _parameters;
-    private readonly ValueLazy<FunctionTemplateDecl> _primaryTemplate;
-    private readonly ValueLazy<Type> _returnType;
-    private readonly ValueLazy<FunctionDecl> _templateInstantiationPattern;
+    private ValueLazy<FunctionTemplateDecl> _primaryTemplate;
+    private ValueLazy<Type> _returnType;
+    private ValueLazy<FunctionDecl> _templateInstantiationPattern;
     private readonly LazyList<TemplateArgument> _templateSpecializationArgs;
 
     internal FunctionDecl(CXCursor handle) : this(handle, CXCursor_FunctionDecl, CX_DeclKind_Function)

--- a/sources/ClangSharp/Cursors/Decls/IndirectFieldDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/IndirectFieldDecl.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class IndirectFieldDecl : ValueDecl, IMergeable<IndirectFieldDecl>
 {
-    private readonly ValueLazy<FieldDecl> _anonField;
-    private readonly ValueLazy<VarDecl> _varDecl;
+    private ValueLazy<FieldDecl> _anonField;
+    private ValueLazy<VarDecl> _varDecl;
 
     internal IndirectFieldDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_IndirectField)
     {

--- a/sources/ClangSharp/Cursors/Decls/LabelDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/LabelDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class LabelDecl : NamedDecl
 {
-    private readonly ValueLazy<LabelStmt> _stmt;
+    private ValueLazy<LabelStmt> _stmt;
 
     internal LabelDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_Label)
     {

--- a/sources/ClangSharp/Cursors/Decls/LifetimeExtendedTemporaryDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/LifetimeExtendedTemporaryDecl.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class LifetimeExtendedTemporaryDecl : Decl, IMergeable<LifetimeExtendedTemporaryDecl>
 {
-    private readonly ValueLazy<ValueDecl> _extendingDecl;
-    private readonly ValueLazy<Expr> _temporaryExpr;
+    private ValueLazy<ValueDecl> _extendingDecl;
+    private ValueLazy<Expr> _temporaryExpr;
 
     internal LifetimeExtendedTemporaryDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_LifetimeExtendedTemporary)
     {

--- a/sources/ClangSharp/Cursors/Decls/NamedDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/NamedDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public class NamedDecl : Decl
 {
-    private readonly ValueLazy<NamedDecl> _underlyingDecl;
+    private ValueLazy<NamedDecl> _underlyingDecl;
 
     private protected NamedDecl(CXCursor handle, CXCursorKind expectedCursorKind, CX_DeclKind expectedDeclKind) : base(handle, expectedCursorKind, expectedDeclKind)
     {

--- a/sources/ClangSharp/Cursors/Decls/NamespaceAliasDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/NamespaceAliasDecl.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class NamespaceAliasDecl : NamedDecl, IRedeclarable<NamespaceDecl>
 {
-    private readonly ValueLazy<NamedDecl> _aliasedNamespace;
-    private readonly ValueLazy<NamespaceDecl> _namespace;
+    private ValueLazy<NamedDecl> _aliasedNamespace;
+    private ValueLazy<NamespaceDecl> _namespace;
 
     internal NamespaceAliasDecl(CXCursor handle) : base(handle, CXCursor_NamespaceAlias, CX_DeclKind_NamespaceAlias)
     {

--- a/sources/ClangSharp/Cursors/Decls/NamespaceDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/NamespaceDecl.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class NamespaceDecl : NamedDecl, IDeclContext, IRedeclarable<NamespaceDecl>
 {
-    private readonly ValueLazy<NamespaceDecl> _anonymousNamespace;
-    private readonly ValueLazy<NamespaceDecl> _originalNamespace;
+    private ValueLazy<NamespaceDecl> _anonymousNamespace;
+    private ValueLazy<NamespaceDecl> _originalNamespace;
 
     internal NamespaceDecl(CXCursor handle) : base(handle, CXCursor_Namespace, CX_DeclKind_Namespace)
     {

--- a/sources/ClangSharp/Cursors/Decls/NonTypeTemplateParmDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/NonTypeTemplateParmDecl.cs
@@ -10,9 +10,9 @@ namespace ClangSharp;
 public sealed class NonTypeTemplateParmDecl : DeclaratorDecl, ITemplateParmPosition
 {
     private readonly LazyList<Expr> _associatedConstraints;
-    private readonly ValueLazy<Expr> _defaultArgument;
+    private ValueLazy<Expr> _defaultArgument;
     private readonly LazyList<Type> _expansionTypes;
-    private readonly ValueLazy<Expr> _placeholderTypeConstraint;
+    private ValueLazy<Expr> _placeholderTypeConstraint;
 
     internal NonTypeTemplateParmDecl(CXCursor handle) : base(handle, CXCursor_NonTypeTemplateParameter, CX_DeclKind_NonTypeTemplateParm)
     {

--- a/sources/ClangSharp/Cursors/Decls/ObjCCategoryDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCCategoryDecl.cs
@@ -10,11 +10,11 @@ namespace ClangSharp;
 
 public sealed class ObjCCategoryDecl : ObjCContainerDecl
 {
-    private readonly ValueLazy<ObjCInterfaceDecl> _classInterface;
-    private readonly ValueLazy<ObjCCategoryImplDecl> _implementation;
-    private readonly ValueLazy<List<ObjCIvarDecl>> _ivars;
-    private readonly ValueLazy<ObjCCategoryDecl> _nextClassCategory;
-    private readonly ValueLazy<ObjCCategoryDecl> _nextClassCategoryRaw;
+    private ValueLazy<ObjCInterfaceDecl> _classInterface;
+    private ValueLazy<ObjCCategoryImplDecl> _implementation;
+    private ValueLazy<List<ObjCIvarDecl>> _ivars;
+    private ValueLazy<ObjCCategoryDecl> _nextClassCategory;
+    private ValueLazy<ObjCCategoryDecl> _nextClassCategoryRaw;
     private readonly LazyList<ObjCProtocolDecl> _protocols;
     private readonly LazyList<ObjCTypeParamDecl> _typeParamList;
 

--- a/sources/ClangSharp/Cursors/Decls/ObjCCategoryImplDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCCategoryImplDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class ObjCCategoryImplDecl : ObjCImplDecl
 {
-    private readonly ValueLazy<ObjCCategoryDecl> _categoryDecl;
+    private ValueLazy<ObjCCategoryDecl> _categoryDecl;
 
     internal ObjCCategoryImplDecl(CXCursor handle) : base(handle, CXCursor_ObjCCategoryImplDecl, CX_DeclKind_ObjCCategoryImpl)
     {

--- a/sources/ClangSharp/Cursors/Decls/ObjCCompatibleAliasDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCCompatibleAliasDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class ObjCCompatibleAliasDecl : NamedDecl
 {
-    private readonly ValueLazy<ObjCInterfaceDecl> _classInterface;
+    private ValueLazy<ObjCInterfaceDecl> _classInterface;
 
     internal ObjCCompatibleAliasDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_ObjCCompatibleAlias)
     {

--- a/sources/ClangSharp/Cursors/Decls/ObjCContainerDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCContainerDecl.cs
@@ -10,12 +10,12 @@ namespace ClangSharp;
 
 public class ObjCContainerDecl : NamedDecl, IDeclContext
 {
-    private readonly ValueLazy<List<ObjCMethodDecl>> _classMethods;
-    private readonly ValueLazy<List<ObjCPropertyDecl>> _classProperties;
-    private readonly ValueLazy<List<ObjCMethodDecl>> _instanceMethods;
-    private readonly ValueLazy<List<ObjCPropertyDecl>> _instanceProperties;
-    private readonly ValueLazy<List<ObjCMethodDecl>> _methods;
-    private readonly ValueLazy<List<ObjCPropertyDecl>> _properties;
+    private ValueLazy<List<ObjCMethodDecl>> _classMethods;
+    private ValueLazy<List<ObjCPropertyDecl>> _classProperties;
+    private ValueLazy<List<ObjCMethodDecl>> _instanceMethods;
+    private ValueLazy<List<ObjCPropertyDecl>> _instanceProperties;
+    private ValueLazy<List<ObjCMethodDecl>> _methods;
+    private ValueLazy<List<ObjCPropertyDecl>> _properties;
 
     private protected ObjCContainerDecl(CXCursor handle, CXCursorKind expectedCursorKind, CX_DeclKind expectedDeclKind) : base(handle, expectedCursorKind, expectedDeclKind)
     {

--- a/sources/ClangSharp/Cursors/Decls/ObjCImplDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCImplDecl.cs
@@ -10,8 +10,8 @@ namespace ClangSharp;
 
 public class ObjCImplDecl : ObjCContainerDecl
 {
-    private readonly ValueLazy<ObjCInterfaceDecl> _classInterface;
-    private readonly ValueLazy<List<ObjCPropertyImplDecl>> _propertyImpls;
+    private ValueLazy<ObjCInterfaceDecl> _classInterface;
+    private ValueLazy<List<ObjCPropertyImplDecl>> _propertyImpls;
 
     private protected ObjCImplDecl(CXCursor handle, CXCursorKind expectedCursorKind, CX_DeclKind expectedDeclKind) : base(handle, expectedCursorKind, expectedDeclKind)
     {

--- a/sources/ClangSharp/Cursors/Decls/ObjCImplementationDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCImplementationDecl.cs
@@ -11,8 +11,8 @@ namespace ClangSharp;
 public sealed class ObjCImplementationDecl : ObjCImplDecl
 {
     private readonly LazyList<Expr> _initExprs;
-    private readonly ValueLazy<List<ObjCIvarDecl>> _ivars;
-    private readonly ValueLazy<ObjCInterfaceDecl> _superClass;
+    private ValueLazy<List<ObjCIvarDecl>> _ivars;
+    private ValueLazy<ObjCInterfaceDecl> _superClass;
 
     internal ObjCImplementationDecl(CXCursor handle) : base(handle, CXCursor_ObjCImplementationDecl, CX_DeclKind_ObjCImplementation)
     {

--- a/sources/ClangSharp/Cursors/Decls/ObjCInterfaceDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCInterfaceDecl.cs
@@ -10,18 +10,18 @@ namespace ClangSharp;
 
 public sealed class ObjCInterfaceDecl : ObjCContainerDecl, IRedeclarable<ObjCInterfaceDecl>
 {
-    private readonly ValueLazy<List<ObjCCategoryDecl>> _categoryList;
-    private readonly ValueLazy<ObjCInterfaceDecl> _definition;
-    private readonly ValueLazy<ObjCImplementationDecl> _implementation;
-    private readonly ValueLazy<List<ObjCIvarDecl>> _ivars;
-    private readonly ValueLazy<List<ObjCCategoryDecl>> _knownExtensions;
+    private ValueLazy<List<ObjCCategoryDecl>> _categoryList;
+    private ValueLazy<ObjCInterfaceDecl> _definition;
+    private ValueLazy<ObjCImplementationDecl> _implementation;
+    private ValueLazy<List<ObjCIvarDecl>> _ivars;
+    private ValueLazy<List<ObjCCategoryDecl>> _knownExtensions;
     private readonly LazyList<ObjCProtocolDecl> _protocols;
-    private readonly ValueLazy<ObjCInterfaceDecl> _superClass;
-    private readonly ValueLazy<ObjCObjectType> _superClassType;
-    private readonly ValueLazy<Type> _typeForDecl;
+    private ValueLazy<ObjCInterfaceDecl> _superClass;
+    private ValueLazy<ObjCObjectType> _superClassType;
+    private ValueLazy<Type> _typeForDecl;
     private readonly LazyList<ObjCTypeParamDecl> _typeParamList;
-    private readonly ValueLazy<List<ObjCCategoryDecl>> _visibleCategories;
-    private readonly ValueLazy<List<ObjCCategoryDecl>> _visibleExtensions;
+    private ValueLazy<List<ObjCCategoryDecl>> _visibleCategories;
+    private ValueLazy<List<ObjCCategoryDecl>> _visibleExtensions;
 
     internal ObjCInterfaceDecl(CXCursor handle) : base(handle, CXCursor_ObjCInterfaceDecl, CX_DeclKind_ObjCInterface)
     {

--- a/sources/ClangSharp/Cursors/Decls/ObjCIvarDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCIvarDecl.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class ObjCIvarDecl : FieldDecl
 {
-    private readonly ValueLazy<ObjCInterfaceDecl> _containingInterface;
-    private readonly ValueLazy<ObjCIvarDecl> _nextIvar;
+    private ValueLazy<ObjCInterfaceDecl> _containingInterface;
+    private ValueLazy<ObjCIvarDecl> _nextIvar;
 
     internal ObjCIvarDecl(CXCursor handle) : base(handle, CXCursor_ObjCIvarDecl, CX_DeclKind_ObjCIvar)
     {

--- a/sources/ClangSharp/Cursors/Decls/ObjCMethodDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCMethodDecl.cs
@@ -10,12 +10,12 @@ namespace ClangSharp;
 
 public sealed class ObjCMethodDecl : NamedDecl, IDeclContext
 {
-    private readonly ValueLazy<ObjCInterfaceDecl> _classInterface;
-    private readonly ValueLazy<ImplicitParamDecl> _cmdDecl;
+    private ValueLazy<ObjCInterfaceDecl> _classInterface;
+    private ValueLazy<ImplicitParamDecl> _cmdDecl;
     private readonly LazyList<ParmVarDecl> _parameters;
-    private readonly ValueLazy<Type> _returnType;
-    private readonly ValueLazy<ImplicitParamDecl> _selfDecl;
-    private readonly ValueLazy<Type> _sendResultType;
+    private ValueLazy<Type> _returnType;
+    private ValueLazy<ImplicitParamDecl> _selfDecl;
+    private ValueLazy<Type> _sendResultType;
 
     internal ObjCMethodDecl(CXCursor handle) : base(handle, handle.Kind, CX_DeclKind_ObjCMethod)
     {

--- a/sources/ClangSharp/Cursors/Decls/ObjCPropertyDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCPropertyDecl.cs
@@ -8,10 +8,10 @@ namespace ClangSharp;
 
 public sealed class ObjCPropertyDecl : NamedDecl
 {
-    private readonly ValueLazy<ObjCMethodDecl> _getterMethodDecl;
-    private readonly ValueLazy<ObjCIvarDecl> _propertyIvarDecl;
-    private readonly ValueLazy<ObjCMethodDecl> _setterMethodDecl;
-    private readonly ValueLazy<Type> _type;
+    private ValueLazy<ObjCMethodDecl> _getterMethodDecl;
+    private ValueLazy<ObjCIvarDecl> _propertyIvarDecl;
+    private ValueLazy<ObjCMethodDecl> _setterMethodDecl;
+    private ValueLazy<Type> _type;
 
     internal ObjCPropertyDecl(CXCursor handle) : base(handle, CXCursor_ObjCPropertyDecl, CX_DeclKind_ObjCProperty)
     {

--- a/sources/ClangSharp/Cursors/Decls/ObjCPropertyImplDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCPropertyImplDecl.cs
@@ -9,12 +9,12 @@ namespace ClangSharp;
 
 public sealed class ObjCPropertyImplDecl : Decl
 {
-    private readonly ValueLazy<Expr> _getterCXXConstructor;
-    private readonly ValueLazy<ObjCMethodDecl> _getterMethodDecl;
-    private readonly ValueLazy<ObjCPropertyDecl> _propertyDecl;
-    private readonly ValueLazy<ObjCIvarDecl> _propertyIvarDecl;
-    private readonly ValueLazy<ObjCMethodDecl> _setterMethodDecl;
-    private readonly ValueLazy<Expr> _setterCXXAssignment;
+    private ValueLazy<Expr> _getterCXXConstructor;
+    private ValueLazy<ObjCMethodDecl> _getterMethodDecl;
+    private ValueLazy<ObjCPropertyDecl> _propertyDecl;
+    private ValueLazy<ObjCIvarDecl> _propertyIvarDecl;
+    private ValueLazy<ObjCMethodDecl> _setterMethodDecl;
+    private ValueLazy<Expr> _setterCXXAssignment;
 
     internal ObjCPropertyImplDecl(CXCursor handle) : base(handle, handle.Kind, CX_DeclKind_ObjCPropertyImpl)
     {

--- a/sources/ClangSharp/Cursors/Decls/ObjCProtocolDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCProtocolDecl.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class ObjCProtocolDecl : ObjCContainerDecl, IRedeclarable<ObjCProtocolDecl>
 {
-    private readonly ValueLazy<ObjCProtocolDecl> _definition;
+    private ValueLazy<ObjCProtocolDecl> _definition;
     private readonly LazyList<ObjCProtocolDecl> _protocols;
 
     internal ObjCProtocolDecl(CXCursor handle) : base(handle, CXCursor_ObjCProtocolDecl, CX_DeclKind_ObjCProtocol)

--- a/sources/ClangSharp/Cursors/Decls/ParmVarDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ParmVarDecl.cs
@@ -8,9 +8,9 @@ namespace ClangSharp;
 
 public sealed class ParmVarDecl : VarDecl
 {
-    private readonly ValueLazy<Expr> _defaultArg;
-    private readonly ValueLazy<Type> _originalType;
-    private readonly ValueLazy<Expr> _uninstantiatedDefaultArg;
+    private ValueLazy<Expr> _defaultArg;
+    private ValueLazy<Type> _originalType;
+    private ValueLazy<Expr> _uninstantiatedDefaultArg;
 
     internal ParmVarDecl(CXCursor handle) : base(handle, CXCursor_ParmDecl, CX_DeclKind_ParmVar)
     {

--- a/sources/ClangSharp/Cursors/Decls/RecordDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/RecordDecl.cs
@@ -11,11 +11,11 @@ namespace ClangSharp;
 
 public class RecordDecl : TagDecl
 {
-    private readonly ValueLazy<List<FieldDecl>> _anonymousFields;
-    private readonly ValueLazy<List<RecordDecl>> _anonymousRecords;
+    private ValueLazy<List<FieldDecl>> _anonymousFields;
+    private ValueLazy<List<RecordDecl>> _anonymousRecords;
     private readonly LazyList<FieldDecl> _fields;
-    private readonly ValueLazy<List<IndirectFieldDecl>> _indirectFields;
-    private readonly ValueLazy<RecordDecl?> _injectedClassName;
+    private ValueLazy<List<IndirectFieldDecl>> _indirectFields;
+    private ValueLazy<RecordDecl?> _injectedClassName;
     
 
     internal RecordDecl(CXCursor handle) : this(handle, handle.Kind, CX_DeclKind_Record)

--- a/sources/ClangSharp/Cursors/Decls/RedeclarableTemplateDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/RedeclarableTemplateDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public class RedeclarableTemplateDecl : TemplateDecl, IRedeclarable<RedeclarableTemplateDecl>
 {
-    private readonly ValueLazy<RedeclarableTemplateDecl> _instantiatedFromMemberTemplate;
+    private ValueLazy<RedeclarableTemplateDecl> _instantiatedFromMemberTemplate;
 
     private protected RedeclarableTemplateDecl(CXCursor handle, CXCursorKind expectedCursorKind, CX_DeclKind expectedDeclKind) : base(handle, expectedCursorKind, expectedDeclKind)
     {

--- a/sources/ClangSharp/Cursors/Decls/StaticAssertDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/StaticAssertDecl.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class StaticAssertDecl : Decl
 {
-    private readonly ValueLazy<Expr> _assertExpr;
-    private readonly ValueLazy<StringLiteral> _message;
+    private ValueLazy<Expr> _assertExpr;
+    private ValueLazy<StringLiteral> _message;
 
     internal StaticAssertDecl(CXCursor handle) : base(handle, CXCursor_StaticAssert, CX_DeclKind_StaticAssert)
     {

--- a/sources/ClangSharp/Cursors/Decls/TagDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/TagDecl.cs
@@ -10,9 +10,9 @@ namespace ClangSharp;
 
 public unsafe class TagDecl : TypeDecl, IDeclContext, IRedeclarable<TagDecl>
 {
-    private readonly ValueLazy<TagDecl?> _definition;
+    private ValueLazy<TagDecl?> _definition;
     private readonly LazyList<LazyList<NamedDecl>> _templateParameterLists;
-    private readonly ValueLazy<TypedefNameDecl?> _typedefNameForAnonDecl;
+    private ValueLazy<TypedefNameDecl?> _typedefNameForAnonDecl;
 
     private protected TagDecl(CXCursor handle, CXCursorKind expectedCursorKind, CX_DeclKind expectedDeclKind) : base(handle, expectedCursorKind, expectedDeclKind)
     {

--- a/sources/ClangSharp/Cursors/Decls/TemplateDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/TemplateDecl.cs
@@ -10,7 +10,7 @@ namespace ClangSharp;
 public class TemplateDecl : NamedDecl
 {
     private readonly LazyList<Expr> _associatedConstraints;
-    private readonly ValueLazy<NamedDecl> _templatedDecl;
+    private ValueLazy<NamedDecl> _templatedDecl;
     private readonly LazyList<NamedDecl> _templateParameters;
 
     private protected TemplateDecl(CXCursor handle, CXCursorKind expectedCursorKind, CX_DeclKind expectedDeclKind) : base(handle, expectedCursorKind, expectedDeclKind)

--- a/sources/ClangSharp/Cursors/Decls/TemplateTemplateParmDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/TemplateTemplateParmDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class TemplateTemplateParmDecl : TemplateDecl, ITemplateParmPosition
 {
-    private readonly ValueLazy<TemplateArgumentLoc> _defaultArgument;
+    private ValueLazy<TemplateArgumentLoc> _defaultArgument;
 
     internal TemplateTemplateParmDecl(CXCursor handle) : base(handle, CXCursor_TemplateTemplateParameter, CX_DeclKind_TemplateTemplateParm)
     {

--- a/sources/ClangSharp/Cursors/Decls/TemplateTypeParmDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/TemplateTypeParmDecl.cs
@@ -11,7 +11,7 @@ namespace ClangSharp;
 public sealed class TemplateTypeParmDecl : TypeDecl
 {
     private readonly LazyList<Expr> _associatedConstraints;
-    private readonly ValueLazy<Type?> _defaultArgument;
+    private ValueLazy<Type?> _defaultArgument;
 
     internal TemplateTypeParmDecl(CXCursor handle) : base(handle, CXCursor_TemplateTypeParameter, CX_DeclKind_TemplateTypeParm)
     {

--- a/sources/ClangSharp/Cursors/Decls/TopLevelStmtDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/TopLevelStmtDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class TopLevelStmtDecl : Decl
 {
-    private readonly ValueLazy<LabelStmt> _stmt;
+    private ValueLazy<LabelStmt> _stmt;
 
     internal TopLevelStmtDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_TopLevelStmt)
     {

--- a/sources/ClangSharp/Cursors/Decls/TypeDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/TypeDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public class TypeDecl : NamedDecl
 {
-    private readonly ValueLazy<Type> _typeForDecl;
+    private ValueLazy<Type> _typeForDecl;
 
     private protected TypeDecl(CXCursor handle, CXCursorKind expectedCursorKind, CX_DeclKind expectedDeclKind) : base(handle, expectedCursorKind, expectedDeclKind)
     {

--- a/sources/ClangSharp/Cursors/Decls/TypedefNameDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/TypedefNameDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public class TypedefNameDecl : TypeDecl, IRedeclarable<TypedefNameDecl>
 {
-    private readonly ValueLazy<Type> _underlyingType;
+    private ValueLazy<Type> _underlyingType;
 
     private protected TypedefNameDecl(CXCursor handle, CXCursorKind expectedCursorKind, CX_DeclKind expectedDeclKind) : base(handle, expectedCursorKind, expectedDeclKind)
     {

--- a/sources/ClangSharp/Cursors/Decls/UsingEnumDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/UsingEnumDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class UsingEnumDecl : BaseUsingDecl, IMergeable<UsingEnumDecl>
 {
-    private readonly ValueLazy<EnumDecl> _enumDecl;
+    private ValueLazy<EnumDecl> _enumDecl;
 
     internal UsingEnumDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_UsingEnum)
     {

--- a/sources/ClangSharp/Cursors/Decls/ValueDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ValueDecl.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public class ValueDecl : NamedDecl
 {
-    private readonly ValueLazy<Type> _type;
+    private ValueLazy<Type> _type;
 
     private protected ValueDecl(CXCursor handle, CXCursorKind expectedCursorKind, CX_DeclKind expectedDeclKind) : base(handle, expectedCursorKind, expectedDeclKind)
     {

--- a/sources/ClangSharp/Cursors/Decls/VarDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/VarDecl.cs
@@ -9,9 +9,9 @@ namespace ClangSharp;
 
 public class VarDecl : DeclaratorDecl, IRedeclarable<VarDecl>
 {
-    private readonly ValueLazy<VarDecl> _definition;
-    private readonly ValueLazy<Expr> _init;
-    private readonly ValueLazy<VarDecl> _instantiatedFromStaticDataMember;
+    private ValueLazy<VarDecl> _definition;
+    private ValueLazy<Expr> _init;
+    private ValueLazy<VarDecl> _instantiatedFromStaticDataMember;
 
     internal VarDecl(CXCursor handle) : this(handle, CXCursor_VarDecl, CX_DeclKind_Var)
     {

--- a/sources/ClangSharp/Cursors/Decls/VarTemplatePartialSpecializationDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/VarTemplatePartialSpecializationDecl.cs
@@ -10,7 +10,7 @@ namespace ClangSharp;
 public class VarTemplatePartialSpecializationDecl : VarDecl
 {
     private readonly LazyList<Expr> _associatedConstraints;
-    private readonly ValueLazy<VarTemplatePartialSpecializationDecl> _instantiatedFromMember;
+    private ValueLazy<VarTemplatePartialSpecializationDecl> _instantiatedFromMember;
     private readonly LazyList<NamedDecl> _templateParameters;
 
     internal VarTemplatePartialSpecializationDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_VarTemplatePartialSpecialization)

--- a/sources/ClangSharp/Cursors/Decls/VarTemplateSpecializationDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/VarTemplateSpecializationDecl.cs
@@ -10,7 +10,7 @@ namespace ClangSharp;
 
 public class VarTemplateSpecializationDecl : VarDecl
 {
-    private readonly ValueLazy<VarTemplateDecl> _specializedTemplate;
+    private ValueLazy<VarTemplateDecl> _specializedTemplate;
     private readonly LazyList<TemplateArgument> _templateArgs;
 
     internal VarTemplateSpecializationDecl(CXCursor handle) : this(handle, CXCursor_UnexposedDecl, CX_DeclKind_VarTemplateSpecialization)

--- a/sources/ClangSharp/Cursors/Exprs/AddrLabelExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/AddrLabelExpr.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class AddrLabelExpr : Expr
 {
-    private readonly ValueLazy<LabelDecl> _label;
+    private ValueLazy<LabelDecl> _label;
 
     internal AddrLabelExpr(CXCursor handle) : base(handle, CXCursor_AddrLabelExpr, CX_StmtClass_AddrLabelExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/AtomicExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/AtomicExpr.cs
@@ -11,7 +11,7 @@ namespace ClangSharp;
 public sealed class AtomicExpr : Expr
 {
     private readonly LazyList<Expr, Stmt> _subExprs;
-    private readonly ValueLazy<Type> _valueType;
+    private ValueLazy<Type> _valueType;
 
     internal AtomicExpr(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_AtomicExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/BinaryConditionalOperator.cs
+++ b/sources/ClangSharp/Cursors/Exprs/BinaryConditionalOperator.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class BinaryConditionalOperator : AbstractConditionalOperator
 {
-    private readonly ValueLazy<OpaqueValueExpr> _opaqueValue;
+    private ValueLazy<OpaqueValueExpr> _opaqueValue;
 
     internal BinaryConditionalOperator(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_BinaryConditionalOperator)
     {

--- a/sources/ClangSharp/Cursors/Exprs/BlockExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/BlockExpr.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class BlockExpr : Expr
 {
-    private readonly ValueLazy<BlockDecl> _blockDecl;
+    private ValueLazy<BlockDecl> _blockDecl;
 
     internal BlockExpr(CXCursor handle) : base(handle, CXCursor_BlockExpr, CX_StmtClass_BlockExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CXXBoolLiteralExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXBoolLiteralExpr.cs
@@ -10,7 +10,7 @@ namespace ClangSharp;
 
 public sealed class CXXBoolLiteralExpr : Expr
 {
-    private readonly ValueLazy<string> _valueString;
+    private ValueLazy<string> _valueString;
 
     internal CXXBoolLiteralExpr(CXCursor handle) : base(handle, CXCursor_CXXBoolLiteralExpr, CX_StmtClass_CXXBoolLiteralExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CXXConstructExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXConstructExpr.cs
@@ -12,7 +12,7 @@ namespace ClangSharp;
 public class CXXConstructExpr : Expr
 {
     private readonly LazyList<Expr, Stmt> _args;
-    private readonly ValueLazy<CXXConstructorDecl> _constructor;
+    private ValueLazy<CXXConstructorDecl> _constructor;
 
     internal CXXConstructExpr(CXCursor handle) : this(handle, CXCursor_CallExpr, CX_StmtClass_CXXConstructExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CXXDefaultArgExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXDefaultArgExpr.cs
@@ -9,8 +9,8 @@ namespace ClangSharp;
 
 public sealed class CXXDefaultArgExpr : Expr
 {
-    private readonly ValueLazy<ParmVarDecl> _param;
-    private readonly ValueLazy<IDeclContext?> _usedContext;
+    private ValueLazy<ParmVarDecl> _param;
+    private ValueLazy<IDeclContext?> _usedContext;
 
     internal CXXDefaultArgExpr(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_CXXDefaultArgExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CXXDefaultInitExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXDefaultInitExpr.cs
@@ -9,8 +9,8 @@ namespace ClangSharp;
 
 public sealed class CXXDefaultInitExpr : Expr
 {
-    private readonly ValueLazy<FieldDecl> _field;
-    private readonly ValueLazy<IDeclContext?> _usedContext;
+    private ValueLazy<FieldDecl> _field;
+    private ValueLazy<IDeclContext?> _usedContext;
 
     internal CXXDefaultInitExpr(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_CXXDefaultInitExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CXXDeleteExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXDeleteExpr.cs
@@ -9,8 +9,8 @@ namespace ClangSharp;
 
 public sealed class CXXDeleteExpr : Expr
 {
-    private readonly ValueLazy<Type> _destroyedType;
-    private readonly ValueLazy<FunctionDecl> _operatorDelete;
+    private ValueLazy<Type> _destroyedType;
+    private ValueLazy<FunctionDecl> _operatorDelete;
 
     internal CXXDeleteExpr(CXCursor handle) : base(handle, CXCursor_CXXDeleteExpr, CX_StmtClass_CXXDeleteExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CXXDependentScopeMemberExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXDependentScopeMemberExpr.cs
@@ -11,8 +11,8 @@ namespace ClangSharp;
 
 public sealed class CXXDependentScopeMemberExpr : Expr
 {
-    private readonly ValueLazy<Type> _baseType;
-    private readonly ValueLazy<NamedDecl> _firstQualifierFoundInScope;
+    private ValueLazy<Type> _baseType;
+    private ValueLazy<NamedDecl> _firstQualifierFoundInScope;
     private readonly LazyList<TemplateArgumentLoc> _templateArgs;
 
     internal CXXDependentScopeMemberExpr(CXCursor handle) : base(handle, CXCursor_MemberRefExpr, CX_StmtClass_CXXDependentScopeMemberExpr)

--- a/sources/ClangSharp/Cursors/Exprs/CXXInheritedCtorInitExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXInheritedCtorInitExpr.cs
@@ -10,7 +10,7 @@ namespace ClangSharp;
 
 public sealed class CXXInheritedCtorInitExpr : Expr
 {
-    private readonly ValueLazy<CXXConstructorDecl> _constructor;
+    private ValueLazy<CXXConstructorDecl> _constructor;
 
     internal CXXInheritedCtorInitExpr(CXCursor handle) : base(handle, CXCursor_CallExpr, CX_StmtClass_CXXInheritedCtorInitExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CXXNewExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXNewExpr.cs
@@ -9,8 +9,8 @@ namespace ClangSharp;
 
 public sealed class CXXNewExpr : Expr
 {
-    private readonly ValueLazy<FunctionDecl> _operatorDelete;
-    private readonly ValueLazy<FunctionDecl> _operatorNew;
+    private ValueLazy<FunctionDecl> _operatorDelete;
+    private ValueLazy<FunctionDecl> _operatorNew;
     private readonly LazyList<Expr, Stmt> _placementArgs;
 
     internal CXXNewExpr(CXCursor handle) : base(handle, CXCursor_CXXNewExpr, CX_StmtClass_CXXNewExpr)

--- a/sources/ClangSharp/Cursors/Exprs/CXXParenListInitExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXParenListInitExpr.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class CXXParenListInitExpr : Expr
 {
-    private readonly ValueLazy<Cursor> _arrayFillerOrUnionFieldInit;
+    private ValueLazy<Cursor> _arrayFillerOrUnionFieldInit;
     private readonly LazyList<Expr> _initExprs;
     private readonly LazyList<Expr> _userSpecifiedInitExprs;
 

--- a/sources/ClangSharp/Cursors/Exprs/CXXPseudoDestructorExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXPseudoDestructorExpr.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class CXXPseudoDestructorExpr : Expr
 {
-    private readonly ValueLazy<Type> _destroyedType;
+    private ValueLazy<Type> _destroyedType;
 
     internal CXXPseudoDestructorExpr(CXCursor handle) : base(handle, CXCursor_MemberRefExpr, CX_StmtClass_CXXPseudoDestructorExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CXXRewrittenBinaryOperator.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXRewrittenBinaryOperator.cs
@@ -9,8 +9,8 @@ namespace ClangSharp;
 
 public sealed class CXXRewrittenBinaryOperator : Expr
 {
-    private readonly ValueLazy<Expr> _lhs;
-    private readonly ValueLazy<Expr> _rhs;
+    private ValueLazy<Expr> _lhs;
+    private ValueLazy<Expr> _rhs;
 
     internal CXXRewrittenBinaryOperator(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_CXXRewrittenBinaryOperator)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CXXScalarValueInitExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXScalarValueInitExpr.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class CXXScalarValueInitExpr : Expr
 {
-    private readonly ValueLazy<Type> _typeSourceInfoType;
+    private ValueLazy<Type> _typeSourceInfoType;
 
     internal CXXScalarValueInitExpr(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_CXXScalarValueInitExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CXXTemporaryObjectExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXTemporaryObjectExpr.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class CXXTemporaryObjectExpr : CXXConstructExpr
 {
-    private readonly ValueLazy<Type> _typeSourceInfoType;
+    private ValueLazy<Type> _typeSourceInfoType;
 
     internal CXXTemporaryObjectExpr(CXCursor handle) : base(handle, CXCursor_CallExpr, CX_StmtClass_CXXTemporaryObjectExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CXXTypeidExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXTypeidExpr.cs
@@ -10,7 +10,7 @@ namespace ClangSharp;
 
 public sealed class CXXTypeidExpr : Expr
 {
-    private readonly ValueLazy<Type> _typeOperand;
+    private ValueLazy<Type> _typeOperand;
 
     internal CXXTypeidExpr(CXCursor handle) : base(handle, CXCursor_CXXTypeidExpr, CX_StmtClass_CXXTypeidExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CXXUnresolvedConstructExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXUnresolvedConstructExpr.cs
@@ -10,7 +10,7 @@ namespace ClangSharp;
 public sealed class CXXUnresolvedConstructExpr : Expr
 {
     private readonly LazyList<Expr, Stmt> _args;
-    private readonly ValueLazy<Type> _typeAsWritten;
+    private ValueLazy<Type> _typeAsWritten;
 
     internal CXXUnresolvedConstructExpr(CXCursor handle) : base(handle, CXCursor_CallExpr, CX_StmtClass_CXXUnresolvedConstructExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CXXUuidofExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXUuidofExpr.cs
@@ -10,8 +10,8 @@ namespace ClangSharp;
 
 public sealed class CXXUuidofExpr : Expr
 {
-    private readonly ValueLazy<Type> _typeOperand;
-    private readonly ValueLazy<MSGuidDecl> _guidDecl;
+    private ValueLazy<Type> _typeOperand;
+    private ValueLazy<MSGuidDecl> _guidDecl;
 
     internal CXXUuidofExpr(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_CXXUuidofExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CallExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CallExpr.cs
@@ -12,7 +12,7 @@ namespace ClangSharp;
 public class CallExpr : Expr
 {
     private readonly LazyList<Expr, Stmt> _args;
-    private readonly ValueLazy<Decl> _calleeDecl;
+    private ValueLazy<Decl> _calleeDecl;
 
     internal CallExpr(CXCursor handle) : this(handle, CXCursor_CallExpr, CX_StmtClass_CallExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CastExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CastExpr.cs
@@ -12,7 +12,7 @@ namespace ClangSharp;
 public class CastExpr : Expr
 {
     private readonly LazyList<CXXBaseSpecifier> _path;
-    private readonly ValueLazy<FieldDecl> _targetUnionField;
+    private ValueLazy<FieldDecl> _targetUnionField;
 
     private protected CastExpr(CXCursor handle, CXCursorKind expectedCursorKind, CX_StmtClass expectedStmtClass) : base(handle, expectedCursorKind, expectedStmtClass)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CharacterLiteral.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CharacterLiteral.cs
@@ -11,7 +11,7 @@ namespace ClangSharp;
 
 public sealed class CharacterLiteral : Expr
 {
-    private readonly ValueLazy<string> _valueString;
+    private ValueLazy<string> _valueString;
 
     internal CharacterLiteral(CXCursor handle) : base(handle, CXCursor_CharacterLiteral, CX_StmtClass_CharacterLiteral)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CompoundAssignOperator.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CompoundAssignOperator.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class CompoundAssignOperator : BinaryOperator
 {
-    private readonly ValueLazy<Type> _computationLHSType;
-    private readonly ValueLazy<Type> _computationResultType;
+    private ValueLazy<Type> _computationLHSType;
+    private ValueLazy<Type> _computationResultType;
 
     internal CompoundAssignOperator(CXCursor handle) : base(handle, CXCursor_CompoundAssignOperator, CX_StmtClass_CompoundAssignOperator)
     {

--- a/sources/ClangSharp/Cursors/Exprs/CompoundLiteralExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CompoundLiteralExpr.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class CompoundLiteralExpr : Expr
 {
-    private readonly ValueLazy<Type> _typeSourceInfoType;
+    private ValueLazy<Type> _typeSourceInfoType;
 
     internal CompoundLiteralExpr(CXCursor handle) : base(handle, CXCursor_CompoundLiteralExpr, CX_StmtClass_CompoundLiteralExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/DeclRefExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/DeclRefExpr.cs
@@ -11,8 +11,8 @@ namespace ClangSharp;
 
 public sealed class DeclRefExpr : Expr
 {
-    private readonly ValueLazy<ValueDecl> _decl;
-    private readonly ValueLazy<NamedDecl> _foundDecl;
+    private ValueLazy<ValueDecl> _decl;
+    private ValueLazy<NamedDecl> _foundDecl;
     private readonly LazyList<TemplateArgumentLoc> _templateArgs;
 
     internal DeclRefExpr(CXCursor handle) : base(handle, handle.Kind, CX_StmtClass_DeclRefExpr)

--- a/sources/ClangSharp/Cursors/Exprs/ExplicitCastExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ExplicitCastExpr.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public class ExplicitCastExpr : CastExpr
 {
-    private readonly ValueLazy<Type> _typeAsWritten;
+    private ValueLazy<Type> _typeAsWritten;
 
     private protected ExplicitCastExpr(CXCursor handle, CXCursorKind expectedCursorKind, CX_StmtClass expectedStmtClass) : base(handle, expectedCursorKind, expectedStmtClass)
     {

--- a/sources/ClangSharp/Cursors/Exprs/Expr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/Expr.cs
@@ -57,7 +57,7 @@ public class Expr : ValueStmt
         return e;
     };
 
-    private readonly ValueLazy<Type> _type;
+    private ValueLazy<Type> _type;
 
     private protected Expr(CXCursor handle, CXCursorKind expectedCursorKind, CX_StmtClass expectedStmtClass) : base(handle, expectedCursorKind, expectedStmtClass)
     {

--- a/sources/ClangSharp/Cursors/Exprs/FloatingLiteral.cs
+++ b/sources/ClangSharp/Cursors/Exprs/FloatingLiteral.cs
@@ -11,7 +11,7 @@ namespace ClangSharp;
 
 public sealed class FloatingLiteral : Expr
 {
-    private readonly ValueLazy<string> _valueString;
+    private ValueLazy<string> _valueString;
 
     internal FloatingLiteral(CXCursor handle) : base(handle, CXCursor_FloatingLiteral, CX_StmtClass_FloatingLiteral)
     {

--- a/sources/ClangSharp/Cursors/Exprs/FunctionParmPackExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/FunctionParmPackExpr.cs
@@ -11,7 +11,7 @@ namespace ClangSharp;
 public sealed class FunctionParmPackExpr : Expr
 {
     private readonly LazyList<VarDecl> _expansions;
-    private readonly ValueLazy<VarDecl> _parameterPack;
+    private ValueLazy<VarDecl> _parameterPack;
 
     internal FunctionParmPackExpr(CXCursor handle) : base(handle, CXCursor_DeclRefExpr, CX_StmtClass_FunctionParmPackExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/InitListExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/InitListExpr.cs
@@ -9,8 +9,8 @@ namespace ClangSharp;
 
 public sealed class InitListExpr : Expr
 {
-    private readonly ValueLazy<Expr> _arrayFiller;
-    private readonly ValueLazy<FieldDecl> _initializedFieldInUnion;
+    private ValueLazy<Expr> _arrayFiller;
+    private ValueLazy<FieldDecl> _initializedFieldInUnion;
     private readonly LazyList<Expr, Stmt> _inits;
 
     internal InitListExpr(CXCursor handle) : base(handle, CXCursor_InitListExpr, CX_StmtClass_InitListExpr)

--- a/sources/ClangSharp/Cursors/Exprs/IntegerLiteral.cs
+++ b/sources/ClangSharp/Cursors/Exprs/IntegerLiteral.cs
@@ -11,7 +11,7 @@ namespace ClangSharp;
 
 public sealed class IntegerLiteral : Expr
 {
-    private readonly ValueLazy<string> _valueString;
+    private ValueLazy<string> _valueString;
 
     internal IntegerLiteral(CXCursor handle) : base(handle, CXCursor_IntegerLiteral, CX_StmtClass_IntegerLiteral)
     {

--- a/sources/ClangSharp/Cursors/Exprs/MaterializeTemporaryExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/MaterializeTemporaryExpr.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class MaterializeTemporaryExpr : Expr
 {
-    private readonly ValueLazy<LifetimeExtendedTemporaryDecl> _lifetimeExtendedTemporaryDecl;
+    private ValueLazy<LifetimeExtendedTemporaryDecl> _lifetimeExtendedTemporaryDecl;
 
     internal MaterializeTemporaryExpr(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_MaterializeTemporaryExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/MemberExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/MemberExpr.cs
@@ -10,7 +10,7 @@ namespace ClangSharp;
 
 public sealed class MemberExpr : Expr
 {
-    private readonly ValueLazy<ValueDecl> _memberDecl;
+    private ValueLazy<ValueDecl> _memberDecl;
     private readonly LazyList<TemplateArgumentLoc> _templateArgs;
 
     internal MemberExpr(CXCursor handle) : base(handle, CXCursor_MemberRefExpr, CX_StmtClass_MemberExpr)

--- a/sources/ClangSharp/Cursors/Exprs/ObjCArrayLiteral.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ObjCArrayLiteral.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class ObjCArrayLiteral : Expr
 {
-    private readonly ValueLazy<ObjCMethodDecl> _arrayWithObjectsMethod;
+    private ValueLazy<ObjCMethodDecl> _arrayWithObjectsMethod;
     private readonly LazyList<Expr, Stmt> _elements;
 
     internal ObjCArrayLiteral(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_ObjCArrayLiteral)

--- a/sources/ClangSharp/Cursors/Exprs/ObjCBoxedExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ObjCBoxedExpr.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class ObjCBoxedExpr : Expr
 {
-    private readonly ValueLazy<ObjCMethodDecl> _boxingMethod;
+    private ValueLazy<ObjCMethodDecl> _boxingMethod;
 
     internal ObjCBoxedExpr(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_ObjCBoxedExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/ObjCDictionaryLiteral.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ObjCDictionaryLiteral.cs
@@ -10,8 +10,8 @@ namespace ClangSharp;
 
 public sealed class ObjCDictionaryLiteral : Expr
 {
-    private readonly ValueLazy<ObjCMethodDecl> _dictWithObjectsMethod;
-    private readonly ValueLazy<List<(Expr Key, Expr Value)>> _keyValueElements;
+    private ValueLazy<ObjCMethodDecl> _dictWithObjectsMethod;
+    private ValueLazy<List<(Expr Key, Expr Value)>> _keyValueElements;
 
     internal ObjCDictionaryLiteral(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_ObjCDictionaryLiteral)
     {

--- a/sources/ClangSharp/Cursors/Exprs/ObjCEncodeExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ObjCEncodeExpr.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class ObjCEncodeExpr : Expr
 {
-    private readonly ValueLazy<Type> _encodedType;
+    private ValueLazy<Type> _encodedType;
 
     internal ObjCEncodeExpr(CXCursor handle) : base(handle, CXCursor_ObjCEncodeExpr, CX_StmtClass_ObjCEncodeExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/ObjCIvarRefExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ObjCIvarRefExpr.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class ObjCIvarRefExpr : Expr
 {
-    private readonly ValueLazy<ObjCIvarDecl> _decl;
+    private ValueLazy<ObjCIvarDecl> _decl;
 
     internal ObjCIvarRefExpr(CXCursor handle) : base(handle, CXCursor_MemberRefExpr, CX_StmtClass_ObjCIvarRefExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/ObjCMessageExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ObjCMessageExpr.cs
@@ -10,11 +10,11 @@ namespace ClangSharp;
 public sealed class ObjCMessageExpr : Expr
 {
     private readonly LazyList<Expr> _args;
-    private readonly ValueLazy<Type> _classReceiver;
-    private readonly ValueLazy<Expr> _instanceReceiver;
-    private readonly ValueLazy<ObjCMethodDecl> _methodDecl;
-    private readonly ValueLazy<Type> _receiverType;
-    private readonly ValueLazy<Type> _superType;
+    private ValueLazy<Type> _classReceiver;
+    private ValueLazy<Expr> _instanceReceiver;
+    private ValueLazy<ObjCMethodDecl> _methodDecl;
+    private ValueLazy<Type> _receiverType;
+    private ValueLazy<Type> _superType;
 
     internal ObjCMessageExpr(CXCursor handle) : base(handle, CXCursor_ObjCMessageExpr, CX_StmtClass_ObjCMessageExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/ObjCPropertyRefExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ObjCPropertyRefExpr.cs
@@ -8,12 +8,12 @@ namespace ClangSharp;
 
 public sealed class ObjCPropertyRefExpr : Expr
 {
-    private readonly ValueLazy<Expr> _base;
-    private readonly ValueLazy<ObjCInterfaceDecl> _classReceiver;
-    private readonly ValueLazy<ObjCPropertyDecl> _explicitProperty;
-    private readonly ValueLazy<ObjCMethodDecl> _implicitPropertyGetter;
-    private readonly ValueLazy<ObjCMethodDecl> _implicitPropertySetter;
-    private readonly ValueLazy<Type> _superReceiverType;
+    private ValueLazy<Expr> _base;
+    private ValueLazy<ObjCInterfaceDecl> _classReceiver;
+    private ValueLazy<ObjCPropertyDecl> _explicitProperty;
+    private ValueLazy<ObjCMethodDecl> _implicitPropertyGetter;
+    private ValueLazy<ObjCMethodDecl> _implicitPropertySetter;
+    private ValueLazy<Type> _superReceiverType;
 
     internal ObjCPropertyRefExpr(CXCursor handle) : base(handle, CXCursor_MemberRefExpr, CX_StmtClass_ObjCPropertyRefExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/ObjCProtocolExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ObjCProtocolExpr.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class ObjCProtocolExpr : Expr
 {
-    private readonly ValueLazy<ObjCProtocolDecl> _protocol;
+    private ValueLazy<ObjCProtocolDecl> _protocol;
 
     internal ObjCProtocolExpr(CXCursor handle) : base(handle, CXCursor_ObjCProtocolExpr, CX_StmtClass_ObjCProtocolExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/ObjCSubscriptRefExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ObjCSubscriptRefExpr.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class ObjCSubscriptRefExpr : Expr
 {
-    private readonly ValueLazy<ObjCMethodDecl> _atIndexMethodDecl;
+    private ValueLazy<ObjCMethodDecl> _atIndexMethodDecl;
 
     internal ObjCSubscriptRefExpr(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_ObjCSubscriptRefExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/OffsetOfExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/OffsetOfExpr.cs
@@ -10,8 +10,8 @@ namespace ClangSharp;
 public sealed class OffsetOfExpr : Expr
 {
     private readonly LazyList<Expr, Stmt> _indexExprs;
-    private readonly ValueLazy<Cursor?> _referenced;
-    private readonly ValueLazy<Type> _typeSourceInfoType;
+    private ValueLazy<Cursor?> _referenced;
+    private ValueLazy<Type> _typeSourceInfoType;
 
     internal OffsetOfExpr(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_OffsetOfExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/OpaqueValueExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/OpaqueValueExpr.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class OpaqueValueExpr : Expr
 {
-    private readonly ValueLazy<Expr> _sourceExpr;
+    private ValueLazy<Expr> _sourceExpr;
 
     internal OpaqueValueExpr(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_OpaqueValueExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/OverloadExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/OverloadExpr.cs
@@ -10,7 +10,7 @@ namespace ClangSharp;
 public class OverloadExpr : Expr
 {
     private readonly LazyList<Decl> _decls;
-    private readonly ValueLazy<CXXRecordDecl> _namingClass;
+    private ValueLazy<CXXRecordDecl> _namingClass;
     private readonly LazyList<TemplateArgumentLoc> _templateArgs;
 
     private protected OverloadExpr(CXCursor handle, CXCursorKind expectedCursorKind, CX_StmtClass expectedStmtClass) : base(handle, expectedCursorKind, expectedStmtClass)

--- a/sources/ClangSharp/Cursors/Exprs/SizeOfPackExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/SizeOfPackExpr.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class SizeOfPackExpr : Expr
 {
-    private readonly ValueLazy<NamedDecl> _pack;
+    private ValueLazy<NamedDecl> _pack;
     private readonly LazyList<TemplateArgument> _partialArguments;
 
     internal SizeOfPackExpr(CXCursor handle) : base(handle, CXCursor_SizeOfPackExpr, CX_StmtClass_SizeOfPackExpr)

--- a/sources/ClangSharp/Cursors/Exprs/SubstNonTypeTemplateParmExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/SubstNonTypeTemplateParmExpr.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class SubstNonTypeTemplateParmExpr : Expr
 {
-    private readonly ValueLazy<NonTypeTemplateParmDecl> _parameter;
+    private ValueLazy<NonTypeTemplateParmDecl> _parameter;
 
     internal SubstNonTypeTemplateParmExpr(CXCursor handle) : base(handle, CXCursor_DeclRefExpr, CX_StmtClass_SubstNonTypeTemplateParmExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/SubstNonTypeTemplateParmPackExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/SubstNonTypeTemplateParmPackExpr.cs
@@ -9,8 +9,8 @@ namespace ClangSharp;
 
 public sealed class SubstNonTypeTemplateParmPackExpr : Expr
 {
-    private readonly ValueLazy<TemplateArgument> _argumentPack;
-    private readonly ValueLazy<NonTypeTemplateParmDecl> _parameterPack;
+    private ValueLazy<TemplateArgument> _argumentPack;
+    private ValueLazy<NonTypeTemplateParmDecl> _parameterPack;
 
     internal SubstNonTypeTemplateParmPackExpr(CXCursor handle) : base(handle, CXCursor_DeclRefExpr, CX_StmtClass_SubstNonTypeTemplateParmPackExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/UnaryExprOrTypeTraitExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/UnaryExprOrTypeTraitExpr.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class UnaryExprOrTypeTraitExpr : Expr
 {
-    private readonly ValueLazy<Expr> _argumentExpr;
-    private readonly ValueLazy<Type> _argumentType;
+    private ValueLazy<Expr> _argumentExpr;
+    private ValueLazy<Type> _argumentType;
 
     internal UnaryExprOrTypeTraitExpr(CXCursor handle) : base(handle, CXCursor_UnaryExpr, CX_StmtClass_UnaryExprOrTypeTraitExpr)
     {

--- a/sources/ClangSharp/Cursors/Exprs/UnresolvedMemberExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/UnresolvedMemberExpr.cs
@@ -10,7 +10,7 @@ namespace ClangSharp;
 
 public sealed class UnresolvedMemberExpr : OverloadExpr
 {
-    private readonly ValueLazy<Type> _baseType;
+    private ValueLazy<Type> _baseType;
 
     internal UnresolvedMemberExpr(CXCursor handle) : base(handle, CXCursor_MemberRefExpr, CX_StmtClass_UnresolvedMemberExpr)
     {

--- a/sources/ClangSharp/Cursors/Preprocessings/MacroExpansion.cs
+++ b/sources/ClangSharp/Cursors/Preprocessings/MacroExpansion.cs
@@ -7,7 +7,7 @@ namespace ClangSharp;
 
 public sealed class MacroExpansion : PreprocessedEntity
 {
-    private readonly ValueLazy<MacroDefinitionRecord> _definition;
+    private ValueLazy<MacroDefinitionRecord> _definition;
 
     internal MacroExpansion(CXCursor handle) : base(handle, CXCursor_MacroExpansion)
     {

--- a/sources/ClangSharp/Cursors/Refs/OverloadedDeclRef.cs
+++ b/sources/ClangSharp/Cursors/Refs/OverloadedDeclRef.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class OverloadedDeclRef : Ref
 {
-    private readonly ValueLazy<IEnumerable<Decl>> _overloadedDecls;
+    private ValueLazy<IEnumerable<Decl>> _overloadedDecls;
 
     internal OverloadedDeclRef(CXCursor handle) : base(handle, CXCursor_OverloadedDeclRef)
     {

--- a/sources/ClangSharp/Cursors/Refs/Ref.cs
+++ b/sources/ClangSharp/Cursors/Refs/Ref.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public class Ref : Cursor
 {
-    private readonly ValueLazy<NamedDecl> _referenced;
-    private readonly ValueLazy<Type> _type;
+    private ValueLazy<NamedDecl> _referenced;
+    private ValueLazy<Type> _type;
 
     private protected Ref(CXCursor handle, CXCursorKind expectedCursorKind) : base(handle, expectedCursorKind)
     {

--- a/sources/ClangSharp/Cursors/Stmts/CXXCatchStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/CXXCatchStmt.cs
@@ -9,8 +9,8 @@ namespace ClangSharp;
 
 public sealed class CXXCatchStmt : Stmt
 {
-    private readonly ValueLazy<Type> _caughtType;
-    private readonly ValueLazy<VarDecl> _exceptionDecl;
+    private ValueLazy<Type> _caughtType;
+    private ValueLazy<VarDecl> _exceptionDecl;
 
     internal CXXCatchStmt(CXCursor handle) : base(handle, CXCursor_CXXCatchStmt, CX_StmtClass_CXXCatchStmt)
     {

--- a/sources/ClangSharp/Cursors/Stmts/CapturedStmt.Capture.cs
+++ b/sources/ClangSharp/Cursors/Stmts/CapturedStmt.Capture.cs
@@ -11,7 +11,7 @@ public partial class CapturedStmt
     {
         private readonly CapturedStmt _parentStmt;
         private readonly uint _index;
-        private readonly ValueLazy<VarDecl> _capturedVar;
+        private ValueLazy<VarDecl> _capturedVar;
 
         internal Capture(CapturedStmt parentStmt, uint index)
         {

--- a/sources/ClangSharp/Cursors/Stmts/CapturedStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/CapturedStmt.cs
@@ -9,9 +9,9 @@ namespace ClangSharp;
 
 public sealed partial class CapturedStmt : Stmt
 {
-    private readonly ValueLazy<CapturedDecl> _capturedDecl;
-    private readonly ValueLazy<RecordDecl> _capturedRecordDecl;
-    private readonly ValueLazy<Stmt> _captureStmt;
+    private ValueLazy<CapturedDecl> _capturedDecl;
+    private ValueLazy<RecordDecl> _capturedRecordDecl;
+    private ValueLazy<Stmt> _captureStmt;
     private readonly LazyList<Capture> _captures;
     private readonly LazyList<Expr, Stmt> _captureInits;
 

--- a/sources/ClangSharp/Cursors/Stmts/GotoStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/GotoStmt.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class GotoStmt : Stmt
 {
-    private readonly ValueLazy<LabelDecl> _label;
+    private ValueLazy<LabelDecl> _label;
 
     internal GotoStmt(CXCursor handle) : base(handle, CXCursor_GotoStmt, CX_StmtClass_GotoStmt)
     {

--- a/sources/ClangSharp/Cursors/Stmts/IndirectGotoStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/IndirectGotoStmt.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class IndirectGotoStmt : Stmt
 {
-    private readonly ValueLazy<LabelDecl> _constantTarget;
+    private ValueLazy<LabelDecl> _constantTarget;
 
     internal IndirectGotoStmt(CXCursor handle) : base(handle, CXCursor_IndirectGotoStmt, CX_StmtClass_IndirectGotoStmt)
     {

--- a/sources/ClangSharp/Cursors/Stmts/LabelStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/LabelStmt.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class LabelStmt : ValueStmt
 {
-    private readonly ValueLazy<LabelDecl> _decl;
+    private ValueLazy<LabelDecl> _decl;
 
     internal LabelStmt(CXCursor handle) : base(handle, CXCursor_LabelStmt, CX_StmtClass_LabelStmt)
     {

--- a/sources/ClangSharp/Cursors/Stmts/ObjCAtCatchStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/ObjCAtCatchStmt.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class ObjCAtCatchStmt : Stmt
 {
-    private readonly ValueLazy<VarDecl?> _catchParamDecl;
+    private ValueLazy<VarDecl?> _catchParamDecl;
 
     internal ObjCAtCatchStmt(CXCursor handle) : base(handle, CXCursor_ObjCAtCatchStmt, CX_StmtClass_ObjCAtCatchStmt)
     {

--- a/sources/ClangSharp/Cursors/Stmts/ObjCAtTryStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/ObjCAtTryStmt.cs
@@ -10,8 +10,8 @@ namespace ClangSharp;
 
 public sealed class ObjCAtTryStmt : Stmt
 {
-    private readonly ValueLazy<LazyList<ObjCAtCatchStmt, Stmt>> _catchStmts;
-    private readonly ValueLazy<ObjCAtFinallyStmt?> _finallyStmt;
+    private ValueLazy<LazyList<ObjCAtCatchStmt, Stmt>> _catchStmts;
+    private ValueLazy<ObjCAtFinallyStmt?> _finallyStmt;
 
     internal ObjCAtTryStmt(CXCursor handle) : base(handle, CXCursor_ObjCAtTryStmt, CX_StmtClass_ObjCAtTryStmt)
     {

--- a/sources/ClangSharp/Cursors/Stmts/ReturnStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/ReturnStmt.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class ReturnStmt : Stmt
 {
-    private readonly ValueLazy<VarDecl> _nrvoCandidate;
+    private ValueLazy<VarDecl> _nrvoCandidate;
 
     internal ReturnStmt(CXCursor handle) : base(handle, CXCursor_ReturnStmt, CX_StmtClass_ReturnStmt)
     {

--- a/sources/ClangSharp/Cursors/Stmts/Stmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/Stmt.cs
@@ -11,7 +11,7 @@ namespace ClangSharp;
 public class Stmt : Cursor
 {
     private protected readonly LazyList<Stmt> _children;
-    private readonly ValueLazy<IDeclContext> _declContext;
+    private ValueLazy<IDeclContext> _declContext;
 
     private protected Stmt(CXCursor handle, CXCursorKind expectedCursorKind, CX_StmtClass expectedStmtClass) : base(handle, expectedCursorKind)
     {

--- a/sources/ClangSharp/Cursors/Stmts/SwitchCase.cs
+++ b/sources/ClangSharp/Cursors/Stmts/SwitchCase.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public class SwitchCase : Stmt
 {
-    private readonly ValueLazy<SwitchCase> _nextSwitchCase;
+    private ValueLazy<SwitchCase> _nextSwitchCase;
 
     private protected SwitchCase(CXCursor handle, CXCursorKind expectedCursorKind, CX_StmtClass expectedStmtClass) : base(handle, expectedCursorKind, expectedStmtClass)
     {

--- a/sources/ClangSharp/Cursors/Stmts/SwitchStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/SwitchStmt.cs
@@ -9,7 +9,7 @@ namespace ClangSharp;
 
 public sealed class SwitchStmt : Stmt
 {
-    private readonly ValueLazy<SwitchCase> _switchCaseList;
+    private ValueLazy<SwitchCase> _switchCaseList;
 
     internal SwitchStmt(CXCursor handle) : base(handle, CXCursor_SwitchStmt, CX_StmtClass_SwitchStmt)
     {

--- a/sources/ClangSharp/TemplateArgument.cs
+++ b/sources/ClangSharp/TemplateArgument.cs
@@ -11,18 +11,18 @@ namespace ClangSharp;
 
 public sealed unsafe class TemplateArgument : IDisposable
 {
-    private readonly ValueLazy<ValueDecl> _asDecl;
-    private readonly ValueLazy<Expr> _asExpr;
-    private readonly ValueLazy<TemplateName> _asTemplate;
-    private readonly ValueLazy<TemplateName> _asTemplateOrTemplatePattern;
-    private readonly ValueLazy<Type> _asType;
-    private readonly ValueLazy<Type> _integralType;
-    private readonly ValueLazy<Type> _nonTypeTemplateArgumentType;
-    private readonly ValueLazy<Type> _nullPtrType;
+    private ValueLazy<ValueDecl> _asDecl;
+    private ValueLazy<Expr> _asExpr;
+    private ValueLazy<TemplateName> _asTemplate;
+    private ValueLazy<TemplateName> _asTemplateOrTemplatePattern;
+    private ValueLazy<Type> _asType;
+    private ValueLazy<Type> _integralType;
+    private ValueLazy<Type> _nonTypeTemplateArgumentType;
+    private ValueLazy<Type> _nullPtrType;
     private readonly LazyList<TemplateArgument> _packElements;
-    private readonly ValueLazy<TemplateArgument> _packExpansionPattern;
-    private readonly ValueLazy<Type> _paramTypeForDecl;
-    private readonly ValueLazy<TranslationUnit> _translationUnit;
+    private ValueLazy<TemplateArgument> _packExpansionPattern;
+    private ValueLazy<Type> _paramTypeForDecl;
+    private ValueLazy<TranslationUnit> _translationUnit;
 
     internal TemplateArgument(CX_TemplateArgument handle)
     {

--- a/sources/ClangSharp/TemplateArgumentLoc.cs
+++ b/sources/ClangSharp/TemplateArgumentLoc.cs
@@ -6,12 +6,12 @@ namespace ClangSharp;
 
 public sealed unsafe class TemplateArgumentLoc
 {
-    private readonly ValueLazy<TemplateArgument> _argument;
-    private readonly ValueLazy<Expr> _sourceDeclExpression;
-    private readonly ValueLazy<Expr> _sourceExpression;
-    private readonly ValueLazy<Expr> _sourceIntegralExpression;
-    private readonly ValueLazy<Expr> _sourceNullPtrExpression;
-    private readonly ValueLazy<TranslationUnit> _translationUnit;
+    private ValueLazy<TemplateArgument> _argument;
+    private ValueLazy<Expr> _sourceDeclExpression;
+    private ValueLazy<Expr> _sourceExpression;
+    private ValueLazy<Expr> _sourceIntegralExpression;
+    private ValueLazy<Expr> _sourceNullPtrExpression;
+    private ValueLazy<TranslationUnit> _translationUnit;
 
     internal TemplateArgumentLoc(CX_TemplateArgumentLoc handle)
     {

--- a/sources/ClangSharp/TemplateName.cs
+++ b/sources/ClangSharp/TemplateName.cs
@@ -6,8 +6,8 @@ namespace ClangSharp;
 
 public sealed unsafe class TemplateName
 {
-    private readonly ValueLazy<TemplateDecl> _asTemplateDecl;
-    private readonly ValueLazy<TranslationUnit> _translationUnit;
+    private ValueLazy<TemplateDecl> _asTemplateDecl;
+    private ValueLazy<TranslationUnit> _translationUnit;
 
     internal TemplateName(CX_TemplateName handle)
     {

--- a/sources/ClangSharp/TranslationUnit.cs
+++ b/sources/ClangSharp/TranslationUnit.cs
@@ -27,7 +27,7 @@ public sealed unsafe class TranslationUnit : IDisposable, IEquatable<Translation
     private readonly Dictionary<CX_TemplateArgumentLoc, WeakReference<TemplateArgumentLoc>> _createdTemplateArgumentLocs;
     private readonly Dictionary<CX_TemplateName, WeakReference<TemplateName>> _createdTemplateNames;
     private readonly Dictionary<CXType, WeakReference<Type>> _createdTypes;
-    private readonly ValueLazy<TranslationUnitDecl> _translationUnitDecl;
+    private ValueLazy<TranslationUnitDecl> _translationUnitDecl;
 
     private bool _isDisposed;
 

--- a/sources/ClangSharp/Types/AdjustedType.cs
+++ b/sources/ClangSharp/Types/AdjustedType.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public class AdjustedType : Type
 {
-    private readonly ValueLazy<Type> _adjustedType;
-    private readonly ValueLazy<Type> _originalType;
+    private ValueLazy<Type> _adjustedType;
+    private ValueLazy<Type> _originalType;
 
     internal AdjustedType(CXType handle) : this(handle, CXType_Unexposed, CX_TypeClass_Adjusted)
     {

--- a/sources/ClangSharp/Types/ArrayType.cs
+++ b/sources/ClangSharp/Types/ArrayType.cs
@@ -6,7 +6,7 @@ namespace ClangSharp;
 
 public class ArrayType : Type
 {
-    private readonly ValueLazy<Type> _elementType;
+    private ValueLazy<Type> _elementType;
 
     private protected ArrayType(CXType handle, CXTypeKind expectedTypeKind, CX_TypeClass expectedTypeClass) : base(handle, expectedTypeKind, expectedTypeClass)
     {

--- a/sources/ClangSharp/Types/AtomicType.cs
+++ b/sources/ClangSharp/Types/AtomicType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class AtomicType : Type
 {
-    private readonly ValueLazy<Type> _valueType;
+    private ValueLazy<Type> _valueType;
 
     internal AtomicType(CXType handle) : base(handle, CXType_Atomic, CX_TypeClass_Atomic)
     {

--- a/sources/ClangSharp/Types/AttributedType.cs
+++ b/sources/ClangSharp/Types/AttributedType.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class AttributedType : Type
 {
-    private readonly ValueLazy<Type> _equivalentType;
-    private readonly ValueLazy<Type> _modifiedType;
+    private ValueLazy<Type> _equivalentType;
+    private ValueLazy<Type> _modifiedType;
 
     internal AttributedType(CXType handle) : base(handle, CXType_Attributed, CX_TypeClass_Attributed)
     {

--- a/sources/ClangSharp/Types/ComplexType.cs
+++ b/sources/ClangSharp/Types/ComplexType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class ComplexType : Type
 {
-    private readonly ValueLazy<Type> _elementType;
+    private ValueLazy<Type> _elementType;
 
     internal ComplexType(CXType handle) : base(handle, CXType_Complex, CX_TypeClass_Complex)
     {

--- a/sources/ClangSharp/Types/ConstantArrayType.cs
+++ b/sources/ClangSharp/Types/ConstantArrayType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public class ConstantArrayType : ArrayType
 {
-    private readonly ValueLazy<Expr> _sizeExpr;
+    private ValueLazy<Expr> _sizeExpr;
 
     internal ConstantArrayType(CXType handle) : this(handle, CXType_ConstantArray, CX_TypeClass_ConstantArray)
     {

--- a/sources/ClangSharp/Types/DecayedType.cs
+++ b/sources/ClangSharp/Types/DecayedType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class DecayedType : AdjustedType
 {
-    private readonly ValueLazy<Type> _decayedType;
+    private ValueLazy<Type> _decayedType;
 
     internal DecayedType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_Decayed)
     {

--- a/sources/ClangSharp/Types/DecltypeType.cs
+++ b/sources/ClangSharp/Types/DecltypeType.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class DecltypeType : Type
 {
-    private readonly ValueLazy<Expr> _underlyingExpr;
-    private readonly ValueLazy<Type> _underlyingType;
+    private ValueLazy<Expr> _underlyingExpr;
+    private ValueLazy<Type> _underlyingType;
 
     internal DecltypeType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_Decltype)
     {

--- a/sources/ClangSharp/Types/DeducedTemplateSpecializationType.cs
+++ b/sources/ClangSharp/Types/DeducedTemplateSpecializationType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class DeducedTemplateSpecializationType : DeducedType
 {
-    private readonly ValueLazy<TemplateName> _templateName;
+    private ValueLazy<TemplateName> _templateName;
 
     internal DeducedTemplateSpecializationType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_DeducedTemplateSpecialization)
     {

--- a/sources/ClangSharp/Types/DeducedType.cs
+++ b/sources/ClangSharp/Types/DeducedType.cs
@@ -6,7 +6,7 @@ namespace ClangSharp;
 
 public class DeducedType : Type
 {
-    private readonly ValueLazy<Type> _deducedType;
+    private ValueLazy<Type> _deducedType;
 
     private protected DeducedType(CXType handle, CXTypeKind expectedTypeKind, CX_TypeClass expectedTypeClass) : base(handle, expectedTypeKind, expectedTypeClass)
     {

--- a/sources/ClangSharp/Types/DependentAddressSpaceType.cs
+++ b/sources/ClangSharp/Types/DependentAddressSpaceType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class DependentAddressSpaceType : Type
 {
-    private readonly ValueLazy<Expr> _addrSpaceExpr;
+    private ValueLazy<Expr> _addrSpaceExpr;
 
     internal DependentAddressSpaceType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_DependentAddressSpace)
     {

--- a/sources/ClangSharp/Types/DependentBitIntType.cs
+++ b/sources/ClangSharp/Types/DependentBitIntType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class DependentBitIntType : Type
 {
-    private readonly ValueLazy<Expr> _numBitsExpr;
+    private ValueLazy<Expr> _numBitsExpr;
 
     internal DependentBitIntType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_DependentBitInt)
     {

--- a/sources/ClangSharp/Types/DependentSizedArrayType.cs
+++ b/sources/ClangSharp/Types/DependentSizedArrayType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class DependentSizedArrayType : ArrayType
 {
-    private readonly ValueLazy<Expr> _sizeExpr;
+    private ValueLazy<Expr> _sizeExpr;
 
     internal DependentSizedArrayType(CXType handle) : base(handle, CXType_DependentSizedArray, CX_TypeClass_DependentSizedArray)
     {

--- a/sources/ClangSharp/Types/DependentSizedExtVectorType.cs
+++ b/sources/ClangSharp/Types/DependentSizedExtVectorType.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class DependentSizedExtVectorType : Type
 {
-    private readonly ValueLazy<Type> _elementType;
-    private readonly ValueLazy<Expr> _sizeExpr;
+    private ValueLazy<Type> _elementType;
+    private ValueLazy<Expr> _sizeExpr;
 
     internal DependentSizedExtVectorType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_DependentSizedExtVector)
     {

--- a/sources/ClangSharp/Types/DependentSizedMatrixType.cs
+++ b/sources/ClangSharp/Types/DependentSizedMatrixType.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class DependentSizedMatrixType : MatrixType
 {
-    private readonly ValueLazy<Expr> _rowExpr;
-    private readonly ValueLazy<Expr> _columnExpr;
+    private ValueLazy<Expr> _rowExpr;
+    private ValueLazy<Expr> _columnExpr;
 
     internal DependentSizedMatrixType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_DependentSizedMatrix)
     {

--- a/sources/ClangSharp/Types/DependentVectorType.cs
+++ b/sources/ClangSharp/Types/DependentVectorType.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class DependentVectorType : Type
 {
-    private readonly ValueLazy<Type> _elementType;
-    private readonly ValueLazy<Expr> _sizeExpr;
+    private ValueLazy<Type> _elementType;
+    private ValueLazy<Expr> _sizeExpr;
 
     internal DependentVectorType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_DependentVector)
     {

--- a/sources/ClangSharp/Types/ElaboratedType.cs
+++ b/sources/ClangSharp/Types/ElaboratedType.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class ElaboratedType : TypeWithKeyword
 {
-    private readonly ValueLazy<Type> _namedType;
-    private readonly ValueLazy<TagDecl?> _ownedTagDecl;
+    private ValueLazy<Type> _namedType;
+    private ValueLazy<TagDecl?> _ownedTagDecl;
 
     internal ElaboratedType(CXType handle) : base(handle, CXType_Elaborated, CX_TypeClass_Elaborated, CXType_ObjCClass, CXType_ObjCId, CXType_ObjCSel)
     {

--- a/sources/ClangSharp/Types/FunctionType.cs
+++ b/sources/ClangSharp/Types/FunctionType.cs
@@ -6,7 +6,7 @@ namespace ClangSharp;
 
 public class FunctionType : Type
 {
-    private readonly ValueLazy<Type> _returnType;
+    private ValueLazy<Type> _returnType;
 
     private protected FunctionType(CXType handle, CXTypeKind expectedTypeKind, CX_TypeClass expectedTypeClass) : base(handle, expectedTypeKind, expectedTypeClass)
     {

--- a/sources/ClangSharp/Types/InjectedClassNameType.cs
+++ b/sources/ClangSharp/Types/InjectedClassNameType.cs
@@ -8,10 +8,10 @@ namespace ClangSharp;
 
 public sealed class InjectedClassNameType : Type
 {
-    private readonly ValueLazy<CXXRecordDecl> _decl;
-    private readonly ValueLazy<Type> _injectedSpecializationType;
-    private readonly ValueLazy<TemplateSpecializationType> _injectedTST;
-    private readonly ValueLazy<TemplateName> _templateName;
+    private ValueLazy<CXXRecordDecl> _decl;
+    private ValueLazy<Type> _injectedSpecializationType;
+    private ValueLazy<TemplateSpecializationType> _injectedTST;
+    private ValueLazy<TemplateName> _templateName;
 
     internal InjectedClassNameType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_InjectedClassName)
     {

--- a/sources/ClangSharp/Types/MacroQualifiedType.cs
+++ b/sources/ClangSharp/Types/MacroQualifiedType.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class MacroQualifiedType : Type
 {
-    private readonly ValueLazy<Type> _modifiedType;
-    private readonly ValueLazy<Type> _underlyingType;
+    private ValueLazy<Type> _modifiedType;
+    private ValueLazy<Type> _underlyingType;
 
     internal MacroQualifiedType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_MacroQualified)
     {

--- a/sources/ClangSharp/Types/MatrixType.cs
+++ b/sources/ClangSharp/Types/MatrixType.cs
@@ -6,7 +6,7 @@ namespace ClangSharp;
 
 public class MatrixType : Type
 {
-    private readonly ValueLazy<Type> _elementType;
+    private ValueLazy<Type> _elementType;
 
     private protected MatrixType(CXType handle, CXTypeKind expectedTypeKind, CX_TypeClass expectedTypeClass) : base(handle, expectedTypeKind, expectedTypeClass)
     {

--- a/sources/ClangSharp/Types/ObjCInterfaceType.cs
+++ b/sources/ClangSharp/Types/ObjCInterfaceType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class ObjCInterfaceType : ObjCObjectType
 {
-    private readonly ValueLazy<ObjCInterfaceDecl> _decl;
+    private ValueLazy<ObjCInterfaceDecl> _decl;
 
     internal ObjCInterfaceType(CXType handle) : base(handle, CXType_ObjCInterface, CX_TypeClass_ObjCInterface)
     {

--- a/sources/ClangSharp/Types/ObjCObjectPointerType.cs
+++ b/sources/ClangSharp/Types/ObjCObjectPointerType.cs
@@ -9,8 +9,8 @@ namespace ClangSharp;
 
 public sealed class ObjCObjectPointerType : Type
 {
-    private readonly ValueLazy<ObjCInterfaceType> _interfaceType;
-    private readonly ValueLazy<Type> _superClassType;
+    private ValueLazy<ObjCInterfaceType> _interfaceType;
+    private ValueLazy<Type> _superClassType;
 
     internal ObjCObjectPointerType(CXType handle) : base(handle, CXType_ObjCObjectPointer, CX_TypeClass_ObjCObjectPointer)
     {

--- a/sources/ClangSharp/Types/ObjCObjectType.cs
+++ b/sources/ClangSharp/Types/ObjCObjectType.cs
@@ -9,10 +9,10 @@ namespace ClangSharp;
 
 public class ObjCObjectType : Type
 {
-    private readonly ValueLazy<Type> _baseType;
-    private readonly ValueLazy<ObjCInterfaceDecl> _interface;
+    private ValueLazy<Type> _baseType;
+    private ValueLazy<ObjCInterfaceDecl> _interface;
     private readonly LazyList<ObjCProtocolDecl> _protocols;
-    private readonly ValueLazy<Type> _superClassType;
+    private ValueLazy<Type> _superClassType;
     private readonly LazyList<Type> _typeArgs;
 
     internal ObjCObjectType(CXType handle) : this(handle, CXType_ObjCObject, CX_TypeClass_ObjCObject)

--- a/sources/ClangSharp/Types/ObjCTypeParamType.cs
+++ b/sources/ClangSharp/Types/ObjCTypeParamType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class ObjCTypeParamType : Type
 {
-    private readonly ValueLazy<ObjCTypeParamDecl> _decl;
+    private ValueLazy<ObjCTypeParamDecl> _decl;
 
     internal ObjCTypeParamType(CXType handle) : base(handle, CXType_ObjCTypeParam, CX_TypeClass_ObjCTypeParam)
     {

--- a/sources/ClangSharp/Types/PackExpansionType.cs
+++ b/sources/ClangSharp/Types/PackExpansionType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class PackExpansionType : Type
 {
-    private readonly ValueLazy<Type> _pattern;
+    private ValueLazy<Type> _pattern;
 
     internal PackExpansionType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_PackExpansion)
     {

--- a/sources/ClangSharp/Types/PipeType.cs
+++ b/sources/ClangSharp/Types/PipeType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class PipeType : Type
 {
-    private readonly ValueLazy<Type> _elementType;
+    private ValueLazy<Type> _elementType;
 
     internal PipeType(CXType handle) : base(handle, CXType_Pipe, CX_TypeClass_Pipe)
     {

--- a/sources/ClangSharp/Types/SubstTemplateTypeParmPackType.cs
+++ b/sources/ClangSharp/Types/SubstTemplateTypeParmPackType.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class SubstTemplateTypeParmPackType : Type
 {
-    private readonly ValueLazy<TemplateArgument> _argumentPack;
-    private readonly ValueLazy<TemplateTypeParmType> _replacedParameter;
+    private ValueLazy<TemplateArgument> _argumentPack;
+    private ValueLazy<TemplateTypeParmType> _replacedParameter;
 
     internal SubstTemplateTypeParmPackType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_SubstTemplateTypeParmPack)
     {

--- a/sources/ClangSharp/Types/SubstTemplateTypeParmType.cs
+++ b/sources/ClangSharp/Types/SubstTemplateTypeParmType.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public sealed class SubstTemplateTypeParmType : Type
 {
-    private readonly ValueLazy<Decl?> _associatedDecl;
-    private readonly ValueLazy<TemplateTypeParmType> _replacedParameter;
+    private ValueLazy<Decl?> _associatedDecl;
+    private ValueLazy<TemplateTypeParmType> _replacedParameter;
 
     internal SubstTemplateTypeParmType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_SubstTemplateTypeParm)
     {

--- a/sources/ClangSharp/Types/TagType.cs
+++ b/sources/ClangSharp/Types/TagType.cs
@@ -6,7 +6,7 @@ namespace ClangSharp;
 
 public class TagType : Type
 {
-    private readonly ValueLazy<TagDecl> _decl;
+    private ValueLazy<TagDecl> _decl;
 
     private protected TagType(CXType handle, CXTypeKind expectedTypeKind, CX_TypeClass expectedTypeClass) : base(handle, expectedTypeKind, expectedTypeClass)
     {

--- a/sources/ClangSharp/Types/TemplateSpecializationType.cs
+++ b/sources/ClangSharp/Types/TemplateSpecializationType.cs
@@ -11,7 +11,7 @@ namespace ClangSharp;
 public sealed class TemplateSpecializationType : Type
 {
     private readonly LazyList<TemplateArgument> _templateArgs;
-    private readonly ValueLazy<TemplateName> _templateName;
+    private ValueLazy<TemplateName> _templateName;
 
     internal TemplateSpecializationType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_TemplateSpecialization)
     {

--- a/sources/ClangSharp/Types/TemplateTypeParmType.cs
+++ b/sources/ClangSharp/Types/TemplateTypeParmType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class TemplateTypeParmType : Type
 {
-    private readonly ValueLazy<TemplateTypeParmDecl> _decl;
+    private ValueLazy<TemplateTypeParmDecl> _decl;
 
     internal TemplateTypeParmType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_TemplateTypeParm)
     {

--- a/sources/ClangSharp/Types/Type.cs
+++ b/sources/ClangSharp/Types/Type.cs
@@ -11,12 +11,12 @@ namespace ClangSharp;
 [DebuggerDisplay("{Handle.DebuggerDisplayString,nq}")]
 public unsafe class Type : IEquatable<Type>
 {
-    private readonly ValueLazy<string> _asString;
-    private readonly ValueLazy<Type> _canonicalType;
-    private readonly ValueLazy<Type> _desugar;
-    private readonly ValueLazy<string> _kindSpelling;
-    private readonly ValueLazy<Type> _pointeeType;
-    private readonly ValueLazy<TranslationUnit> _translationUnit;
+    private ValueLazy<string> _asString;
+    private ValueLazy<Type> _canonicalType;
+    private ValueLazy<Type> _desugar;
+    private ValueLazy<string> _kindSpelling;
+    private ValueLazy<Type> _pointeeType;
+    private ValueLazy<TranslationUnit> _translationUnit;
 
     protected Type(CXType handle, CXTypeKind expectedKind, CX_TypeClass expectedTypeClass, params ReadOnlySpan<CXTypeKind> additionalExpectedKinds)
     {

--- a/sources/ClangSharp/Types/TypeOfExprType.cs
+++ b/sources/ClangSharp/Types/TypeOfExprType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class TypeOfExprType : Type
 {
-    private readonly ValueLazy<Expr> _underlyingExpr;
+    private ValueLazy<Expr> _underlyingExpr;
 
     internal TypeOfExprType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_TypeOfExpr)
     {

--- a/sources/ClangSharp/Types/TypeOfType.cs
+++ b/sources/ClangSharp/Types/TypeOfType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class TypeOfType : Type
 {
-    private readonly ValueLazy<Type> _underlyingType;
+    private ValueLazy<Type> _underlyingType;
 
     internal TypeOfType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_TypeOf)
     {

--- a/sources/ClangSharp/Types/TypedefType.cs
+++ b/sources/ClangSharp/Types/TypedefType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class TypedefType : Type
 {
-    private readonly ValueLazy<TypedefNameDecl> _decl;
+    private ValueLazy<TypedefNameDecl> _decl;
 
     internal TypedefType(CXType handle) : base(handle, CXType_Typedef, CX_TypeClass_Typedef, CXType_ObjCClass, CXType_ObjCId, CXType_ObjCSel)
     {

--- a/sources/ClangSharp/Types/UnaryTransformType.cs
+++ b/sources/ClangSharp/Types/UnaryTransformType.cs
@@ -8,8 +8,8 @@ namespace ClangSharp;
 
 public class UnaryTransformType : Type
 {
-    private readonly ValueLazy<Type> _baseType;
-    private readonly ValueLazy<Type> _underlyingType;
+    private ValueLazy<Type> _baseType;
+    private ValueLazy<Type> _underlyingType;
 
     internal UnaryTransformType(CXType handle) : this(handle, CXType_Unexposed, CX_TypeClass_UnaryTransform)
     {

--- a/sources/ClangSharp/Types/UnresolvedUsingType.cs
+++ b/sources/ClangSharp/Types/UnresolvedUsingType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class UnresolvedUsingType : Type
 {
-    private readonly ValueLazy<UnresolvedUsingTypenameDecl> _decl;
+    private ValueLazy<UnresolvedUsingTypenameDecl> _decl;
 
     internal UnresolvedUsingType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_UnresolvedUsing)
     {

--- a/sources/ClangSharp/Types/UsingType.cs
+++ b/sources/ClangSharp/Types/UsingType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class UsingType : Type
 {
-    private readonly ValueLazy<UsingShadowDecl> _foundDecl;
+    private ValueLazy<UsingShadowDecl> _foundDecl;
 
     internal UsingType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_Using)
     {

--- a/sources/ClangSharp/Types/VariableArrayType.cs
+++ b/sources/ClangSharp/Types/VariableArrayType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public sealed class VariableArrayType : ArrayType
 {
-    private readonly ValueLazy<Expr> _sizeExpr;
+    private ValueLazy<Expr> _sizeExpr;
 
     internal VariableArrayType(CXType handle) : base(handle, CXType_VariableArray, CX_TypeClass_VariableArray)
     {

--- a/sources/ClangSharp/Types/VectorType.cs
+++ b/sources/ClangSharp/Types/VectorType.cs
@@ -8,7 +8,7 @@ namespace ClangSharp;
 
 public class VectorType : Type
 {
-    private readonly ValueLazy<Type> _elementType;
+    private ValueLazy<Type> _elementType;
 
     internal VectorType(CXType handle) : this(handle, CXType_Vector, CX_TypeClass_Vector)
     {


### PR DESCRIPTION
`ValueLazy<T>` is a mutable struct: its `Value` getter computes the value on first access and clears the factory so subsequent accesses return the cached value. Every field storing one was declared `readonly`, so each access operated on a defensive copy and the cached result was discarded -- the factory ran again on every access, defeating the memoization the type exists to provide. This is the classic mutable-struct-in-a-readonly-field bug.

Dropping `readonly` from all 326 `ValueLazy<T>` fields (170 files) lets the cached value persist. The factories are idempotent, so behavior is unchanged; access to lazy members (spellings, parents, translation units, etc.) simply no longer recomputes each time -- which avoids repeated native `clang_*` calls, `GetOrCreate` lookups, and string marshaling.

----------

Measured on a representative real-world workload -- the `d3d12` generation from terrafx/terrafx.interop.windows against the Windows SDK:

- Wall-clock: **4404 -> 4230 ms** median (~4-5%), with clean separation (baseline min 4342 > fixed max 4241).
- Allocations: 284.9 -> 280.2 MB (~1.6%) under full optimization.

I audited the rest of the runtime, generator, and interop layers for the same pattern: the descriptor structs (`StructDesc`, `ValueDesc`, `FunctionOrDelegateDesc`, etc.) are mutable but only ever used as locals or by-value parameters, and `LazyList` is a sealed class -- `ValueLazy` was the only type caught in this trap.

All 3706 tests pass with a 0-warning build.