### PR TITLE
Unify duplicated bool type transforms into a shared helper

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -27,6 +27,23 @@ public partial class PInvokeGenerator
 
     private void VisitClassTemplateSpecializationDecl(ClassTemplateSpecializationDecl classTemplateSpecializationDecl) => AddDiagnostic(DiagnosticLevel.Warning, $"Class template specializations are not supported: '{GetCursorQualifiedName(classTemplateSpecializationDecl)}'. Generated bindings may be incomplete.", classTemplateSpecializationDecl);
 
+    private void TransformBoolType(ref string typeName, ref string nativeTypeName)
+    {
+        if (!_config.GenerateDisableRuntimeMarshalling && typeName.Equals("bool", StringComparison.Ordinal))
+        {
+            // bool is not blittable when DisableRuntimeMarshalling is not specified, so we shouldn't use it for structs that may be in P/Invoke signatures
+            typeName = "byte";
+            nativeTypeName = string.IsNullOrWhiteSpace(nativeTypeName) ? "bool" : nativeTypeName;
+        }
+
+        if (_config.GenerateCompatibleCode && typeName.StartsWith("bool*", StringComparison.Ordinal))
+        {
+            // bool* is not blittable in compat mode, so we shouldn't use it for structs that may be in P/Invoke signatures
+            typeName = typeName.Replace("bool*", "byte*", StringComparison.Ordinal);
+            nativeTypeName = string.IsNullOrWhiteSpace(nativeTypeName) ? typeName.Replace("byte*", "bool*", StringComparison.Ordinal) : nativeTypeName;
+        }
+    }
+
     private void VisitDecl(Decl decl)
     {
         if (IsExcluded(decl))
@@ -418,19 +435,7 @@ public partial class PInvokeGenerator
         var type = fieldDecl.Type;
         var typeName = GetRemappedTypeName(fieldDecl, context: null, type, out var nativeTypeName);
 
-        if (!_config.GenerateDisableRuntimeMarshalling && typeName.Equals("bool", StringComparison.Ordinal))
-        {
-            // bool is not blittable when DisableRuntimeMarshalling is not specified, so we shouldn't use it for structs that may be in P/Invoke signatures
-            typeName = "byte";
-            nativeTypeName = string.IsNullOrWhiteSpace(nativeTypeName) ? "bool" : nativeTypeName;
-        }
-
-        if (_config.GenerateCompatibleCode && typeName.StartsWith("bool*", StringComparison.Ordinal))
-        {
-            // bool* is not blittable in compat mode, so we shouldn't use it for structs that may be in P/Invoke signatures
-            typeName = typeName.Replace("bool*", "byte*", StringComparison.Ordinal);
-            nativeTypeName = string.IsNullOrWhiteSpace(nativeTypeName) ? typeName.Replace("byte*", "bool*", StringComparison.Ordinal) : nativeTypeName;
-        }
+        TransformBoolType(ref typeName, ref nativeTypeName);
 
         var parent = fieldDecl.Parent;
         Debug.Assert(parent is not null);
@@ -561,19 +566,7 @@ public partial class PInvokeGenerator
 
         if (isVirtual || (body is null))
         {
-            if (!_config.GenerateDisableRuntimeMarshalling && returnTypeName.Equals("bool", StringComparison.Ordinal))
-            {
-                // bool is not blittable when DisableRuntimeMarshalling is not specified, so we shouldn't use it for P/Invoke signatures
-                returnTypeName = "byte";
-                nativeTypeName = string.IsNullOrWhiteSpace(nativeTypeName) ? "bool" : nativeTypeName;
-            }
-
-            if (_config.GenerateCompatibleCode && returnTypeName.StartsWith("bool*", StringComparison.Ordinal))
-            {
-                // bool* is not blittable in compat mode, so we shouldn't use it for P/Invoke signatures
-                returnTypeName = returnTypeName.Replace("bool*", "byte*", StringComparison.Ordinal);
-                nativeTypeName = string.IsNullOrWhiteSpace(nativeTypeName) ? returnTypeName.Replace("byte*", "bool*", StringComparison.Ordinal) : nativeTypeName;
-            }
+            TransformBoolType(ref returnTypeName, ref nativeTypeName);
         }
 
         var type = functionDecl.Type;
@@ -922,19 +915,9 @@ public partial class PInvokeGenerator
 
         var accessSpecifier = GetAccessSpecifier(anonymousRecordDecl, matchStar: true);
 
-        var typeName = GetRemappedTypeName(fieldDecl, context: null, type, out _);
+        var typeName = GetRemappedTypeName(fieldDecl, context: null, type, out var nativeTypeName);
 
-        if (!_config.GenerateDisableRuntimeMarshalling && typeName.Equals("bool", StringComparison.Ordinal))
-        {
-            // bool is not blittable when DisableRuntimeMarshalling is not specified, so we shouldn't use it for structs that may be in P/Invoke signatures
-            typeName = "byte";
-        }
-
-        if (_config.GenerateCompatibleCode && typeName.StartsWith("bool*", StringComparison.Ordinal))
-        {
-            // bool* is not blittable in compat mode, so we shouldn't use it for structs that may be in P/Invoke signatures
-            typeName = typeName.Replace("bool*", "byte*", StringComparison.Ordinal);
-        }
+        TransformBoolType(ref typeName, ref nativeTypeName);
 
         var name = GetRemappedCursorName(fieldDecl);
         var escapedName = EscapeName(name);


### PR DESCRIPTION
The `bool`/`bool*` type-transform logic used when emitting P/Invoke-facing signatures was copy-pasted across three sites in `PInvokeGenerator.VisitDecl.cs`. The plain `bool` -> `byte` remap, the compat-mode `bool*` -> `byte*` remap, and the `nativeTypeName` fallback were each duplicated, so keeping the sites in sync was manual and drift-prone.

This factors that logic into a single private helper and calls it from each site:

```csharp
private void TransformBoolType(ref string typeName, ref string nativeTypeName)
```

Sites unified (all in `PInvokeGenerator.VisitDecl.cs`):
- `VisitFieldDecl`
- `VisitFunctionDecl` virtual / no-body return handling
- the anonymous-record field emit path

The anonymous-record site previously discarded `nativeTypeName` via `out _`; it now captures it so it can pass the `ref`. That field emits `NativeTypeName = null` regardless, so the discarded value stays byte-identical.

This is behavior-preserving; generated output is unchanged.

Deferred intentionally: the four `bool`-only sites in `PInvokeGenerator.TypeResolution.cs` are left as-is. They only do `bool` -> `byte` and deliberately omit the `bool*` transform; two of them build `delegate*` signatures, so folding them into the full helper would change fnptr/template codegen. The `!= 0` write in `VisitDecl` is a value expression rather than a type transform, so it is out of scope.

Validation: Release build with 0 warnings / 0 errors, and all 3708 golden-file generator tests pass (byte-identical output).