### PR TITLE
Hoist XmlWriterSettings and dispose StringWriter in XmlOutputBuilder

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/XML/XmlOutputBuilder.cs
+++ b/sources/ClangSharp.PInvokeGenerator/XML/XmlOutputBuilder.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using ClangSharp.Abstractions;
@@ -19,28 +20,66 @@ internal partial class XmlOutputBuilder(string name, PInvokeGenerator generator)
 
     public bool IsTestOutput { get; }
 
+    private static readonly XmlWriterSettings s_writerSettings = new()
+    {
+        Indent = true,
+        IndentChars = "  ",
+        ConformanceLevel = ConformanceLevel.Fragment,
+        NewLineChars = "\n",
+    };
+
     public IEnumerable<string> Contents
     {
         get
         {
-            StringWriter sw = new();
-            using var writer = XmlWriter.Create(sw, new()
-            {
-                Indent = true,
-                IndentChars = "  ",
-                ConformanceLevel = ConformanceLevel.Fragment,
-                NewLineChars = "\n",
-            });
+            using StringWriter sw = new();
 
-            foreach (var node in XElement.Parse($"<tmp>{_sb}</tmp>").Nodes())
+            using (var writer = XmlWriter.Create(sw, s_writerSettings))
             {
-                node.WriteTo(writer);
+                foreach (var node in XElement.Parse($"<tmp>{_sb}</tmp>").Nodes())
+                {
+                    node.WriteTo(writer);
+                }
             }
 
-            writer.Flush();
             return sw.ToString().Split('\n');
         }
     }
 
-    private static string EscapeText(string value) => new XText(value).ToString();
+    private static string EscapeText(string value)
+    {
+        var sb = new StringBuilder(value.Length);
+
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '<':
+                {
+                    _ = sb.Append("&lt;");
+                    break;
+                }
+
+                case '>':
+                {
+                    _ = sb.Append("&gt;");
+                    break;
+                }
+
+                case '&':
+                {
+                    _ = sb.Append("&amp;");
+                    break;
+                }
+
+                default:
+                {
+                    _ = sb.Append(c);
+                    break;
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
 }


### PR DESCRIPTION
Modernizes `XmlOutputBuilder.cs` with two behavior-preserving cleanups. Generated output is unchanged -- all ~3708 golden tests pass and the build is clean (0 warnings, 0 errors).

----------

**Hoist `XmlWriterSettings` + dispose `StringWriter`**

`Contents` previously allocated a fresh `XmlWriterSettings` on every access and leaked the backing `StringWriter`. The settings are now a `private static readonly` field constructed once, and both the `StringWriter` and `XmlWriter` are wrapped in `using` scopes. The `XmlWriter` is disposed (which fully flushes it) *before* `sw.ToString()`, so this replaces the old explicit `writer.Flush()` while producing identical XML -- no truncation.

----------

**Replace `XText`-based escaping with a direct escaper**

`EscapeText` used `new XText(value).ToString()` solely to XML-escape a string. It now uses a small purpose-built escaper for `<`, `>`, and `&`. This was verified byte-identical to `XText.ToString()` across every UTF-16 code point plus realistic type names -- the only divergence is raw `\r`/`\n`, which `XText` newline-normalizes and which never appear in the type names `EscapeText` receives. `SecurityElement.Escape` was rejected since it escapes a different character set (`"`/`'`) and does not match `XText`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
