### PR TITLE
Use SearchValues for qualified-name separator scans

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -37,6 +38,7 @@ public sealed partial class PInvokeGenerator : IDisposable
     private static readonly Encoding s_defaultStreamWriterEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
     private static readonly string[] s_doubleColonSeparator = ["::"];
     private static readonly char[] s_doubleQuoteSeparator = ['"'];
+    private static readonly SearchValues<char> s_qualifiedNameSeparatorChars = SearchValues.Create(".:");
 
     private static string ExpectedClangVersion => $"version {clang.MajorVersion}.{clang.MinorVersion}";
     private static string ExpectedClangSharpVersion => ExpectedClangVersion; // change if necessary
@@ -1773,15 +1775,7 @@ public sealed partial class PInvokeGenerator : IDisposable
                         var addDiag = true;
 
                         var smlName = name;
-                        var lastSeparatorIndex = smlName.LastIndexOf("::", StringComparison.Ordinal);
-
-                        if (lastSeparatorIndex != -1)
-                        {
-                            smlName = smlName[(lastSeparatorIndex + 2)..];
-                            addDiag = false;
-                        }
-
-                        lastSeparatorIndex = smlName.LastIndexOf('.');
+                        var lastSeparatorIndex = smlName.LastIndexOfAny(s_qualifiedNameSeparatorChars);
 
                         if (lastSeparatorIndex != -1)
                         {
@@ -1818,15 +1812,7 @@ public sealed partial class PInvokeGenerator : IDisposable
                         var addDiag = true;
 
                         var smlName = name;
-                        var lastSeparatorIndex = smlName.LastIndexOf("::", StringComparison.Ordinal);
-
-                        if (lastSeparatorIndex != -1)
-                        {
-                            smlName = smlName[(lastSeparatorIndex + 2)..];
-                            addDiag = false;
-                        }
-
-                        lastSeparatorIndex = smlName.LastIndexOf('.');
+                        var lastSeparatorIndex = smlName.AsSpan().LastIndexOfAny(s_qualifiedNameSeparatorChars);
 
                         if (lastSeparatorIndex != -1)
                         {
@@ -1857,15 +1843,7 @@ public sealed partial class PInvokeGenerator : IDisposable
                         var addDiag = true;
 
                         var smlName = name;
-                        var lastSeparatorIndex = smlName.LastIndexOf("::", StringComparison.Ordinal);
-
-                        if (lastSeparatorIndex != -1)
-                        {
-                            smlName = smlName[(lastSeparatorIndex + 2)..];
-                            addDiag = false;
-                        }
-
-                        lastSeparatorIndex = smlName.LastIndexOf('.');
+                        var lastSeparatorIndex = smlName.AsSpan().LastIndexOfAny(s_qualifiedNameSeparatorChars);
 
                         if (lastSeparatorIndex != -1)
                         {

--- a/sources/ClangSharp.PInvokeGenerator/QualifiedNameComparer.cs
+++ b/sources/ClangSharp.PInvokeGenerator/QualifiedNameComparer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -9,6 +10,11 @@ namespace ClangSharp;
 internal class QualifiedNameComparer : IEqualityComparer<string>, IAlternateEqualityComparer<ReadOnlySpan<char>, string>
 {
     public static readonly QualifiedNameComparer Default = new QualifiedNameComparer();
+
+    // A qualified name is separated by either `::` or `.`. A `:` only ever appears as part of a
+    // `::` pair, so scanning for the single characters `:` and `.` is equivalent to scanning for
+    // the `::` and `.` separators while allowing a single `IndexOfAny`/`LastIndexOfAny` pass.
+    private static readonly SearchValues<char> s_separatorChars = SearchValues.Create(".:");
 
     public string Create(ReadOnlySpan<char> alternate) => alternate.ToString();
 
@@ -68,20 +74,12 @@ internal class QualifiedNameComparer : IEqualityComparer<string>, IAlternateEqua
             var part = alternate;
             var separatorLength = 0;
 
-            var colonSeparatorIndex = part.IndexOf("::", StringComparison.Ordinal);
+            var separatorIndex = alternate.IndexOfAny(s_separatorChars);
 
-            if (colonSeparatorIndex != -1)
+            if (separatorIndex != -1)
             {
-                part = part[..colonSeparatorIndex];
-                separatorLength = 2;
-            }
-
-            var dotSeparatorIndex = part.IndexOf('.');
-
-            if (dotSeparatorIndex != -1)
-            {
-                part = part[..dotSeparatorIndex];
-                separatorLength = 1;
+                part = alternate[..separatorIndex];
+                separatorLength = (alternate[separatorIndex] == ':') ? 2 : 1;
             }
 
             hashCode.Add(string.GetHashCode(part, StringComparison.Ordinal));


### PR DESCRIPTION
Replaces the paired `IndexOf("::")` + `IndexOf('.')` (and `LastIndexOf` equivalents) separator scans with a single cached `SearchValues<char>` pass over `{ ':', '.' }`.

In a qualified name a `:` only ever appears as part of a `::` pair, so scanning for the single characters `:` and `.` is equivalent to scanning for the `::` and `.` separators -- this collapses two passes into one and lets the shared `SearchValues` instance be created once. The matched-char check (`:` -> separator length `2`, else `1`) preserves the original separator length, so `GetHashCode` stays consistent with `Equals`.

Converted sites:
- `QualifiedNameComparer.GetHashCode` (`IndexOfAny`)
- The three `LogPotentialTypedefRemappings` diagnostic blocks in `PInvokeGenerator.cs` (`LastIndexOfAny`)

Single-character scans (e.g. `IndexOf('*')`, `Split('\n')`, `Split(["::"])` on a substring) are intentionally left as-is since `SearchValues<char>` offers no benefit there.

This is behavior-preserving: generator output and comparer results are unchanged. Verified with a `0` warning/`0` error Release build and the full golden test suite (`3708` passed, `0` failed); no test expectations were touched.