### PR TITLE
Avoid allocating per-cursor LazyList factory delegates using function pointers

### DIFF
--- a/sources/ClangSharp/Cursors/Decls/BlockDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/BlockDecl.cs
@@ -16,8 +16,8 @@ public sealed partial class BlockDecl : Decl, IDeclContext
     internal unsafe BlockDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_Block)
     {
         _blockManglingContextDecl = new ValueLazy<BlockDecl, Decl>(&BlockManglingContextDeclFactory);
-        _captures = LazyList.Create<Capture>(Handle.NumCaptures, (i) => new Capture(this, unchecked((uint)i)));
-        _parameters = LazyList.Create<ParmVarDecl>(Handle.NumArguments, (i) => TranslationUnit.GetOrCreate<ParmVarDecl>(Handle.GetArgument(unchecked((uint)i))));
+        _captures = LazyList.Create<Capture>(this, Handle.NumCaptures, &CapturesFactory);
+        _parameters = LazyList.Create<ParmVarDecl>(this, Handle.NumArguments, &ParametersFactory);
     }
 
     public Decl BlockManglingContextDecl => _blockManglingContextDecl.GetValue(this);
@@ -55,4 +55,16 @@ public sealed partial class BlockDecl : Decl, IDeclContext
     public bool CapturesVariable(VarDecl var) => Handle.CapturesVariable((var is not null) ? var.Handle : CXCursor.Null);
 
     private static unsafe Decl BlockManglingContextDeclFactory(BlockDecl self) => self.TranslationUnit.GetOrCreate<Decl>(self.Handle.BlockManglingContextDecl);
+
+    private static unsafe Capture CapturesFactory(object self, int i)
+    {
+        var @this = (BlockDecl)self;
+        return new Capture(@this, unchecked((uint)i));
+    }
+
+    private static unsafe ParmVarDecl ParametersFactory(object self, int i)
+    {
+        var @this = (BlockDecl)self;
+        return @this.TranslationUnit.GetOrCreate<ParmVarDecl>(@this.Handle.GetArgument(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/CXXConstructorDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CXXConstructorDecl.cs
@@ -15,7 +15,7 @@ public sealed class CXXConstructorDecl : CXXMethodDecl
     internal unsafe CXXConstructorDecl(CXCursor handle) : base(handle, CXCursor_Constructor, CX_DeclKind_CXXConstructor)
     {
         _inheritedConstructor = new ValueLazy<CXXConstructorDecl, CXXConstructorDecl>(&InheritedConstructorFactory);
-        _initExprs = LazyList.Create<Expr>(Handle.NumExprs , (i) => TranslationUnit.GetOrCreate<Expr>(Handle.GetExpr(unchecked((uint)i))));
+        _initExprs = LazyList.Create<Expr>(this, Handle.NumExprs, &InitExprsFactory);
     }
 
     public new CXXConstructorDecl CanonicalDecl => (CXXConstructorDecl)base.CanonicalDecl;
@@ -58,4 +58,10 @@ public sealed class CXXConstructorDecl : CXXMethodDecl
     }
 
     private static unsafe CXXConstructorDecl InheritedConstructorFactory(CXXConstructorDecl self) => self.TranslationUnit.GetOrCreate<CXXConstructorDecl>(self.Handle.InheritedConstructor);
+
+    private static unsafe Expr InitExprsFactory(object self, int i)
+    {
+        var @this = (CXXConstructorDecl)self;
+        return @this.TranslationUnit.GetOrCreate<Expr>(@this.Handle.GetExpr(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/CXXMethodDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CXXMethodDecl.cs
@@ -25,7 +25,7 @@ public class CXXMethodDecl : FunctionDecl
             throw new ArgumentOutOfRangeException(nameof(handle));
         }
 
-        _overriddenMethods = LazyList.Create<CXXMethodDecl>(Handle.NumMethods, (i) => TranslationUnit.GetOrCreate<CXXMethodDecl>(Handle.GetMethod(unchecked((uint)i))));
+        _overriddenMethods = LazyList.Create<CXXMethodDecl>(this, Handle.NumMethods, &OverriddenMethodsFactory);
         _thisType = new ValueLazy<CXXMethodDecl, Type>(&ThisTypeFactory);
         _thisObjectType = new ValueLazy<CXXMethodDecl, Type>(&ThisObjectTypeFactory);
     }
@@ -57,4 +57,10 @@ public class CXXMethodDecl : FunctionDecl
     private static unsafe Type ThisObjectTypeFactory(CXXMethodDecl self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.ThisObjectType);
 
     private static unsafe Type ThisTypeFactory(CXXMethodDecl self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.ThisType);
+
+    private static unsafe CXXMethodDecl OverriddenMethodsFactory(object self, int i)
+    {
+        var @this = (CXXMethodDecl)self;
+        return @this.TranslationUnit.GetOrCreate<CXXMethodDecl>(@this.Handle.GetMethod(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/CXXRecordDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CXXRecordDecl.cs
@@ -35,19 +35,19 @@ public class CXXRecordDecl : RecordDecl
             throw new ArgumentOutOfRangeException(nameof(handle));
         }
 
-        _bases = LazyList.Create<CXXBaseSpecifier>(Handle.NumBases, (i) => TranslationUnit.GetOrCreate<CXXBaseSpecifier>(Handle.GetBase(unchecked((uint)i))));
-        _ctors = LazyList.Create<CXXConstructorDecl>(Handle.NumCtors, (i) => TranslationUnit.GetOrCreate<CXXConstructorDecl>(Handle.GetCtor(unchecked((uint)i))));
+        _bases = LazyList.Create<CXXBaseSpecifier>(this, Handle.NumBases, &BasesFactory);
+        _ctors = LazyList.Create<CXXConstructorDecl>(this, Handle.NumCtors, &CtorsFactory);
         _dependentLambdaCallOperator = new ValueLazy<CXXRecordDecl, FunctionTemplateDecl>(&DependentLambdaCallOperatorFactory);
         _describedClassTemplate = new ValueLazy<CXXRecordDecl, ClassTemplateDecl>(&DescribedClassTemplateFactory);
         _destructor = new ValueLazy<CXXRecordDecl, CXXDestructorDecl?>(&DestructorFactory);
-        _friends = LazyList.Create<FriendDecl>(Handle.NumFriends, (i) => TranslationUnit.GetOrCreate<FriendDecl>(Handle.GetFriend(unchecked((uint)i))));
+        _friends = LazyList.Create<FriendDecl>(this, Handle.NumFriends, &FriendsFactory);
         _instantiatedFromMemberClass = new ValueLazy<CXXRecordDecl, CXXRecordDecl>(&InstantiatedFromMemberClassFactory);
         _lambdaCallOperator = new ValueLazy<CXXRecordDecl, CXXMethodDecl>(&LambdaCallOperatorFactory);
         _lambdaContextDecl = new ValueLazy<CXXRecordDecl, Decl>(&LambdaContextDeclFactory);
         _lambdaStaticInvoker = new ValueLazy<CXXRecordDecl, CXXMethodDecl>(&LambdaStaticInvokerFactory);
-        _methods = LazyList.Create<CXXMethodDecl>(Handle.NumMethods, (i) => TranslationUnit.GetOrCreate<CXXMethodDecl>(Handle.GetMethod(unchecked((uint)i))));
+        _methods = LazyList.Create<CXXMethodDecl>(this, Handle.NumMethods, &MethodsFactory);
         _templateInstantiationPattern = new ValueLazy<CXXRecordDecl, CXXRecordDecl>(&TemplateInstantiationPatternFactory);
-        _vbases = LazyList.Create<CXXBaseSpecifier>(Handle.NumVBases, (i) => TranslationUnit.GetOrCreate<CXXBaseSpecifier>(Handle.GetVBase(unchecked((uint)i))));
+        _vbases = LazyList.Create<CXXBaseSpecifier>(this, Handle.NumVBases, &VbasesFactory);
     }
 
     public bool IsAbstract => Handle.CXXRecord_IsAbstract;
@@ -146,4 +146,34 @@ public class CXXRecordDecl : RecordDecl
     private static unsafe ClassTemplateDecl DescribedClassTemplateFactory(CXXRecordDecl self) => self.TranslationUnit.GetOrCreate<ClassTemplateDecl>(self.Handle.DescribedCursorTemplate);
 
     private static unsafe FunctionTemplateDecl DependentLambdaCallOperatorFactory(CXXRecordDecl self) => self.TranslationUnit.GetOrCreate<FunctionTemplateDecl>(self.Handle.DependentLambdaCallOperator);
+
+    private static unsafe CXXBaseSpecifier BasesFactory(object self, int i)
+    {
+        var @this = (CXXRecordDecl)self;
+        return @this.TranslationUnit.GetOrCreate<CXXBaseSpecifier>(@this.Handle.GetBase(unchecked((uint)i)));
+    }
+
+    private static unsafe CXXConstructorDecl CtorsFactory(object self, int i)
+    {
+        var @this = (CXXRecordDecl)self;
+        return @this.TranslationUnit.GetOrCreate<CXXConstructorDecl>(@this.Handle.GetCtor(unchecked((uint)i)));
+    }
+
+    private static unsafe FriendDecl FriendsFactory(object self, int i)
+    {
+        var @this = (CXXRecordDecl)self;
+        return @this.TranslationUnit.GetOrCreate<FriendDecl>(@this.Handle.GetFriend(unchecked((uint)i)));
+    }
+
+    private static unsafe CXXMethodDecl MethodsFactory(object self, int i)
+    {
+        var @this = (CXXRecordDecl)self;
+        return @this.TranslationUnit.GetOrCreate<CXXMethodDecl>(@this.Handle.GetMethod(unchecked((uint)i)));
+    }
+
+    private static unsafe CXXBaseSpecifier VbasesFactory(object self, int i)
+    {
+        var @this = (CXXRecordDecl)self;
+        return @this.TranslationUnit.GetOrCreate<CXXBaseSpecifier>(@this.Handle.GetVBase(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/CapturedDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CapturedDecl.cs
@@ -15,7 +15,7 @@ public sealed class CapturedDecl : Decl, IDeclContext
     internal unsafe CapturedDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_Captured)
     {
         _contextParam = new ValueLazy<CapturedDecl, ImplicitParamDecl>(&ContextParamFactory);
-        _parameters = LazyList.Create<ImplicitParamDecl>(Handle.NumArguments, (i) => TranslationUnit.GetOrCreate<ImplicitParamDecl>(Handle.GetArgument(unchecked((uint)i))));
+        _parameters = LazyList.Create<ImplicitParamDecl>(this, Handle.NumArguments, &ParametersFactory);
     }
 
     public ImplicitParamDecl ContextParam => _contextParam.GetValue(this);
@@ -29,4 +29,10 @@ public sealed class CapturedDecl : Decl, IDeclContext
     public IReadOnlyList<ImplicitParamDecl> Parameters => _parameters;
 
     private static unsafe ImplicitParamDecl ContextParamFactory(CapturedDecl self) => self.TranslationUnit.GetOrCreate<ImplicitParamDecl>(self.Handle.ContextParam);
+
+    private static unsafe ImplicitParamDecl ParametersFactory(object self, int i)
+    {
+        var @this = (CapturedDecl)self;
+        return @this.TranslationUnit.GetOrCreate<ImplicitParamDecl>(@this.Handle.GetArgument(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/ClassTemplateDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ClassTemplateDecl.cs
@@ -15,7 +15,7 @@ public sealed class ClassTemplateDecl : RedeclarableTemplateDecl
     internal unsafe ClassTemplateDecl(CXCursor handle) : base(handle, CXCursor_ClassTemplate, CX_DeclKind_ClassTemplate)
     {
         _injectedClassNameSpecialization = new ValueLazy<ClassTemplateDecl, Type>(&InjectedClassNameSpecializationFactory);
-        _specializations = LazyList.Create<ClassTemplateSpecializationDecl>(Handle.NumSpecializations, (i) => TranslationUnit.GetOrCreate<ClassTemplateSpecializationDecl>(Handle.GetSpecialization(unchecked((uint)i))));
+        _specializations = LazyList.Create<ClassTemplateSpecializationDecl>(this, Handle.NumSpecializations, &SpecializationsFactory);
     }
 
     public new ClassTemplateDecl CanonicalDecl => (ClassTemplateDecl)base.CanonicalDecl;
@@ -35,4 +35,10 @@ public sealed class ClassTemplateDecl : RedeclarableTemplateDecl
     public new CXXRecordDecl TemplatedDecl => (CXXRecordDecl)base.TemplatedDecl;
 
     private static unsafe Type InjectedClassNameSpecializationFactory(ClassTemplateDecl self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.InjectedSpecializationType);
+
+    private static unsafe ClassTemplateSpecializationDecl SpecializationsFactory(object self, int i)
+    {
+        var @this = (ClassTemplateDecl)self;
+        return @this.TranslationUnit.GetOrCreate<ClassTemplateSpecializationDecl>(@this.Handle.GetSpecialization(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/ClassTemplatePartialSpecializationDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ClassTemplatePartialSpecializationDecl.cs
@@ -16,10 +16,10 @@ public sealed class ClassTemplatePartialSpecializationDecl : ClassTemplateSpecia
 
     internal unsafe ClassTemplatePartialSpecializationDecl(CXCursor handle) : base(handle, CXCursor_ClassTemplatePartialSpecialization, CX_DeclKind_ClassTemplatePartialSpecialization)
     {
-        _associatedConstraints = LazyList.Create<Expr>(Handle.NumAssociatedConstraints, (i) => TranslationUnit.GetOrCreate<Expr>(Handle.GetAssociatedConstraint(unchecked((uint)i))));
+        _associatedConstraints = LazyList.Create<Expr>(this, Handle.NumAssociatedConstraints, &AssociatedConstraintsFactory);
         _injectedSpecializationType = new ValueLazy<ClassTemplatePartialSpecializationDecl, Type>(&InjectedSpecializationTypeFactory);
         _instantiatedFromMember = new ValueLazy<ClassTemplatePartialSpecializationDecl, ClassTemplatePartialSpecializationDecl>(&InstantiatedFromMemberFactory);
-        _templateParameters = LazyList.Create<NamedDecl>(Handle.GetNumTemplateParameters(0), (i) => TranslationUnit.GetOrCreate<NamedDecl>(Handle.GetTemplateParameter(0, unchecked((uint)i))));
+        _templateParameters = LazyList.Create<NamedDecl>(this, Handle.GetNumTemplateParameters(0), &TemplateParametersFactory);
     }
 
     public IReadOnlyList<Expr> AssociatedConstraints => _associatedConstraints;
@@ -41,4 +41,16 @@ public sealed class ClassTemplatePartialSpecializationDecl : ClassTemplateSpecia
     private static unsafe ClassTemplatePartialSpecializationDecl InstantiatedFromMemberFactory(ClassTemplatePartialSpecializationDecl self) => self.TranslationUnit.GetOrCreate<ClassTemplatePartialSpecializationDecl>(self.Handle.InstantiatedFromMember);
 
     private static unsafe Type InjectedSpecializationTypeFactory(ClassTemplatePartialSpecializationDecl self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.InjectedSpecializationType);
+
+    private static unsafe Expr AssociatedConstraintsFactory(object self, int i)
+    {
+        var @this = (ClassTemplatePartialSpecializationDecl)self;
+        return @this.TranslationUnit.GetOrCreate<Expr>(@this.Handle.GetAssociatedConstraint(unchecked((uint)i)));
+    }
+
+    private static unsafe NamedDecl TemplateParametersFactory(object self, int i)
+    {
+        var @this = (ClassTemplatePartialSpecializationDecl)self;
+        return @this.TranslationUnit.GetOrCreate<NamedDecl>(@this.Handle.GetTemplateParameter(0, unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/ClassTemplateSpecializationDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ClassTemplateSpecializationDecl.cs
@@ -17,7 +17,7 @@ public class ClassTemplateSpecializationDecl : CXXRecordDecl
     internal unsafe ClassTemplateSpecializationDecl(CXCursor handle) : this(handle, handle.Kind, CX_DeclKind_ClassTemplateSpecialization)
     {
         _specializedTemplate = new ValueLazy<ClassTemplateSpecializationDecl, ClassTemplateDecl>(&SpecializedTemplateFactory);
-        _templateArgs = LazyList.Create<TemplateArgument>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgument(unchecked((uint)i))));
+        _templateArgs = LazyList.Create<TemplateArgument>(this, Handle.NumTemplateArguments, &TemplateArgsFactory);
     }
 
     private protected unsafe ClassTemplateSpecializationDecl(CXCursor handle, CXCursorKind expectedCursorKind, CX_DeclKind expectedDeclKind) : base(handle, expectedCursorKind, expectedDeclKind)
@@ -28,7 +28,7 @@ public class ClassTemplateSpecializationDecl : CXXRecordDecl
         }
 
         _specializedTemplate = new ValueLazy<ClassTemplateSpecializationDecl, ClassTemplateDecl>(&SpecializedTemplateFactory);
-        _templateArgs = LazyList.Create<TemplateArgument>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgument(unchecked((uint)i))));
+        _templateArgs = LazyList.Create<TemplateArgument>(this, Handle.NumTemplateArguments, &TemplateArgsFactory);
     }
 
     public bool IsClassScopeExplicitSpecialization => IsExplicitSpecialization && (LexicalDeclContext is CXXRecordDecl);
@@ -69,4 +69,10 @@ public class ClassTemplateSpecializationDecl : CXXRecordDecl
     public IReadOnlyList<TemplateArgument> TemplateArgs => _templateArgs;
 
     private static unsafe ClassTemplateDecl SpecializedTemplateFactory(ClassTemplateSpecializationDecl self) => self.TranslationUnit.GetOrCreate<ClassTemplateDecl>(self.Handle.SpecializedCursorTemplate);
+
+    private static unsafe TemplateArgument TemplateArgsFactory(object self, int i)
+    {
+        var @this = (ClassTemplateSpecializationDecl)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgument(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/Decl.cs
+++ b/sources/ClangSharp/Cursors/Decls/Decl.cs
@@ -37,19 +37,10 @@ public class Decl : Cursor
         }
 
         _asFunction = new ValueLazy<Decl, FunctionDecl>(&AsFunctionFactory);
-        _attrs = LazyList.Create<Attr>(Handle.NumAttrs, (i) => TranslationUnit.GetOrCreate<Attr>(Handle.GetAttr(unchecked((uint)i))));
+        _attrs = LazyList.Create<Attr>(this, Handle.NumAttrs, &AttrsFactory);
         _body = new ValueLazy<Decl, Stmt?>(&BodyFactory);
         _canonicalDecl = new ValueLazy<Decl, Decl>(&CanonicalDeclFactory);
-        _decls = LazyList.Create<Decl>(Handle.NumDecls, (i, previousDecl) => {
-            if (previousDecl is null)
-            {
-                return TranslationUnit.GetOrCreate<Decl>(Handle.GetDecl(unchecked((uint)i)));
-            }
-            else
-            {
-                return previousDecl.NextDeclInContext;
-            }
-        });
+        _decls = LazyList.Create<Decl>(this, Handle.NumDecls, &DeclsFactory);
         _describedTemplate = new ValueLazy<Decl, TemplateDecl?>(&DescribedTemplateFactory);
         _mostRecentDecl = new ValueLazy<Decl, Decl>(&MostRecentDeclFactory);
         _nextDeclInContext = new ValueLazy<Decl, Decl>(&NextDeclInContextFactory);
@@ -276,4 +267,48 @@ public class Decl : Cursor
     private static unsafe Stmt? BodyFactory(Decl self) => !self.Handle.Body.IsNull ? self.TranslationUnit.GetOrCreate<Stmt>(self.Handle.Body) : null;
 
     private static unsafe FunctionDecl AsFunctionFactory(Decl self) => self.TranslationUnit.GetOrCreate<FunctionDecl>(self.Handle.AsFunction);
+
+    private static unsafe Attr AttrsFactory(object self, int i)
+    {
+        var @this = (Decl)self;
+        return @this.TranslationUnit.GetOrCreate<Attr>(@this.Handle.GetAttr(unchecked((uint)i)));
+    }
+
+    private static unsafe Decl DeclsFactory(object self, int i, Decl? previousDecl)
+    {
+        var @this = (Decl)self;
+
+        if (previousDecl is null)
+        {
+            return @this.TranslationUnit.GetOrCreate<Decl>(@this.Handle.GetDecl(unchecked((uint)i)));
+        }
+        else
+        {
+            return previousDecl.NextDeclInContext;
+        }
+    }
+
+    private protected static unsafe LazyList<LazyList<NamedDecl>> CreateTemplateParameterLists(Decl self)
+    {
+        return LazyList.Create<LazyList<NamedDecl>>(self, self.Handle.NumTemplateParameterLists, &TemplateParameterListFactory);
+    }
+
+    private static unsafe LazyList<NamedDecl> TemplateParameterListFactory(object self, int listIndex)
+    {
+        var @this = (Decl)self;
+        var numTemplateParameters = @this.Handle.GetNumTemplateParameters(unchecked((uint)listIndex));
+        return LazyList.Create<NamedDecl>(new TemplateParameterListContext(@this, unchecked((uint)listIndex)), numTemplateParameters, &TemplateParameterFactory);
+    }
+
+    private static unsafe NamedDecl TemplateParameterFactory(object self, int parameterIndex)
+    {
+        var context = (TemplateParameterListContext)self;
+        return context.Owner.TranslationUnit.GetOrCreate<NamedDecl>(context.Owner.Handle.GetTemplateParameter(context.ListIndex, unchecked((uint)parameterIndex)));
+    }
+
+    private sealed class TemplateParameterListContext(Decl owner, uint listIndex)
+    {
+        public readonly Decl Owner = owner;
+        public readonly uint ListIndex = listIndex;
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/DeclaratorDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/DeclaratorDecl.cs
@@ -19,10 +19,7 @@ public class DeclaratorDecl : ValueDecl
             throw new ArgumentOutOfRangeException(nameof(handle));
         }
 
-        _templateParameterLists = LazyList.Create<LazyList<NamedDecl>>(Handle.NumTemplateParameterLists, (listIndex) => {
-            var numTemplateParameters = Handle.GetNumTemplateParameters(unchecked((uint)listIndex));
-            return LazyList.Create<NamedDecl>(numTemplateParameters, (parameterIndex) => TranslationUnit.GetOrCreate<NamedDecl>(Handle.GetTemplateParameter(unchecked((uint)listIndex), unchecked((uint)parameterIndex))));
-        });
+        _templateParameterLists = CreateTemplateParameterLists(this);
         _trailingRequiresClause = new ValueLazy<DeclaratorDecl, Expr>(&TrailingRequiresClauseFactory);
     }
 

--- a/sources/ClangSharp/Cursors/Decls/DecompositionDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/DecompositionDecl.cs
@@ -11,10 +11,16 @@ public sealed class DecompositionDecl : VarDecl
 {
     private readonly LazyList<BindingDecl> _bindings;
 
-    internal DecompositionDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_Decomposition)
+    internal unsafe DecompositionDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_Decomposition)
     {
-        _bindings = LazyList.Create<BindingDecl>(Handle.NumBindings, (i) => TranslationUnit.GetOrCreate<BindingDecl>(Handle.GetBindingDecl(unchecked((uint)i))));
+        _bindings = LazyList.Create<BindingDecl>(this, Handle.NumBindings, &BindingsFactory);
     }
 
     public IReadOnlyList<BindingDecl> Bindings => _bindings;
+
+    private static unsafe BindingDecl BindingsFactory(object self, int i)
+    {
+        var @this = (DecompositionDecl)self;
+        return @this.TranslationUnit.GetOrCreate<BindingDecl>(@this.Handle.GetBindingDecl(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/EnumDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/EnumDecl.cs
@@ -17,7 +17,7 @@ public sealed class EnumDecl : TagDecl
 
     internal unsafe EnumDecl(CXCursor handle) : base(handle, CXCursor_EnumDecl, CX_DeclKind_Enum)
     {
-        _enumerators = LazyList.Create<EnumConstantDecl>(Handle.NumEnumerators, (i) => TranslationUnit.GetOrCreate<EnumConstantDecl>(Handle.GetEnumerator(unchecked((uint)i))));
+        _enumerators = LazyList.Create<EnumConstantDecl>(this, Handle.NumEnumerators, &EnumeratorsFactory);
         _instantiatedFromMemberEnum = new ValueLazy<EnumDecl, EnumDecl>(&InstantiatedFromMemberEnumFactory);
         _integerType = new ValueLazy<EnumDecl, Type>(&IntegerTypeFactory);
         _promotionType = new ValueLazy<EnumDecl, Type>(&PromotionTypeFactory);
@@ -55,4 +55,10 @@ public sealed class EnumDecl : TagDecl
     private static unsafe Type IntegerTypeFactory(EnumDecl self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.EnumDecl_IntegerType);
 
     private static unsafe EnumDecl InstantiatedFromMemberEnumFactory(EnumDecl self) => self.TranslationUnit.GetOrCreate<EnumDecl>(self.Handle.InstantiatedFromMember);
+
+    private static unsafe EnumConstantDecl EnumeratorsFactory(object self, int i)
+    {
+        var @this = (EnumDecl)self;
+        return @this.TranslationUnit.GetOrCreate<EnumConstantDecl>(@this.Handle.GetEnumerator(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/FriendDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/FriendDecl.cs
@@ -15,10 +15,7 @@ public sealed class FriendDecl : Decl
     internal unsafe FriendDecl(CXCursor handle) : base(handle, CXCursor_FriendDecl, CX_DeclKind_Friend)
     {
         _friendNamedDecl = new ValueLazy<FriendDecl, NamedDecl>(&FriendNamedDeclFactory);
-        _friendTypeTemplateParameterLists = LazyList.Create<LazyList<NamedDecl>>(Handle.NumTemplateParameterLists, (listIndex) => {
-            var numTemplateParameters = Handle.GetNumTemplateParameters(unchecked((uint)listIndex));
-            return LazyList.Create<NamedDecl>(numTemplateParameters, (parameterIndex) => TranslationUnit.GetOrCreate<NamedDecl>(Handle.GetTemplateParameter(unchecked((uint)listIndex), unchecked((uint)parameterIndex))));
-        });
+        _friendTypeTemplateParameterLists = CreateTemplateParameterLists(this);
     }
 
     public NamedDecl FriendNamedDecl => _friendNamedDecl.GetValue(this);

--- a/sources/ClangSharp/Cursors/Decls/FriendTemplateDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/FriendTemplateDecl.cs
@@ -17,10 +17,7 @@ public sealed class FriendTemplateDecl : Decl
     {
         _friendDecl = new ValueLazy<FriendTemplateDecl, NamedDecl>(&FriendDeclFactory);
         _friendType = new ValueLazy<FriendTemplateDecl, Type>(&FriendTypeFactory);
-        _templateParameterLists = LazyList.Create<LazyList<NamedDecl>>(Handle.NumTemplateParameterLists, (listIndex) => {
-            var numTemplateParameters = Handle.GetNumTemplateParameters(unchecked((uint)listIndex));
-            return LazyList.Create<NamedDecl>(numTemplateParameters, (parameterIndex) => TranslationUnit.GetOrCreate<NamedDecl>(Handle.GetTemplateParameter(unchecked((uint)listIndex), unchecked((uint)parameterIndex))));
-        });
+        _templateParameterLists = CreateTemplateParameterLists(this);
     }
 
     public NamedDecl FriendDecl => _friendDecl.GetValue(this);

--- a/sources/ClangSharp/Cursors/Decls/FunctionDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/FunctionDecl.cs
@@ -37,11 +37,11 @@ public class FunctionDecl : DeclaratorDecl, IDeclContext, IRedeclarable<Function
         _definition = new ValueLazy<FunctionDecl, FunctionDecl>(&DefinitionFactory);
         _describedFunctionDecl = new ValueLazy<FunctionDecl, FunctionTemplateDecl>(&DescribedFunctionDeclFactory);
         _instantiatedFromMemberFunction = new ValueLazy<FunctionDecl, FunctionDecl>(&InstantiatedFromMemberFunctionFactory);
-        _parameters = LazyList.Create<ParmVarDecl>(Handle.NumArguments, (i) => TranslationUnit.GetOrCreate<ParmVarDecl>(Handle.GetArgument(unchecked((uint)i))));
+        _parameters = LazyList.Create<ParmVarDecl>(this, Handle.NumArguments, &ParametersFactory);
         _primaryTemplate = new ValueLazy<FunctionDecl, FunctionTemplateDecl>(&PrimaryTemplateFactory);
         _returnType = new ValueLazy<FunctionDecl, Type>(&ReturnTypeFactory);
         _templateInstantiationPattern = new ValueLazy<FunctionDecl, FunctionDecl>(&TemplateInstantiationPatternFactory);
-        _templateSpecializationArgs = LazyList.Create<TemplateArgument>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgument(unchecked((uint)i))));
+        _templateSpecializationArgs = LazyList.Create<TemplateArgument>(this, Handle.NumTemplateArguments, &TemplateSpecializationArgsFactory);
     }
 
     public Type CallResultType => _callResultType.GetValue(this);
@@ -127,4 +127,16 @@ public class FunctionDecl : DeclaratorDecl, IDeclContext, IRedeclarable<Function
     private static unsafe Type DeclaredReturnTypeFactory(FunctionDecl self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.DeclaredReturnType);
 
     private static unsafe Type CallResultTypeFactory(FunctionDecl self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.CallResultType);
+
+    private static unsafe ParmVarDecl ParametersFactory(object self, int i)
+    {
+        var @this = (FunctionDecl)self;
+        return @this.TranslationUnit.GetOrCreate<ParmVarDecl>(@this.Handle.GetArgument(unchecked((uint)i)));
+    }
+
+    private static unsafe TemplateArgument TemplateSpecializationArgsFactory(object self, int i)
+    {
+        var @this = (FunctionDecl)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgument(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/FunctionTemplateDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/FunctionTemplateDecl.cs
@@ -12,10 +12,10 @@ public sealed class FunctionTemplateDecl : RedeclarableTemplateDecl
     private readonly LazyList<TemplateArgument> _injectedTemplateArgs;
     private readonly LazyList<FunctionDecl> _specializations;
 
-    internal FunctionTemplateDecl(CXCursor handle) : base(handle, CXCursor_FunctionTemplate, CX_DeclKind_FunctionTemplate)
+    internal unsafe FunctionTemplateDecl(CXCursor handle) : base(handle, CXCursor_FunctionTemplate, CX_DeclKind_FunctionTemplate)
     {
-        _injectedTemplateArgs = LazyList.Create<TemplateArgument>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgument(unchecked((uint)i))));
-        _specializations = LazyList.Create<FunctionDecl>(Handle.NumSpecializations, (i) => TranslationUnit.GetOrCreate<FunctionDecl>(Handle.GetSpecialization(unchecked((uint)i))));
+        _injectedTemplateArgs = LazyList.Create<TemplateArgument>(this, Handle.NumTemplateArguments, &InjectedTemplateArgsFactory);
+        _specializations = LazyList.Create<FunctionDecl>(this, Handle.NumSpecializations, &SpecializationsFactory);
     }
 
     public new FunctionTemplateDecl CanonicalDecl => (FunctionTemplateDecl)base.CanonicalDecl;
@@ -33,4 +33,16 @@ public sealed class FunctionTemplateDecl : RedeclarableTemplateDecl
     public IReadOnlyList<FunctionDecl> Specializations => _specializations;
 
     public new FunctionDecl TemplatedDecl => (FunctionDecl)base.TemplatedDecl;
+
+    private static unsafe TemplateArgument InjectedTemplateArgsFactory(object self, int i)
+    {
+        var @this = (FunctionTemplateDecl)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgument(unchecked((uint)i)));
+    }
+
+    private static unsafe FunctionDecl SpecializationsFactory(object self, int i)
+    {
+        var @this = (FunctionTemplateDecl)self;
+        return @this.TranslationUnit.GetOrCreate<FunctionDecl>(@this.Handle.GetSpecialization(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/ImplicitConceptSpecializationDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ImplicitConceptSpecializationDecl.cs
@@ -11,12 +11,18 @@ public sealed class ImplicitConceptSpecializationDecl : Decl
 {
     private readonly LazyList<TemplateArgumentLoc> _templateArgs;
 
-    internal ImplicitConceptSpecializationDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_ImplicitConceptSpecialization)
+    internal unsafe ImplicitConceptSpecializationDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_ImplicitConceptSpecialization)
     {
-        _templateArgs = LazyList.Create<TemplateArgumentLoc>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgumentLoc(unchecked((uint)i))));
+        _templateArgs = LazyList.Create<TemplateArgumentLoc>(this, Handle.NumTemplateArguments, &TemplateArgsFactory);
     }
 
     public uint NumTemplateArgs => unchecked((uint)Handle.NumTemplateArguments);
 
     public IReadOnlyList<TemplateArgumentLoc> TemplateArgs => _templateArgs;
+
+    private static unsafe TemplateArgumentLoc TemplateArgsFactory(object self, int i)
+    {
+        var @this = (ImplicitConceptSpecializationDecl)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgumentLoc(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/NonTypeTemplateParmDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/NonTypeTemplateParmDecl.cs
@@ -16,9 +16,9 @@ public sealed class NonTypeTemplateParmDecl : DeclaratorDecl, ITemplateParmPosit
 
     internal unsafe NonTypeTemplateParmDecl(CXCursor handle) : base(handle, CXCursor_NonTypeTemplateParameter, CX_DeclKind_NonTypeTemplateParm)
     {
-        _associatedConstraints = LazyList.Create<Expr>(Handle.NumAssociatedConstraints, (i) => TranslationUnit.GetOrCreate<Expr>(Handle.GetAssociatedConstraint(unchecked((uint)i))));
+        _associatedConstraints = LazyList.Create<Expr>(this, Handle.NumAssociatedConstraints, &AssociatedConstraintsFactory);
         _defaultArgument = new ValueLazy<NonTypeTemplateParmDecl, Expr>(&DefaultArgumentFactory);
-        _expansionTypes = LazyList.Create<Type>(Handle.NumExpansionTypes, (i) => TranslationUnit.GetOrCreate<Type>(Handle.GetExpansionType(unchecked((uint)i))));
+        _expansionTypes = LazyList.Create<Type>(this, Handle.NumExpansionTypes, &ExpansionTypesFactory);
         _placeholderTypeConstraint = new ValueLazy<NonTypeTemplateParmDecl, Expr>(&PlaceholderTypeConstraintFactory);
     }
 
@@ -49,4 +49,16 @@ public sealed class NonTypeTemplateParmDecl : DeclaratorDecl, ITemplateParmPosit
     private static unsafe Expr PlaceholderTypeConstraintFactory(NonTypeTemplateParmDecl self) => self.TranslationUnit.GetOrCreate<Expr>(self.Handle.PlaceholderTypeConstraint);
 
     private static unsafe Expr DefaultArgumentFactory(NonTypeTemplateParmDecl self) => self.TranslationUnit.GetOrCreate<Expr>(self.Handle.DefaultArg);
+
+    private static unsafe Expr AssociatedConstraintsFactory(object self, int i)
+    {
+        var @this = (NonTypeTemplateParmDecl)self;
+        return @this.TranslationUnit.GetOrCreate<Expr>(@this.Handle.GetAssociatedConstraint(unchecked((uint)i)));
+    }
+
+    private static unsafe Type ExpansionTypesFactory(object self, int i)
+    {
+        var @this = (NonTypeTemplateParmDecl)self;
+        return @this.TranslationUnit.GetOrCreate<Type>(@this.Handle.GetExpansionType(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/ObjCCategoryDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCCategoryDecl.cs
@@ -25,8 +25,8 @@ public sealed class ObjCCategoryDecl : ObjCContainerDecl
         _ivars = new ValueLazy<ObjCCategoryDecl, List<ObjCIvarDecl>>(&IvarsFactory);
         _nextClassCategory = new ValueLazy<ObjCCategoryDecl, ObjCCategoryDecl>(&NextClassCategoryFactory);
         _nextClassCategoryRaw = new ValueLazy<ObjCCategoryDecl, ObjCCategoryDecl>(&NextClassCategoryRawFactory);
-        _protocols = LazyList.Create<ObjCProtocolDecl>(Handle.NumProtocols, (i) => TranslationUnit.GetOrCreate<ObjCProtocolDecl>(Handle.GetProtocol(unchecked((uint)i))));
-        _typeParamList = LazyList.Create<ObjCTypeParamDecl>(Handle.NumTypeParams, (i) => TranslationUnit.GetOrCreate<ObjCTypeParamDecl>(Handle.GetTypeParam(unchecked((uint)i))));
+        _protocols = LazyList.Create<ObjCProtocolDecl>(this, Handle.NumProtocols, &ProtocolsFactory);
+        _typeParamList = LazyList.Create<ObjCTypeParamDecl>(this, Handle.NumTypeParams, &TypeParamListFactory);
     }
 
     public ObjCInterfaceDecl ClassInterface => _classInterface.GetValue(this);
@@ -56,4 +56,16 @@ public sealed class ObjCCategoryDecl : ObjCContainerDecl
     private static unsafe ObjCCategoryImplDecl ImplementationFactory(ObjCCategoryDecl self) => self.TranslationUnit.GetOrCreate<ObjCCategoryImplDecl>(self.Handle.GetSubDecl(1));
 
     private static unsafe ObjCInterfaceDecl ClassInterfaceFactory(ObjCCategoryDecl self) => self.TranslationUnit.GetOrCreate<ObjCInterfaceDecl>(self.Handle.GetSubDecl(0));
+
+    private static unsafe ObjCProtocolDecl ProtocolsFactory(object self, int i)
+    {
+        var @this = (ObjCCategoryDecl)self;
+        return @this.TranslationUnit.GetOrCreate<ObjCProtocolDecl>(@this.Handle.GetProtocol(unchecked((uint)i)));
+    }
+
+    private static unsafe ObjCTypeParamDecl TypeParamListFactory(object self, int i)
+    {
+        var @this = (ObjCCategoryDecl)self;
+        return @this.TranslationUnit.GetOrCreate<ObjCTypeParamDecl>(@this.Handle.GetTypeParam(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/ObjCImplementationDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCImplementationDecl.cs
@@ -16,7 +16,7 @@ public sealed class ObjCImplementationDecl : ObjCImplDecl
 
     internal unsafe ObjCImplementationDecl(CXCursor handle) : base(handle, CXCursor_ObjCImplementationDecl, CX_DeclKind_ObjCImplementation)
     {
-        _initExprs = LazyList.Create<Expr>(Handle.NumExprs, (i) => TranslationUnit.GetOrCreate<Expr>(Handle.GetExpr(unchecked((uint)i))));
+        _initExprs = LazyList.Create<Expr>(this, Handle.NumExprs, &InitExprsFactory);
         _ivars = new ValueLazy<ObjCImplementationDecl, List<ObjCIvarDecl>>(&IvarsFactory);
         _superClass = new ValueLazy<ObjCImplementationDecl, ObjCInterfaceDecl>(&SuperClassFactory);
     }
@@ -32,4 +32,10 @@ public sealed class ObjCImplementationDecl : ObjCImplDecl
     private static unsafe ObjCInterfaceDecl SuperClassFactory(ObjCImplementationDecl self) => self.TranslationUnit.GetOrCreate<ObjCInterfaceDecl>(self.Handle.GetSubDecl(1));
 
     private static unsafe List<ObjCIvarDecl> IvarsFactory(ObjCImplementationDecl self) => [.. self.Decls.OfType<ObjCIvarDecl>()];
+
+    private static unsafe Expr InitExprsFactory(object self, int i)
+    {
+        var @this = (ObjCImplementationDecl)self;
+        return @this.TranslationUnit.GetOrCreate<Expr>(@this.Handle.GetExpr(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/ObjCInterfaceDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCInterfaceDecl.cs
@@ -31,11 +31,11 @@ public sealed class ObjCInterfaceDecl : ObjCContainerDecl, IRedeclarable<ObjCInt
         _implementation = new ValueLazy<ObjCInterfaceDecl, ObjCImplementationDecl>(&ImplementationFactory);
         _ivars = new ValueLazy<ObjCInterfaceDecl, List<ObjCIvarDecl>>(&IvarsFactory);
         _knownExtensions = new ValueLazy<ObjCInterfaceDecl, List<ObjCCategoryDecl>>(&KnownExtensionsFactory);
-        _protocols = LazyList.Create<ObjCProtocolDecl>(Handle.NumProtocols, (i) => TranslationUnit.GetOrCreate<ObjCProtocolDecl>(Handle.GetProtocol(unchecked((uint)i))));
+        _protocols = LazyList.Create<ObjCProtocolDecl>(this, Handle.NumProtocols, &ProtocolsFactory);
         _superClass = new ValueLazy<ObjCInterfaceDecl, ObjCInterfaceDecl>(&SuperClassFactory);
         _superClassType = new ValueLazy<ObjCInterfaceDecl, ObjCObjectType>(&SuperClassTypeFactory);
         _typeForDecl = new ValueLazy<ObjCInterfaceDecl, Type>(&TypeForDeclFactory);
-        _typeParamList = LazyList.Create<ObjCTypeParamDecl>(Handle.NumTypeParams, (i) => TranslationUnit.GetOrCreate<ObjCTypeParamDecl>(Handle.GetTypeParam(unchecked((uint)i))));
+        _typeParamList = LazyList.Create<ObjCTypeParamDecl>(this, Handle.NumTypeParams, &TypeParamListFactory);
         _visibleCategories = new ValueLazy<ObjCInterfaceDecl, List<ObjCCategoryDecl>>(&VisibleCategoriesFactory);
         _visibleExtensions = new ValueLazy<ObjCInterfaceDecl, List<ObjCCategoryDecl>>(&VisibleExtensionsFactory);
     }
@@ -103,4 +103,16 @@ public sealed class ObjCInterfaceDecl : ObjCContainerDecl, IRedeclarable<ObjCInt
 
             return categories;
         }
+
+    private static unsafe ObjCProtocolDecl ProtocolsFactory(object self, int i)
+    {
+        var @this = (ObjCInterfaceDecl)self;
+        return @this.TranslationUnit.GetOrCreate<ObjCProtocolDecl>(@this.Handle.GetProtocol(unchecked((uint)i)));
+    }
+
+    private static unsafe ObjCTypeParamDecl TypeParamListFactory(object self, int i)
+    {
+        var @this = (ObjCInterfaceDecl)self;
+        return @this.TranslationUnit.GetOrCreate<ObjCTypeParamDecl>(@this.Handle.GetTypeParam(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/ObjCMethodDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCMethodDecl.cs
@@ -26,7 +26,7 @@ public sealed class ObjCMethodDecl : NamedDecl, IDeclContext
 
         _classInterface = new ValueLazy<ObjCMethodDecl, ObjCInterfaceDecl>(&ClassInterfaceFactory);
         _cmdDecl = new ValueLazy<ObjCMethodDecl, ImplicitParamDecl>(&CmdDeclFactory);
-        _parameters = LazyList.Create<ParmVarDecl>(Handle.NumArguments, (i) => TranslationUnit.GetOrCreate<ParmVarDecl>(Handle.GetArgument(unchecked((uint)i))));
+        _parameters = LazyList.Create<ParmVarDecl>(this, Handle.NumArguments, &ParametersFactory);
         _selfDecl = new ValueLazy<ObjCMethodDecl, ImplicitParamDecl>(&SelfDeclFactory);
         _returnType = new ValueLazy<ObjCMethodDecl, Type>(&ReturnTypeFactory);
         _sendResultType = new ValueLazy<ObjCMethodDecl, Type>(&SendResultTypeFactory);
@@ -69,4 +69,10 @@ public sealed class ObjCMethodDecl : NamedDecl, IDeclContext
     private static unsafe ImplicitParamDecl CmdDeclFactory(ObjCMethodDecl self) => self.TranslationUnit.GetOrCreate<ImplicitParamDecl>(self.Handle.GetSubDecl(1));
 
     private static unsafe ObjCInterfaceDecl ClassInterfaceFactory(ObjCMethodDecl self) => self.TranslationUnit.GetOrCreate<ObjCInterfaceDecl>(self.Handle.GetSubDecl(0));
+
+    private static unsafe ParmVarDecl ParametersFactory(object self, int i)
+    {
+        var @this = (ObjCMethodDecl)self;
+        return @this.TranslationUnit.GetOrCreate<ParmVarDecl>(@this.Handle.GetArgument(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/ObjCProtocolDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/ObjCProtocolDecl.cs
@@ -15,7 +15,7 @@ public sealed class ObjCProtocolDecl : ObjCContainerDecl, IRedeclarable<ObjCProt
     internal unsafe ObjCProtocolDecl(CXCursor handle) : base(handle, CXCursor_ObjCProtocolDecl, CX_DeclKind_ObjCProtocol)
     {
         _definition = new ValueLazy<ObjCProtocolDecl, ObjCProtocolDecl>(&DefinitionFactory);
-        _protocols = LazyList.Create<ObjCProtocolDecl>(Handle.NumProtocols, (i) => TranslationUnit.GetOrCreate<ObjCProtocolDecl>(Handle.GetProtocol(unchecked((uint)i))));
+        _protocols = LazyList.Create<ObjCProtocolDecl>(this, Handle.NumProtocols, &ProtocolsFactory);
     }
 
     public new ObjCProtocolDecl CanonicalDecl => (ObjCProtocolDecl)base.CanonicalDecl;
@@ -33,4 +33,10 @@ public sealed class ObjCProtocolDecl : ObjCContainerDecl, IRedeclarable<ObjCProt
     public IReadOnlyList<ObjCProtocolDecl> ReferencedProtocols => Protocols;
 
     private static unsafe ObjCProtocolDecl DefinitionFactory(ObjCProtocolDecl self) => self.TranslationUnit.GetOrCreate<ObjCProtocolDecl>(self.Handle.Definition);
+
+    private static unsafe ObjCProtocolDecl ProtocolsFactory(object self, int i)
+    {
+        var @this = (ObjCProtocolDecl)self;
+        return @this.TranslationUnit.GetOrCreate<ObjCProtocolDecl>(@this.Handle.GetProtocol(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/RecordDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/RecordDecl.cs
@@ -34,7 +34,7 @@ public class RecordDecl : TagDecl
             throw new ArgumentOutOfRangeException(nameof(handle));
         }
 
-        _fields = LazyList.Create<FieldDecl>(Handle.NumFields, (i) => TranslationUnit.GetOrCreate<FieldDecl>(Handle.GetField(unchecked((uint)i))));
+        _fields = LazyList.Create<FieldDecl>(this, Handle.NumFields, &FieldsFactory);
         _anonymousFields = new ValueLazy<RecordDecl, List<FieldDecl>>(&AnonymousFieldsFactory);
         _anonymousRecords = new ValueLazy<RecordDecl, List<RecordDecl>>(&AnonymousRecordsFactory);
         _indirectFields = new ValueLazy<RecordDecl, List<IndirectFieldDecl>>(&IndirectFieldsFactory);
@@ -68,4 +68,10 @@ public class RecordDecl : TagDecl
     private static unsafe List<RecordDecl> AnonymousRecordsFactory(RecordDecl self) => [.. self.Decls.OfType<RecordDecl>().Where(decl => decl.IsAnonymousStructOrUnion && !decl.IsInjectedClassName)];
 
     private static unsafe List<FieldDecl> AnonymousFieldsFactory(RecordDecl self) => [.. self.Decls.OfType<FieldDecl>().Where(decl => decl.IsAnonymousField)];
+
+    private static unsafe FieldDecl FieldsFactory(object self, int i)
+    {
+        var @this = (RecordDecl)self;
+        return @this.TranslationUnit.GetOrCreate<FieldDecl>(@this.Handle.GetField(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/TagDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/TagDecl.cs
@@ -22,10 +22,7 @@ public unsafe class TagDecl : TypeDecl, IDeclContext, IRedeclarable<TagDecl>
         }
 
         _definition = new ValueLazy<TagDecl, TagDecl?>(&DefinitionFactory);
-        _templateParameterLists = LazyList.Create<LazyList<NamedDecl>>(Handle.NumTemplateParameterLists, (listIndex) => {
-            var numTemplateParameters = Handle.GetNumTemplateParameters(unchecked((uint)listIndex));
-            return LazyList.Create<NamedDecl>(numTemplateParameters, (parameterIndex) => TranslationUnit.GetOrCreate<NamedDecl>(Handle.GetTemplateParameter(unchecked((uint)listIndex), unchecked((uint)parameterIndex))));
-        });
+        _templateParameterLists = CreateTemplateParameterLists(this);
         _typedefNameForAnonDecl = new ValueLazy<TagDecl, TypedefNameDecl?>(&TypedefNameForAnonDeclFactory);
     }
 

--- a/sources/ClangSharp/Cursors/Decls/TemplateDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/TemplateDecl.cs
@@ -20,9 +20,9 @@ public class TemplateDecl : NamedDecl
             throw new ArgumentOutOfRangeException(nameof(handle));
         }
 
-        _associatedConstraints = LazyList.Create<Expr>(Handle.NumAssociatedConstraints, (i) => TranslationUnit.GetOrCreate<Expr>(Handle.GetAssociatedConstraint(unchecked((uint)i))));
+        _associatedConstraints = LazyList.Create<Expr>(this, Handle.NumAssociatedConstraints, &AssociatedConstraintsFactory);
         _templatedDecl = new ValueLazy<TemplateDecl, NamedDecl>(&TemplatedDeclFactory);
-        _templateParameters = LazyList.Create<NamedDecl>(Handle.GetNumTemplateParameters(0), (i) => TranslationUnit.GetOrCreate<NamedDecl>(Handle.GetTemplateParameter(0, unchecked((uint)i))));
+        _templateParameters = LazyList.Create<NamedDecl>(this, Handle.GetNumTemplateParameters(0), &TemplateParametersFactory);
     }
 
     public IReadOnlyList<Expr> AssociatedConstraints => _associatedConstraints;
@@ -34,4 +34,16 @@ public class TemplateDecl : NamedDecl
     public IReadOnlyList<NamedDecl> TemplateParameters => _templateParameters;
 
     private static unsafe NamedDecl TemplatedDeclFactory(TemplateDecl self) => self.TranslationUnit.GetOrCreate<NamedDecl>(self.Handle.TemplatedDecl);
+
+    private static unsafe Expr AssociatedConstraintsFactory(object self, int i)
+    {
+        var @this = (TemplateDecl)self;
+        return @this.TranslationUnit.GetOrCreate<Expr>(@this.Handle.GetAssociatedConstraint(unchecked((uint)i)));
+    }
+
+    private static unsafe NamedDecl TemplateParametersFactory(object self, int i)
+    {
+        var @this = (TemplateDecl)self;
+        return @this.TranslationUnit.GetOrCreate<NamedDecl>(@this.Handle.GetTemplateParameter(0, unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/TemplateTypeParmDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/TemplateTypeParmDecl.cs
@@ -15,7 +15,7 @@ public sealed class TemplateTypeParmDecl : TypeDecl
 
     internal unsafe TemplateTypeParmDecl(CXCursor handle) : base(handle, CXCursor_TemplateTypeParameter, CX_DeclKind_TemplateTypeParm)
     {
-        _associatedConstraints = LazyList.Create<Expr>(Handle.NumAssociatedConstraints, (i) => TranslationUnit.GetOrCreate<Expr>(Handle.GetAssociatedConstraint(unchecked((uint)i))));
+        _associatedConstraints = LazyList.Create<Expr>(this, Handle.NumAssociatedConstraints, &AssociatedConstraintsFactory);
         _defaultArgument = new ValueLazy<TemplateTypeParmDecl, Type?>(&DefaultArgumentFactory);
     }
 
@@ -41,4 +41,10 @@ public sealed class TemplateTypeParmDecl : TypeDecl
             var defaultArgType = self.Handle.DefaultArgType;
             return defaultArgType.kind == CXType_Invalid ? null : self.TranslationUnit.GetOrCreate<Type>(defaultArgType);
         }
+
+    private static unsafe Expr AssociatedConstraintsFactory(object self, int i)
+    {
+        var @this = (TemplateTypeParmDecl)self;
+        return @this.TranslationUnit.GetOrCreate<Expr>(@this.Handle.GetAssociatedConstraint(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/VarTemplatePartialSpecializationDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/VarTemplatePartialSpecializationDecl.cs
@@ -15,9 +15,9 @@ public class VarTemplatePartialSpecializationDecl : VarDecl
 
     internal unsafe VarTemplatePartialSpecializationDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_VarTemplatePartialSpecialization)
     {
-        _associatedConstraints = LazyList.Create<Expr>(Handle.NumAssociatedConstraints, (i) => TranslationUnit.GetOrCreate<Expr>(Handle.GetAssociatedConstraint(unchecked((uint)i))));
+        _associatedConstraints = LazyList.Create<Expr>(this, Handle.NumAssociatedConstraints, &AssociatedConstraintsFactory);
         _instantiatedFromMember = new ValueLazy<VarTemplatePartialSpecializationDecl, VarTemplatePartialSpecializationDecl>(&InstantiatedFromMemberFactory);
-        _templateParameters = LazyList.Create<NamedDecl>(Handle.GetNumTemplateParameters(0), (i) => TranslationUnit.GetOrCreate<NamedDecl>(Handle.GetTemplateParameter(0, unchecked((uint)i))));
+        _templateParameters = LazyList.Create<NamedDecl>(this, Handle.GetNumTemplateParameters(0), &TemplateParametersFactory);
     }
 
     public IReadOnlyList<Expr> AssociatedConstraints => _associatedConstraints;
@@ -29,4 +29,16 @@ public class VarTemplatePartialSpecializationDecl : VarDecl
     public IReadOnlyList<NamedDecl> TemplateParameters => _templateParameters;
 
     private static unsafe VarTemplatePartialSpecializationDecl InstantiatedFromMemberFactory(VarTemplatePartialSpecializationDecl self) => self.TranslationUnit.GetOrCreate<VarTemplatePartialSpecializationDecl>(self.Handle.InstantiatedFromMember);
+
+    private static unsafe Expr AssociatedConstraintsFactory(object self, int i)
+    {
+        var @this = (VarTemplatePartialSpecializationDecl)self;
+        return @this.TranslationUnit.GetOrCreate<Expr>(@this.Handle.GetAssociatedConstraint(unchecked((uint)i)));
+    }
+
+    private static unsafe NamedDecl TemplateParametersFactory(object self, int i)
+    {
+        var @this = (VarTemplatePartialSpecializationDecl)self;
+        return @this.TranslationUnit.GetOrCreate<NamedDecl>(@this.Handle.GetTemplateParameter(0, unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Decls/VarTemplateSpecializationDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/VarTemplateSpecializationDecl.cs
@@ -25,7 +25,7 @@ public class VarTemplateSpecializationDecl : VarDecl
         }
 
         _specializedTemplate = new ValueLazy<VarTemplateSpecializationDecl, VarTemplateDecl>(&SpecializedTemplateFactory);
-        _templateArgs = LazyList.Create<TemplateArgument>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgument(unchecked((uint)i))));
+        _templateArgs = LazyList.Create<TemplateArgument>(this, Handle.NumTemplateArguments, &TemplateArgsFactory);
     }
 
     public new VarTemplateSpecializationDecl MostRecentDecl => (VarTemplateSpecializationDecl)base.MostRecentDecl;
@@ -35,4 +35,10 @@ public class VarTemplateSpecializationDecl : VarDecl
     public IReadOnlyList<TemplateArgument> TemplateArgs => _templateArgs;
 
     private static unsafe VarTemplateDecl SpecializedTemplateFactory(VarTemplateSpecializationDecl self) => self.TranslationUnit.GetOrCreate<VarTemplateDecl>(self.Handle.SpecializedCursorTemplate);
+
+    private static unsafe TemplateArgument TemplateArgsFactory(object self, int i)
+    {
+        var @this = (VarTemplateSpecializationDecl)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgument(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Exprs/CXXDependentScopeMemberExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXDependentScopeMemberExpr.cs
@@ -21,7 +21,7 @@ public sealed class CXXDependentScopeMemberExpr : Expr
 
         _baseType = new ValueLazy<CXXDependentScopeMemberExpr, Type>(&BaseTypeFactory);
         _firstQualifierFoundInScope = new ValueLazy<CXXDependentScopeMemberExpr, NamedDecl>(&FirstQualifierFoundInScopeFactory);
-        _templateArgs = LazyList.Create<TemplateArgumentLoc>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgumentLoc(unchecked((uint)i))));
+        _templateArgs = LazyList.Create<TemplateArgumentLoc>(this, Handle.NumTemplateArguments, &TemplateArgsFactory);
     }
 
     public Expr? Base => (Expr?)Children.SingleOrDefault();
@@ -47,4 +47,10 @@ public sealed class CXXDependentScopeMemberExpr : Expr
     private static unsafe NamedDecl FirstQualifierFoundInScopeFactory(CXXDependentScopeMemberExpr self) => self.TranslationUnit.GetOrCreate<NamedDecl>(self.Handle.Referenced);
 
     private static unsafe Type BaseTypeFactory(CXXDependentScopeMemberExpr self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.TypeOperand);
+
+    private static unsafe TemplateArgumentLoc TemplateArgsFactory(object self, int i)
+    {
+        var @this = (CXXDependentScopeMemberExpr)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgumentLoc(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Exprs/CXXParenListInitExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXParenListInitExpr.cs
@@ -16,8 +16,8 @@ public sealed class CXXParenListInitExpr : Expr
     internal unsafe CXXParenListInitExpr(CXCursor handle) : base(handle, CXCursor_CXXParenListInitExpr, CX_StmtClass_CXXParenListInitExpr)
     {
         _arrayFillerOrUnionFieldInit = new ValueLazy<CXXParenListInitExpr, Cursor>(&ArrayFillerOrUnionFieldInitFactory);
-        _initExprs = LazyList.Create<Expr>(Handle.NumExprs, (i) => TranslationUnit.GetOrCreate<Expr>(Handle.GetExpr(unchecked((uint)i))));
-        _userSpecifiedInitExprs = LazyList.Create<Expr>(Handle.NumExprsOther, (i) => TranslationUnit.GetOrCreate<Expr>(Handle.GetExpr(unchecked((uint)i))));
+        _initExprs = LazyList.Create<Expr>(this, Handle.NumExprs, &InitExprsFactory);
+        _userSpecifiedInitExprs = LazyList.Create<Expr>(this, Handle.NumExprsOther, &UserSpecifiedInitExprsFactory);
     }
 
     public Expr? ArrayFiller => _arrayFillerOrUnionFieldInit.GetValue(this) as Expr;
@@ -29,4 +29,16 @@ public sealed class CXXParenListInitExpr : Expr
     public IReadOnlyList<Expr> UserSpecifiedInitExprs => _userSpecifiedInitExprs;
 
     private static unsafe Cursor ArrayFillerOrUnionFieldInitFactory(CXXParenListInitExpr self) => self.TranslationUnit.GetOrCreate<Cursor>(self.Handle.SubExpr);
+
+    private static unsafe Expr InitExprsFactory(object self, int i)
+    {
+        var @this = (CXXParenListInitExpr)self;
+        return @this.TranslationUnit.GetOrCreate<Expr>(@this.Handle.GetExpr(unchecked((uint)i)));
+    }
+
+    private static unsafe Expr UserSpecifiedInitExprsFactory(object self, int i)
+    {
+        var @this = (CXXParenListInitExpr)self;
+        return @this.TranslationUnit.GetOrCreate<Expr>(@this.Handle.GetExpr(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Exprs/CastExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CastExpr.cs
@@ -23,7 +23,7 @@ public class CastExpr : Expr
 
         Debug.Assert(NumChildren is 1);
 
-        _path = LazyList.Create<CXXBaseSpecifier>(Handle.NumArguments, (i) => TranslationUnit.GetOrCreate<CXXBaseSpecifier>(Handle.GetArgument(unchecked((uint)i))));
+        _path = LazyList.Create<CXXBaseSpecifier>(this, Handle.NumArguments, &PathFactory);
         _targetUnionField = new ValueLazy<CastExpr, FieldDecl>(&TargetUnionFieldFactory);
     }
 
@@ -106,4 +106,10 @@ public class CastExpr : Expr
     public FieldDecl TargetUnionField => _targetUnionField.GetValue(this);
 
     private static unsafe FieldDecl TargetUnionFieldFactory(CastExpr self) => self.TranslationUnit.GetOrCreate<FieldDecl>(self.Handle.TargetUnionField);
+
+    private static unsafe CXXBaseSpecifier PathFactory(object self, int i)
+    {
+        var @this = (CastExpr)self;
+        return @this.TranslationUnit.GetOrCreate<CXXBaseSpecifier>(@this.Handle.GetArgument(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Exprs/DeclRefExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/DeclRefExpr.cs
@@ -26,7 +26,7 @@ public sealed class DeclRefExpr : Expr
 
         _decl = new ValueLazy<DeclRefExpr, ValueDecl>(&DeclFactory);
         _foundDecl = new ValueLazy<DeclRefExpr, NamedDecl>(&FoundDeclFactory);
-        _templateArgs = LazyList.Create<TemplateArgumentLoc>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgumentLoc(unchecked((uint)i))));
+        _templateArgs = LazyList.Create<TemplateArgumentLoc>(this, Handle.NumTemplateArguments, &TemplateArgsFactory);
     }
 
     public ValueDecl Decl => _decl.GetValue(this);
@@ -48,4 +48,10 @@ public sealed class DeclRefExpr : Expr
     private static unsafe NamedDecl FoundDeclFactory(DeclRefExpr self) => self.TranslationUnit.GetOrCreate<NamedDecl>(self.Handle.FoundDecl);
 
     private static unsafe ValueDecl DeclFactory(DeclRefExpr self) => self.TranslationUnit.GetOrCreate<ValueDecl>(self.Handle.Referenced);
+
+    private static unsafe TemplateArgumentLoc TemplateArgsFactory(object self, int i)
+    {
+        var @this = (DeclRefExpr)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgumentLoc(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Exprs/DependentScopeDeclRefExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/DependentScopeDeclRefExpr.cs
@@ -12,10 +12,10 @@ public sealed class DependentScopeDeclRefExpr : Expr
 {
     private readonly LazyList<TemplateArgumentLoc> _templateArgs;
 
-    internal DependentScopeDeclRefExpr(CXCursor handle) : base(handle, CXCursor_DeclRefExpr, CX_StmtClass_DependentScopeDeclRefExpr)
+    internal unsafe DependentScopeDeclRefExpr(CXCursor handle) : base(handle, CXCursor_DeclRefExpr, CX_StmtClass_DependentScopeDeclRefExpr)
     {
         Debug.Assert(NumChildren is 0);
-        _templateArgs = LazyList.Create<TemplateArgumentLoc>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgumentLoc(unchecked((uint)i))));
+        _templateArgs = LazyList.Create<TemplateArgumentLoc>(this, Handle.NumTemplateArguments, &TemplateArgsFactory);
     }
 
     public string DeclName => Handle.Name.CString;
@@ -25,4 +25,10 @@ public sealed class DependentScopeDeclRefExpr : Expr
     public bool HasTemplateKeyword => Handle.HasTemplateKeyword;
 
     public IReadOnlyList<TemplateArgumentLoc> TemplateArgs => _templateArgs;
+
+    private static unsafe TemplateArgumentLoc TemplateArgsFactory(object self, int i)
+    {
+        var @this = (DependentScopeDeclRefExpr)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgumentLoc(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Exprs/ExprWithCleanups.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ExprWithCleanups.cs
@@ -11,12 +11,18 @@ public sealed class ExprWithCleanups : FullExpr
 {
     private readonly LazyList<Cursor> _objects;
 
-    internal ExprWithCleanups(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_ExprWithCleanups)
+    internal unsafe ExprWithCleanups(CXCursor handle) : base(handle, CXCursor_UnexposedExpr, CX_StmtClass_ExprWithCleanups)
     {
-        _objects = LazyList.Create<Cursor>(Handle.NumArguments, (i) => TranslationUnit.GetOrCreate<Cursor>(Handle.GetArgument(unchecked((uint)i))));
+        _objects = LazyList.Create<Cursor>(this, Handle.NumArguments, &ObjectsFactory);
     }
 
     public uint NumObjects => unchecked((uint)Handle.NumArguments);
 
     public IReadOnlyList<Cursor> Objects => _objects;
+
+    private static unsafe Cursor ObjectsFactory(object self, int i)
+    {
+        var @this = (ExprWithCleanups)self;
+        return @this.TranslationUnit.GetOrCreate<Cursor>(@this.Handle.GetArgument(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Exprs/FunctionParmPackExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/FunctionParmPackExpr.cs
@@ -17,7 +17,7 @@ public sealed class FunctionParmPackExpr : Expr
     {
         Debug.Assert(NumChildren is 0);
 
-        _expansions = LazyList.Create<VarDecl>(Handle.NumDecls, (i) => TranslationUnit.GetOrCreate<VarDecl>(Handle.GetDecl(unchecked((uint)i))));
+        _expansions = LazyList.Create<VarDecl>(this, Handle.NumDecls, &ExpansionsFactory);
         _parameterPack = new ValueLazy<FunctionParmPackExpr, VarDecl>(&ParameterPackFactory);
     }
 
@@ -28,4 +28,10 @@ public sealed class FunctionParmPackExpr : Expr
     public VarDecl ParameterPack => _parameterPack.GetValue(this);
 
     private static unsafe VarDecl ParameterPackFactory(FunctionParmPackExpr self) => self.TranslationUnit.GetOrCreate<VarDecl>(self.Handle.Referenced);
+
+    private static unsafe VarDecl ExpansionsFactory(object self, int i)
+    {
+        var @this = (FunctionParmPackExpr)self;
+        return @this.TranslationUnit.GetOrCreate<VarDecl>(@this.Handle.GetDecl(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Exprs/MemberExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/MemberExpr.cs
@@ -18,7 +18,7 @@ public sealed class MemberExpr : Expr
         Debug.Assert(NumChildren is 1);
 
         _memberDecl = new ValueLazy<MemberExpr, ValueDecl>(&MemberDeclFactory);
-        _templateArgs = LazyList.Create<TemplateArgumentLoc>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgumentLoc(unchecked((uint)i))));
+        _templateArgs = LazyList.Create<TemplateArgumentLoc>(this, Handle.NumTemplateArguments, &TemplateArgsFactory);
     }
 
     public Expr Base => (Expr)Children[0];
@@ -42,4 +42,10 @@ public sealed class MemberExpr : Expr
     public IReadOnlyList<TemplateArgumentLoc> TemplateArgs => _templateArgs;
 
     private static unsafe ValueDecl MemberDeclFactory(MemberExpr self) => self.TranslationUnit.GetOrCreate<ValueDecl>(self.Handle.Referenced);
+
+    private static unsafe TemplateArgumentLoc TemplateArgsFactory(object self, int i)
+    {
+        var @this = (MemberExpr)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgumentLoc(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Exprs/ObjCMessageExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/ObjCMessageExpr.cs
@@ -18,7 +18,7 @@ public sealed class ObjCMessageExpr : Expr
 
     internal unsafe ObjCMessageExpr(CXCursor handle) : base(handle, CXCursor_ObjCMessageExpr, CX_StmtClass_ObjCMessageExpr)
     {
-        _args = LazyList.Create<Expr>(Handle.NumArguments, (i) => TranslationUnit.GetOrCreate<Expr>(Handle.GetArgument(unchecked((uint)i))));
+        _args = LazyList.Create<Expr>(this, Handle.NumArguments, &ArgsFactory);
         _classReceiver = new ValueLazy<ObjCMessageExpr, Type>(&ClassReceiverFactory);
         _instanceReceiver = new ValueLazy<ObjCMessageExpr, Expr>(&InstanceReceiverFactory);
         _methodDecl = new ValueLazy<ObjCMessageExpr, ObjCMethodDecl>(&MethodDeclFactory);
@@ -51,4 +51,10 @@ public sealed class ObjCMessageExpr : Expr
     private static unsafe Expr InstanceReceiverFactory(ObjCMessageExpr self) => self.TranslationUnit.GetOrCreate<Expr>(self.Handle.GetExpr(0));
 
     private static unsafe Type ClassReceiverFactory(ObjCMessageExpr self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.TypeOperand);
+
+    private static unsafe Expr ArgsFactory(object self, int i)
+    {
+        var @this = (ObjCMessageExpr)self;
+        return @this.TranslationUnit.GetOrCreate<Expr>(@this.Handle.GetArgument(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Exprs/OverloadExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/OverloadExpr.cs
@@ -20,9 +20,9 @@ public class OverloadExpr : Expr
             throw new ArgumentOutOfRangeException(nameof(handle));
         }
 
-        _decls = LazyList.Create<Decl>(Handle.NumDecls, (i) => TranslationUnit.GetOrCreate<Decl>(Handle.GetDecl(unchecked((uint)i))));
+        _decls = LazyList.Create<Decl>(this, Handle.NumDecls, &DeclsFactory);
         _namingClass = new ValueLazy<OverloadExpr, CXXRecordDecl>(&NamingClassFactory);
-        _templateArgs = LazyList.Create<TemplateArgumentLoc>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgumentLoc(unchecked((uint)i))));
+        _templateArgs = LazyList.Create<TemplateArgumentLoc>(this, Handle.NumTemplateArguments, &TemplateArgsFactory);
     }
 
     public IReadOnlyList<Decl> Decls => _decls;
@@ -42,4 +42,16 @@ public class OverloadExpr : Expr
     public IReadOnlyList<TemplateArgumentLoc> TemplateArgs => _templateArgs;
 
     private static unsafe CXXRecordDecl NamingClassFactory(OverloadExpr self) => self.TranslationUnit.GetOrCreate<CXXRecordDecl>(self.Handle.Referenced);
+
+    private static unsafe Decl DeclsFactory(object self, int i)
+    {
+        var @this = (OverloadExpr)self;
+        return @this.TranslationUnit.GetOrCreate<Decl>(@this.Handle.GetDecl(unchecked((uint)i)));
+    }
+
+    private static unsafe TemplateArgumentLoc TemplateArgsFactory(object self, int i)
+    {
+        var @this = (OverloadExpr)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgumentLoc(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Exprs/SizeOfPackExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/SizeOfPackExpr.cs
@@ -15,7 +15,7 @@ public sealed class SizeOfPackExpr : Expr
     internal unsafe SizeOfPackExpr(CXCursor handle) : base(handle, CXCursor_SizeOfPackExpr, CX_StmtClass_SizeOfPackExpr)
     {
         _pack = new ValueLazy<SizeOfPackExpr, NamedDecl>(&PackFactory);
-        _partialArguments = LazyList.Create<TemplateArgument>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgument(unchecked((uint)i))));
+        _partialArguments = LazyList.Create<TemplateArgument>(this, Handle.NumTemplateArguments, &PartialArgumentsFactory);
     }
 
     public NamedDecl Pack => _pack.GetValue(this);
@@ -27,4 +27,10 @@ public sealed class SizeOfPackExpr : Expr
     public IReadOnlyList<TemplateArgument> PartialArguments => _partialArguments;
 
     private static unsafe NamedDecl PackFactory(SizeOfPackExpr self) => self.TranslationUnit.GetOrCreate<NamedDecl>(self.Handle.Referenced);
+
+    private static unsafe TemplateArgument PartialArgumentsFactory(object self, int i)
+    {
+        var @this = (SizeOfPackExpr)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgument(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Stmts/AttributedStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/AttributedStmt.cs
@@ -12,14 +12,20 @@ public sealed class AttributedStmt : ValueStmt
 {
     private readonly LazyList<Attr> _attrs;
 
-    internal AttributedStmt(CXCursor handle) : base(handle, CXCursor_UnexposedStmt, CX_StmtClass_AttributedStmt)
+    internal unsafe AttributedStmt(CXCursor handle) : base(handle, CXCursor_UnexposedStmt, CX_StmtClass_AttributedStmt)
     {
         Debug.Assert(NumChildren == 1);
 
-        _attrs = LazyList.Create<Attr>(Handle.NumAttrs, (i) => TranslationUnit.GetOrCreate<Attr>(Handle.GetAttr(unchecked((uint)i))));
+        _attrs = LazyList.Create<Attr>(this, Handle.NumAttrs, &AttrsFactory);
     }
 
     public IReadOnlyList<Attr> Attrs => _attrs;
 
     public Stmt SubStmt => Children[0];
+
+    private static unsafe Attr AttrsFactory(object self, int i)
+    {
+        var @this = (AttributedStmt)self;
+        return @this.TranslationUnit.GetOrCreate<Attr>(@this.Handle.GetAttr(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Stmts/CapturedStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/CapturedStmt.cs
@@ -20,7 +20,7 @@ public sealed partial class CapturedStmt : Stmt
         _capturedDecl = new ValueLazy<CapturedStmt, CapturedDecl>(&CapturedDeclFactory);
         _capturedRecordDecl = new ValueLazy<CapturedStmt, RecordDecl>(&CapturedRecordDeclFactory);
         _captureStmt = new ValueLazy<CapturedStmt, Stmt>(&CaptureStmtFactory);
-        _captures = LazyList.Create<Capture>(Handle.NumCaptures, (i) => new Capture(this, unchecked((uint)i)));
+        _captures = LazyList.Create<Capture>(this, Handle.NumCaptures, &CapturesFactory);
         _captureInits = LazyList.Create<Expr, Stmt>(_children);
     }
 
@@ -62,4 +62,10 @@ public sealed partial class CapturedStmt : Stmt
     private static unsafe RecordDecl CapturedRecordDeclFactory(CapturedStmt self) => self.TranslationUnit.GetOrCreate<RecordDecl>(self.Handle.CapturedRecordDecl);
 
     private static unsafe CapturedDecl CapturedDeclFactory(CapturedStmt self) => self.TranslationUnit.GetOrCreate<CapturedDecl>(self.Handle.CapturedDecl);
+
+    private static unsafe Capture CapturesFactory(object self, int i)
+    {
+        var @this = (CapturedStmt)self;
+        return new Capture(@this, unchecked((uint)i));
+    }
 }

--- a/sources/ClangSharp/Cursors/Stmts/DeclStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/DeclStmt.cs
@@ -12,9 +12,9 @@ public sealed class DeclStmt : Stmt
 {
     private readonly LazyList<Decl> _decls;
 
-    internal DeclStmt(CXCursor handle) : base(handle, CXCursor_DeclStmt, CX_StmtClass_DeclStmt)
+    internal unsafe DeclStmt(CXCursor handle) : base(handle, CXCursor_DeclStmt, CX_StmtClass_DeclStmt)
     {
-        _decls = LazyList.Create<Decl>(Handle.NumDecls, (i) => TranslationUnit.GetOrCreate<Decl>(Handle.GetDecl(unchecked((uint)i))));
+        _decls = LazyList.Create<Decl>(this, Handle.NumDecls, &DeclsFactory);
     }
 
     public IReadOnlyList<Decl> Decls => _decls;
@@ -22,4 +22,10 @@ public sealed class DeclStmt : Stmt
     public bool IsSingleDecl => Decls.Count == 1;
 
     public Decl? SingleDecl => Decls.SingleOrDefault();
+
+    private static unsafe Decl DeclsFactory(object self, int i)
+    {
+        var @this = (DeclStmt)self;
+        return @this.TranslationUnit.GetOrCreate<Decl>(@this.Handle.GetDecl(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Cursors/Stmts/Stmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/Stmt.cs
@@ -20,10 +20,7 @@ public class Stmt : Cursor
             throw new ArgumentOutOfRangeException(nameof(handle));
         }
 
-        _children = LazyList.Create<Stmt>(Handle.NumChildren, (i) => {
-            var childHandle = Handle.GetChild(unchecked((uint)i));
-            return !childHandle.IsNull ? TranslationUnit.GetOrCreate<Stmt>(childHandle) : null!;
-        });
+        _children = LazyList.Create<Stmt>(this, Handle.NumChildren, &ChildrenFactory);
         _declContext = new ValueLazy<Stmt, IDeclContext>(&DeclContextFactory);
     }
 
@@ -374,4 +371,11 @@ public class Stmt : Cursor
             Debug.Assert(semanticParent is not null);
             return (IDeclContext)semanticParent!;
         }
+
+    private static unsafe Stmt ChildrenFactory(object self, int i)
+    {
+        var @this = (Stmt)self;
+        var childHandle = @this.Handle.GetChild(unchecked((uint)i));
+        return !childHandle.IsNull ? @this.TranslationUnit.GetOrCreate<Stmt>(childHandle) : null!;
+    }
 }

--- a/sources/ClangSharp/LazyList.cs
+++ b/sources/ClangSharp/LazyList.cs
@@ -1,30 +1,29 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace ClangSharp;
 
 internal static class LazyList
 {
-    public static LazyList<T> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(int count, Func<int, T> valueFactory)
+    public static unsafe LazyList<T> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(object self, int count, delegate*<object, int, T> valueFactory)
         where T : class
     {
         if (count <= 0)
         {
             return LazyList<T>.Empty;
         }
-        return new LazyList<T>(count, valueFactory);
+        return new LazyList<T>(self, count, valueFactory);
     }
 
-    public static LazyList<T> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(int count, Func<int, T?, T> valueFactory)
+    public static unsafe LazyList<T> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(object self, int count, delegate*<object, int, T?, T> valueFactory)
         where T : class
     {
         if (count <= 0)
         {
             return LazyList<T>.Empty;
         }
-        return new LazyList<T>(count, valueFactory);
+        return new LazyList<T>(self, count, valueFactory);
     }
 
     public static LazyList<T, TBase> Create<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TBase>(LazyList<TBase> list, int skip = -1, int take = -1)

--- a/sources/ClangSharp/LazyList`1.cs
+++ b/sources/ClangSharp/LazyList`1.cs
@@ -7,28 +7,33 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ClangSharp;
 
-internal sealed class LazyList<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> : IList<T>, IReadOnlyList<T>
+internal sealed unsafe class LazyList<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> : IList<T>, IReadOnlyList<T>
     where T : class
 {
     internal readonly T[] _items;
-    internal readonly Func<int, T>? _valueFactory;
-    internal readonly Func<int, T?, T>? _valueFactoryWithPreviousValue;
+    internal readonly object? _self;
+    internal readonly delegate*<object, int, T> _valueFactory;
+    internal readonly delegate*<object, int, T?, T> _valueFactoryWithPreviousValue;
 
-    public static readonly LazyList<T> Empty = new LazyList<T>(0, _ => null!);
+    public static readonly LazyList<T> Empty = new LazyList<T>(null!, 0, &EmptyFactory);
 
-    public LazyList(int count, Func<int, T> valueFactory)
+    public LazyList(object self, int count, delegate*<object, int, T> valueFactory)
     {
         _items = (count <= 0) ? [] : new T[count];
+        _self = self;
         _valueFactory = valueFactory;
         _valueFactoryWithPreviousValue = null;
     }
 
-    public LazyList(int count, Func<int, T?, T> valueFactoryWithPreviousValue)
+    public LazyList(object self, int count, delegate*<object, int, T?, T> valueFactoryWithPreviousValue)
     {
         _items = (count <= 0) ? [] : new T[count];
+        _self = self;
         _valueFactory = null;
         _valueFactoryWithPreviousValue = valueFactoryWithPreviousValue;
     }
+
+    private static T EmptyFactory(object self, int index) => null!;
 
     public T this[int index]
     {
@@ -39,13 +44,13 @@ internal sealed class LazyList<[DynamicallyAccessedMembers(DynamicallyAccessedMe
 
             if (item is null)
             {
-                if (_valueFactoryWithPreviousValue is not null)
+                if (_valueFactoryWithPreviousValue != null)
                 {
-                    item = _valueFactoryWithPreviousValue(index, index == 0 ? null : _items[index - 1]);
+                    item = _valueFactoryWithPreviousValue(_self!, index, index == 0 ? null : _items[index - 1]);
                 }
                 else
                 {
-                    item = _valueFactory!.Invoke(index);
+                    item = _valueFactory(_self!, index);
                 }
                 items[index] = item;
             }

--- a/sources/ClangSharp/LazyList`2.cs
+++ b/sources/ClangSharp/LazyList`2.cs
@@ -7,13 +7,14 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ClangSharp;
 
-internal sealed class LazyList<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TBase> : IList<T>, IReadOnlyList<T>
+internal sealed unsafe class LazyList<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TBase> : IList<T>, IReadOnlyList<T>
     where T : class, TBase
     where TBase : class
 {
     internal readonly TBase[] _items;
-    internal readonly Func<int, TBase>? _valueFactory;
-    internal readonly Func<int, TBase?, TBase>? _valueFactoryWithPreviousValue;
+    internal readonly object? _self;
+    internal readonly delegate*<object, int, TBase> _valueFactory;
+    internal readonly delegate*<object, int, TBase?, TBase> _valueFactoryWithPreviousValue;
 
     private readonly int _start;
     private readonly int _count;
@@ -24,6 +25,7 @@ internal sealed class LazyList<T, [DynamicallyAccessedMembers(DynamicallyAccesse
         take = (take < 0) ? (list.Count - skip) : take;
 
         _items = list._items;
+        _self = list._self;
         _valueFactory = list._valueFactory;
         _valueFactoryWithPreviousValue = list._valueFactoryWithPreviousValue;
 
@@ -41,13 +43,13 @@ internal sealed class LazyList<T, [DynamicallyAccessedMembers(DynamicallyAccesse
             if (item is null)
             {
                 var idx = index + _start;
-                if (_valueFactoryWithPreviousValue is not null)
+                if (_valueFactoryWithPreviousValue != null)
                 {
-                    item = _valueFactoryWithPreviousValue(idx, idx == 0 ? null : _items[idx - 1]);
+                    item = _valueFactoryWithPreviousValue(_self!, idx, idx == 0 ? null : _items[idx - 1]);
                 }
                 else
                 {
-                    item = _valueFactory!.Invoke(idx);
+                    item = _valueFactory(_self!, idx);
                 }
                 items[index] = item;
             }

--- a/sources/ClangSharp/TemplateArgument.cs
+++ b/sources/ClangSharp/TemplateArgument.cs
@@ -39,7 +39,7 @@ public sealed unsafe class TemplateArgument : IDisposable
         _nonTypeTemplateArgumentType = new ValueLazy<TemplateArgument, Type>(&NonTypeTemplateArgumentTypeFactory);
         _nullPtrType = new ValueLazy<TemplateArgument, Type>(&NullPtrTypeFactory);
         _packExpansionPattern = new ValueLazy<TemplateArgument, TemplateArgument>(&PackExpansionPatternFactory);
-        _packElements = LazyList.Create<TemplateArgument>(Handle.NumPackElements, (i) => TranslationUnit.GetOrCreate(Handle.GetPackElement(unchecked((uint)i))));
+        _packElements = LazyList.Create<TemplateArgument>(this, Handle.NumPackElements, &PackElementsFactory);
         _paramTypeForDecl = new ValueLazy<TemplateArgument, Type>(&ParamTypeForDeclFactory);
     }
 
@@ -151,4 +151,10 @@ public sealed unsafe class TemplateArgument : IDisposable
     private static unsafe ValueDecl AsDeclFactory(TemplateArgument self) => self.TranslationUnit.GetOrCreate<ValueDecl>(self.Handle.AsDecl);
 
     private static unsafe TranslationUnit TranslationUnitFactory(TemplateArgument self) => TranslationUnit.GetOrCreate(self.Handle.tu);
+
+    private static unsafe TemplateArgument PackElementsFactory(object self, int i)
+    {
+        var @this = (TemplateArgument)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetPackElement(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Types/AutoType.cs
+++ b/sources/ClangSharp/Types/AutoType.cs
@@ -11,10 +11,16 @@ public sealed class AutoType : DeducedType
 {
     private readonly LazyList<TemplateArgument> _templateArgs;
 
-    internal AutoType(CXType handle) : base(handle, CXType_Auto, CX_TypeClass_Auto)
+    internal unsafe AutoType(CXType handle) : base(handle, CXType_Auto, CX_TypeClass_Auto)
     {
-        _templateArgs = LazyList.Create<TemplateArgument>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgument(unchecked((uint)i))));
+        _templateArgs = LazyList.Create<TemplateArgument>(this, Handle.NumTemplateArguments, &TemplateArgsFactory);
     }
 
     public IReadOnlyList<TemplateArgument> Args => _templateArgs;
+
+    private static unsafe TemplateArgument TemplateArgsFactory(object self, int i)
+    {
+        var @this = (AutoType)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgument(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Types/DependentTemplateSpecializationType.cs
+++ b/sources/ClangSharp/Types/DependentTemplateSpecializationType.cs
@@ -11,10 +11,16 @@ public sealed class DependentTemplateSpecializationType : TypeWithKeyword
 {
     private readonly LazyList<TemplateArgument> _templateArgs;
 
-    internal DependentTemplateSpecializationType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_DependentTemplateSpecialization)
+    internal unsafe DependentTemplateSpecializationType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_DependentTemplateSpecialization)
     {
-        _templateArgs = LazyList.Create<TemplateArgument>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgument(unchecked((uint)i))));
+        _templateArgs = LazyList.Create<TemplateArgument>(this, Handle.NumTemplateArguments, &TemplateArgsFactory);
     }
 
     public IReadOnlyList<TemplateArgument> Args => _templateArgs;
+
+    private static unsafe TemplateArgument TemplateArgsFactory(object self, int i)
+    {
+        var @this = (DependentTemplateSpecializationType)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgument(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Types/FunctionProtoType.cs
+++ b/sources/ClangSharp/Types/FunctionProtoType.cs
@@ -11,9 +11,9 @@ public sealed class FunctionProtoType : FunctionType
 {
     private readonly LazyList<Type> _paramTypes;
 
-    internal FunctionProtoType(CXType handle) : base(handle, CXType_FunctionProto, CX_TypeClass_FunctionProto)
+    internal unsafe FunctionProtoType(CXType handle) : base(handle, CXType_FunctionProto, CX_TypeClass_FunctionProto)
     {
-        _paramTypes = LazyList.Create<Type>(Handle.NumArgTypes, (i) => TranslationUnit.GetOrCreate<Type>(Handle.GetArgType(unchecked((uint)i))));
+        _paramTypes = LazyList.Create<Type>(this, Handle.NumArgTypes, &ParamTypesFactory);
     }
 
     public CXCursor_ExceptionSpecificationKind ExceptionSpecType => Handle.ExceptionSpecificationType;
@@ -25,4 +25,10 @@ public sealed class FunctionProtoType : FunctionType
     public IReadOnlyList<Type> ParamTypes => _paramTypes;
 
     public CXRefQualifierKind RefQualifier => Handle.CXXRefQualifier;
+
+    private static unsafe Type ParamTypesFactory(object self, int i)
+    {
+        var @this = (FunctionProtoType)self;
+        return @this.TranslationUnit.GetOrCreate<Type>(@this.Handle.GetArgType(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Types/ObjCObjectType.cs
+++ b/sources/ClangSharp/Types/ObjCObjectType.cs
@@ -23,9 +23,9 @@ public class ObjCObjectType : Type
     {
         _baseType = new ValueLazy<ObjCObjectType, Type>(&BaseTypeFactory);
         _interface = new ValueLazy<ObjCObjectType, ObjCInterfaceDecl>(&InterfaceFactory);
-        _protocols = LazyList.Create<ObjCProtocolDecl>(unchecked((int)Handle.NumObjCProtocolRefs), (i) => TranslationUnit.GetOrCreate<ObjCProtocolDecl>(Handle.GetObjCProtocolDecl(unchecked((uint)i))));
+        _protocols = LazyList.Create<ObjCProtocolDecl>(this, unchecked((int)Handle.NumObjCProtocolRefs), &ProtocolsFactory);
         _superClassType = new ValueLazy<ObjCObjectType, Type>(&SuperClassTypeFactory);
-        _typeArgs = LazyList.Create<Type>(unchecked((int)Handle.NumObjCTypeArgs), (i) => TranslationUnit.GetOrCreate<Type>(Handle.GetObjCTypeArg(unchecked((uint)i))));
+        _typeArgs = LazyList.Create<Type>(this, unchecked((int)Handle.NumObjCTypeArgs), &TypeArgsFactory);
     }
 
     public Type BaseType => _baseType.GetValue(this);
@@ -43,4 +43,16 @@ public class ObjCObjectType : Type
     private static unsafe ObjCInterfaceDecl InterfaceFactory(ObjCObjectType self) => self.TranslationUnit.GetOrCreate<ObjCInterfaceDecl>(self.Handle.Declaration);
 
     private static unsafe Type BaseTypeFactory(ObjCObjectType self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.ObjCObjectBaseType);
+
+    private static unsafe ObjCProtocolDecl ProtocolsFactory(object self, int i)
+    {
+        var @this = (ObjCObjectType)self;
+        return @this.TranslationUnit.GetOrCreate<ObjCProtocolDecl>(@this.Handle.GetObjCProtocolDecl(unchecked((uint)i)));
+    }
+
+    private static unsafe Type TypeArgsFactory(object self, int i)
+    {
+        var @this = (ObjCObjectType)self;
+        return @this.TranslationUnit.GetOrCreate<Type>(@this.Handle.GetObjCTypeArg(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Types/TemplateSpecializationType.cs
+++ b/sources/ClangSharp/Types/TemplateSpecializationType.cs
@@ -15,7 +15,7 @@ public sealed class TemplateSpecializationType : Type
 
     internal unsafe TemplateSpecializationType(CXType handle) : base(handle, CXType_Unexposed, CX_TypeClass_TemplateSpecialization)
     {
-        _templateArgs = LazyList.Create<TemplateArgument>(Handle.NumTemplateArguments, (i) => TranslationUnit.GetOrCreate(Handle.GetTemplateArgument(unchecked((uint)i))));
+        _templateArgs = LazyList.Create<TemplateArgument>(this, Handle.NumTemplateArguments, &TemplateArgsFactory);
         _templateName = new ValueLazy<TemplateSpecializationType, TemplateName>(&TemplateNameFactory);
     }
 
@@ -29,4 +29,10 @@ public sealed class TemplateSpecializationType : Type
     public TemplateName TemplateName => _templateName.GetValue(this);
 
     private static unsafe TemplateName TemplateNameFactory(TemplateSpecializationType self) => self.TranslationUnit.GetOrCreate(self.Handle.TemplateName);
+
+    private static unsafe TemplateArgument TemplateArgsFactory(object self, int i)
+    {
+        var @this = (TemplateSpecializationType)self;
+        return @this.TranslationUnit.GetOrCreate(@this.Handle.GetTemplateArgument(unchecked((uint)i)));
+    }
 }


### PR DESCRIPTION
`LazyList<T>` stored a `Func<int, T>` (or `Func<int, T?, T>`) factory per instance, which allocated a closure delegate for every cursor that exposed a lazy child list -- even when the list was empty (the common case for `Decl._attrs`). Mirroring the `ValueLazy<TSelf, T>` conversion in #707, the factory is now a `delegate*<object, int, T>` function pointer plus a stored `object _self`, so the per-instance closure allocation is gone.

All owners (`Cursor`, `Type`, `TemplateArgument`) are reference types, so passing `this` as `object self` never boxes. Each former lambda becomes a `static` factory method that casts `self` back to the owning type. The four nested `_templateParameterLists` sites are deduplicated into a shared `Decl.CreateTemplateParameterLists` helper.

----------

Measured on the TerraFX `d3d12` generation workload (`gc-verbose`, `DOTNET_TieredCompilation=0`): `Func<int, Decl, Decl>` (~2.0 MB) and `Func<int, Attr>` (~1.9 MB) are eliminated entirely, dropping sampled allocations from ~142.6 MB to ~134.2 MB. No behavioral change; all 3708 golden tests pass, output is byte-identical.

> [!NOTE]
> This PR description was drafted by Copilot.
