### PR TITLE
Cache normalized file names to avoid re-allocating them per cursor

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Predicates.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Predicates.cs
@@ -310,8 +310,17 @@ public sealed partial class PInvokeGenerator
             // Use case insensitive comparison on Windows
             var equalityComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
-            // Normalize paths to be '/' for comparison
-            var fileName = file.Name.ToString().NormalizePath();
+            // Normalize paths to be '/' for comparison. The same file recurs for
+            // every cursor it contains, so cache the normalized names per file to
+            // avoid re-allocating them (and re-running Path.GetFullPath) each call.
+            if (!_fileNames.TryGetValue(file, out var names))
+            {
+                var name = file.Name.ToString().NormalizePath();
+                names = (name, name.NormalizeFullPath());
+                _fileNames.Add(file, names);
+            }
+
+            var fileName = names.Name;
 
             if (_visitedFiles.Add(fileName) && _config.LogVisitedFiles)
             {
@@ -322,7 +331,7 @@ public sealed partial class PInvokeGenerator
             {
                 return true;
             }
-            else if (_config.TraversalNames.Contains(fileName.NormalizeFullPath(), equalityComparer))
+            else if (_config.TraversalNames.Contains(names.FullName, equalityComparer))
             {
                 return true;
             }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -63,6 +63,7 @@ public sealed partial class PInvokeGenerator : IDisposable
     private readonly Dictionary<string, HashSet<string>> _topLevelClassUsings;
     private readonly Dictionary<string, List<string>> _topLevelClassAttributes;
     private readonly Dictionary<CXFile, (nuint Address, nuint Length)> _fileContents;
+    private readonly Dictionary<CXFile, (string Name, string FullName)> _fileNames;
     private readonly HashSet<string> _topLevelClassNames;
     private readonly HashSet<string> _usedRemappings;
     private readonly string _placeholderMacroType;
@@ -161,6 +162,7 @@ public sealed partial class PInvokeGenerator : IDisposable
             _topLevelClassNames = new HashSet<string>(StringComparer.Ordinal);
             _topLevelClassAttributes = new Dictionary<string, List<string>>(StringComparer.Ordinal);
             _fileContents = [];
+            _fileNames = [];
             _topLevelClassUsings = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
             _usedRemappings = new HashSet<string>(StringComparer.Ordinal);
             _filePath = "";
@@ -1680,6 +1682,7 @@ public sealed partial class PInvokeGenerator : IDisposable
         _overloadIndices.Clear();
         _isExcluded.Clear();
         _fileContents.Clear();
+        _fileNames.Clear();
 
         if (translationUnit.Handle.NumDiagnostics != 0)
         {


### PR DESCRIPTION
`IsIncludedFileOrLocation` runs for every cursor (via `IsExcluded`) and re-derives the file's normalized name from scratch each time -- `file.Name.ToString().NormalizePath()`, plus a `NormalizeFullPath()` (`Path.GetFullPath`) on the traversal-name path. The same file recurs for every cursor it contains, so this repeats identical work thousands of times per generation.

Cache the normalized name and full name per `CXFile`, mirroring the existing `_fileContents` cache -- same key type, populated on miss, cleared per translation unit in `GenerateBindings`.

----------

Measured on the TerraFX Windows SDK generation (`DirectX/d3d12`) with `DOTNET_TieredCompilation=0` (the NativeAOT-representative full-opt proxy the shipped tool runs under), sampled `GCAllocationTick`, before vs. after this change:

| | Before | After |
| --- | --- | --- |
| Total sampled allocations | 179.6 MB | 142.7 MB |
| `StringExtensions.NormalizePath` | 18.0 MB | 0 |
| `StringExtensions.NormalizeFullPath` | 8.7 MB | 0 |

~20% fewer allocations overall; both normalization frames drop out of the profile entirely. All 3706 generator tests pass and the build is warning-clean.

> [!NOTE]
> This PR body was drafted by Copilot.