### PR TITLE
Standardize argument-name validation in OutputBuilderFactory

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/OutputBuilderFactory.cs
+++ b/sources/ClangSharp.PInvokeGenerator/OutputBuilderFactory.cs
@@ -20,10 +20,7 @@ internal sealed class OutputBuilderFactory(PInvokeGenerator generator)
 
     public IOutputBuilder Create(string name)
     {
-        if (string.IsNullOrWhiteSpace(name))
-        {
-            throw new ArgumentNullException(nameof(name));
-        }
+        ValidateName(name);
 
         var outputBuilder = generator.Config.OutputMode switch
         {
@@ -38,10 +35,7 @@ internal sealed class OutputBuilderFactory(PInvokeGenerator generator)
 
     public CSharpOutputBuilder CreateTests(string name)
     {
-        if (string.IsNullOrWhiteSpace(name))
-        {
-            throw new ArgumentNullException(nameof(name));
-        }
+        ValidateName(name);
 
         var outputBuilder = new CSharpOutputBuilder(name, generator, isTestOutput: true, writeSourceLocation: _writeSourceLocation);
 
@@ -49,21 +43,31 @@ internal sealed class OutputBuilderFactory(PInvokeGenerator generator)
         return outputBuilder;
     }
 
-    public IOutputBuilder GetOutputBuilder(string name) => string.IsNullOrWhiteSpace(name) ? throw new ArgumentNullException(nameof(name)) : _outputBuilders[name];
+    public IOutputBuilder GetOutputBuilder(string name)
+    {
+        ValidateName(name);
+        return _outputBuilders[name];
+    }
 
     public CSharpOutputBuilder GetTestOutputBuilder(string name)
     {
-        return string.IsNullOrWhiteSpace(name)
-            ? throw new ArgumentNullException(nameof(name))
-            : _outputBuilders[name] is CSharpOutputBuilder csharpOutputBuilder && csharpOutputBuilder.IsTestOutput
+        ValidateName(name);
+        return _outputBuilders[name] is CSharpOutputBuilder csharpOutputBuilder && csharpOutputBuilder.IsTestOutput
             ? csharpOutputBuilder
             : throw new ArgumentException("A test output builder was not found with the given name", nameof(name));
     }
 
     public bool TryGetOutputBuilder(string name, [MaybeNullWhen(false)] out IOutputBuilder outputBuilder)
     {
-        return string.IsNullOrWhiteSpace(name)
-            ? throw new ArgumentNullException(nameof(name))
-            : _outputBuilders.TryGetValue(name, out outputBuilder);
+        ValidateName(name);
+        return _outputBuilders.TryGetValue(name, out outputBuilder);
+    }
+
+    private static void ValidateName([NotNull] string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
     }
 }


### PR DESCRIPTION
The five public methods on `OutputBuilderFactory` each duplicated the same `string name` guard, split across two styles: an `if (string.IsNullOrWhiteSpace(name)) throw` block in `Create`/`CreateTests`, and a ternary-throw form in `GetOutputBuilder`/`GetTestOutputBuilder`/`TryGetOutputBuilder`. This factors the check into a single private `ValidateName` helper called from every method.

`ValidateName` is annotated `[NotNull]` on its `name` parameter so the analyzer treats `name` as non-null once it returns, matching how `ArgumentNullException.ThrowIfNull` is annotated.

Exception semantics are preserved exactly. The existing guard throws `ArgumentNullException(nameof(name))` for null, empty, *and* whitespace names, so `ValidateName` keeps the `string.IsNullOrWhiteSpace` check rather than switching to `ArgumentNullException.ThrowIfNull` (which would not throw for a non-null empty/whitespace name) or `ArgumentException.ThrowIfNullOrWhiteSpace` (which would throw `ArgumentException` instead of `ArgumentNullException`). The distinct `ArgumentException` for a non-test builder in `GetTestOutputBuilder` is left unchanged.

Build (Release): 0 warnings, 0 errors. Golden `PInvokeGenerator.UnitTests`: 3708 passed, 0 failed.
