### PR TITLE
Promote anonymous-name prefixes to consts with helper predicates

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -456,7 +456,7 @@ public sealed partial class PInvokeGenerator
         {
             remappedName = "Dispose";
         }
-        else if ((namedDecl is FieldDecl fieldDecl) && name.StartsWith("__AnonymousFieldDecl_", StringComparison.Ordinal))
+        else if ((namedDecl is FieldDecl fieldDecl) && name.StartsWith(AnonymousFieldDeclPrefix, StringComparison.Ordinal))
         {
             if (fieldDecl.Type.AsCXXRecordDecl?.IsAnonymousStructOrUnion == true)
             {
@@ -482,7 +482,7 @@ public sealed partial class PInvokeGenerator
                 }
             }
         }
-        else if ((namedDecl is RecordDecl recordDecl) && name.StartsWith("__AnonymousRecord_", StringComparison.Ordinal))
+        else if ((namedDecl is RecordDecl recordDecl) && IsAnonymousRecord(name))
         {
             remappedName = GetRemappedNameForAnonymousRecord(recordDecl);
         }
@@ -614,7 +614,7 @@ public sealed partial class PInvokeGenerator
             return AddUsingDirectiveIfNeeded(_outputBuilder, remappedName, skipUsing);
         }
 
-        if ((cursor is CXXBaseSpecifier cxxBaseSpecifier) && remappedName.StartsWith("__AnonymousBase_", StringComparison.Ordinal))
+        if ((cursor is CXXBaseSpecifier cxxBaseSpecifier) && remappedName.StartsWith(AnonymousBasePrefix, StringComparison.Ordinal))
         {
             Debug.Assert(_cxxRecordDeclContext is not null);
             remappedName = "Base";
@@ -668,12 +668,12 @@ public sealed partial class PInvokeGenerator
                     type = arrayType.ElementType;
                 }
 
-                if (IsType<RecordType>(cursor, type, out var recordType) && remappedName.StartsWith("__AnonymousRecord_", StringComparison.Ordinal))
+                if (IsType<RecordType>(cursor, type, out var recordType) && IsAnonymousRecord(remappedName))
                 {
                     var recordDecl = recordType.Decl;
                     remappedName = GetRemappedNameForAnonymousRecord(recordDecl);
                 }
-                else if (IsType<EnumType>(cursor, type, out var enumType) && remappedName.StartsWith("__AnonymousEnum_", StringComparison.Ordinal))
+                else if (IsType<EnumType>(cursor, type, out var enumType) && IsAnonymousEnum(remappedName))
                 {
                     remappedName = GetRemappedTypeName(enumType.Decl, context: null, enumType.Decl.IntegerType, out _, skipUsing);
                 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -296,7 +296,7 @@ public partial class PInvokeGenerator
         {
             parentName = GetRemappedCursorName(enumDecl);
 
-            if (parentName.StartsWith("__AnonymousEnum_", StringComparison.Ordinal))
+            if (IsAnonymousEnum(parentName))
             {
                 parentName = "";
                 isAnonymousEnum = true;
@@ -365,7 +365,7 @@ public partial class PInvokeGenerator
         var escapedName = EscapeName(name);
         var isAnonymousEnum = false;
 
-        if (name.StartsWith("__AnonymousEnum_", StringComparison.Ordinal))
+        if (IsAnonymousEnum(name))
         {
             isAnonymousEnum = true;
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -1026,7 +1026,7 @@ public partial class PInvokeGenerator
 
                 if (!_config.DontUseUsingStaticsForEnums)
                 {
-                    if (enumName.StartsWith("__AnonymousEnum_", StringComparison.Ordinal))
+                    if (IsAnonymousEnum(enumName))
                     {
                         var className = GetClass(enumName);
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -35,6 +35,12 @@ public sealed partial class PInvokeGenerator : IDisposable
 {
     private const int DefaultStreamWriterBufferSize = 1024;
 
+    private const string AnonymousNamePrefix = "__Anonymous";
+    private const string AnonymousBasePrefix = $"{AnonymousNamePrefix}Base_";
+    private const string AnonymousEnumPrefix = $"{AnonymousNamePrefix}Enum_";
+    private const string AnonymousFieldDeclPrefix = $"{AnonymousNamePrefix}FieldDecl_";
+    private const string AnonymousRecordPrefix = $"{AnonymousNamePrefix}Record_";
+
     private static readonly Encoding s_defaultStreamWriterEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
     private static readonly string[] s_doubleColonSeparator = ["::"];
     private static readonly char[] s_doubleQuoteSeparator = ['"'];
@@ -1076,8 +1082,12 @@ public sealed partial class PInvokeGenerator : IDisposable
     {
         cursor.Location.GetFileLocation(out var file, out var line, out var column, out _);
         var fileName = Path.GetFileNameWithoutExtension(file.Name.ToString());
-        return $"__Anonymous{kind}_{fileName}_L{line}_C{column}";
+        return $"{AnonymousNamePrefix}{kind}_{fileName}_L{line}_C{column}";
     }
+
+    private static bool IsAnonymousEnum(string name) => name.StartsWith(AnonymousEnumPrefix, StringComparison.Ordinal);
+
+    private static bool IsAnonymousRecord(string name) => name.StartsWith(AnonymousRecordPrefix, StringComparison.Ordinal);
 
     private string GetArtificialFixedSizedBufferName(FieldDecl fieldDecl)
     {


### PR DESCRIPTION
The generator checked scattered `__Anonymous*_` magic string prefixes inline across several files. This promotes each distinct prefix to a `private const string` and routes the produce side through a shared base const, so the produce and consume sides share the exact same literals.

**Consts added** (grouped near the top of `PInvokeGenerator.cs`):
- `AnonymousNamePrefix = "__Anonymous"`
- `AnonymousBasePrefix = $"{AnonymousNamePrefix}Base_"`
- `AnonymousEnumPrefix = $"{AnonymousNamePrefix}Enum_"`
- `AnonymousFieldDeclPrefix = $"{AnonymousNamePrefix}FieldDecl_"`
- `AnonymousRecordPrefix = $"{AnonymousNamePrefix}Record_"`

The specific prefixes are built via compile-time const interpolation from the shared base, and `GetAnonymousName` now emits `$"{AnonymousNamePrefix}{kind}_..."` so the produce side is tied to the same base literal.

**Helpers added** (static, next to `GetAnonymousName`):
- `IsAnonymousEnum(string)` -- 4 call sites
- `IsAnonymousRecord(string)` -- 2 call sites

Single-use `FieldDecl`/`Base` prefix checks reference the const directly rather than a one-off helper.

**Sites touched:** `PInvokeGenerator.cs`, `PInvokeGenerator.Naming.cs`, `PInvokeGenerator.VisitDecl.cs`, `PInvokeGenerator.VisitStmt.cs`.

Behavior-preserving: the literal string values are unchanged, so generated output is byte-identical. Build is clean (0 warnings) and all 3708 golden-file tests pass with no expectation changes.