### PR TITLE
Drop net8.0 and modernize DllImportResolver invocation-list enumeration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@ in the **generator** instead — change the generator, then regenerate.
 Requires the **.NET 10 SDK** (`global.json` pins `10.0.100-preview`, `allowPrerelease`). `dotnet` resolves it.
 
 - Build: `dotnet build -c Release` (root, builds `ClangSharp.slnx`). ~20s incremental, clean.
-- Test: `dotnet test -c Release --no-build` (~1 min; ~3760 tests: 3706 generator + interop on `net8.0`+`net10.0`).
+- Test: `dotnet test -c Release --no-build` (~1 min; ~3760 tests: 3706 generator + interop on `net10.0`).
 - `--no-build` requires a prior successful build; drop it if you changed code since the last build.
 
 `TreatWarningsAsErrors=true`, `Nullable=enable`, `AnalysisLevel=latest-all`, and `EnforceCodeStyleInBuild=true`

--- a/sources/ClangSharp.Interop/ClangSharp.Interop.csproj
+++ b/sources/ClangSharp.Interop/ClangSharp.Interop.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sources/ClangSharp.Interop/clang.cs
+++ b/sources/ClangSharp.Interop/clang.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -168,9 +167,7 @@ public static unsafe partial class @clang
 
         if (resolveLibrary is not null)
         {
-            var resolvers = resolveLibrary.GetInvocationList().Cast<DllImportResolver>();
-
-            foreach (DllImportResolver resolver in resolvers)
+            foreach (DllImportResolver resolver in Delegate.EnumerateInvocationList(resolveLibrary))
             {
                 nativeLibrary = resolver(libraryName, assembly, searchPath);
 

--- a/sources/ClangSharp/ClangSharp.csproj
+++ b/sources/ClangSharp/ClangSharp.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sources/ClangSharp/Cursors/Decls/FieldDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/FieldDecl.cs
@@ -68,11 +68,7 @@ public class FieldDecl : DeclaratorDecl, IMergeable<FieldDecl>
                 name = name[anonymousNameStartIndex..];
             }
 
-#if NET8_0
-            if (name.StartsWith("("))
-#else
             if (name.StartsWith('('))
-#endif
             {
                 Debug.Assert(name.StartsWith("(anonymous enum at ", StringComparison.Ordinal) ||
                                  name.StartsWith("(anonymous struct at ", StringComparison.Ordinal) ||
@@ -82,11 +78,7 @@ public class FieldDecl : DeclaratorDecl, IMergeable<FieldDecl>
                                  name.StartsWith("(unnamed union at ", StringComparison.Ordinal) ||
                                  name.StartsWith("(unnamed at ", StringComparison.Ordinal));
 
-#if NET8_0
-                Debug.Assert(name.EndsWith(")"));
-#else
                 Debug.Assert(name.EndsWith(')'));
-#endif
 
                 return true;
             }

--- a/sources/ClangSharp/TranslationUnit.cs
+++ b/sources/ClangSharp/TranslationUnit.cs
@@ -16,11 +16,7 @@ public sealed unsafe class TranslationUnit : IDisposable, IEquatable<Translation
 {
     private static readonly ConcurrentDictionary<CXTranslationUnit, WeakReference<TranslationUnit>> s_createdTranslationUnits = new ConcurrentDictionary<CXTranslationUnit, WeakReference<TranslationUnit>>();
 
-#if NET8_0
-    private static readonly object s_createTranslationUnitLock = new object();
-#else
     private static readonly Lock s_createTranslationUnitLock = new Lock();
-#endif
 
     private readonly Dictionary<CXCursor, WeakReference<Cursor>> _createdCursors;
     private readonly Dictionary<CX_TemplateArgument, WeakReference<TemplateArgument>> _createdTemplateArguments;

--- a/tests/ClangSharp.UnitTests/ClangSharp.UnitTests.csproj
+++ b/tests/ClangSharp.UnitTests/ClangSharp.UnitTests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Drops the out-of-support `net8.0` target framework and modernizes the `DllImportResolver` invocation-list iteration to be allocation-free and AOT/trim-friendly.

----------

**Drop net8.0 target framework**

`net8.0` is out of support, so it is dropped from the three remaining multi-targeting projects (`ClangSharp`, `ClangSharp.Interop`, and `ClangSharp.UnitTests`), leaving `net10.0` as the sole target. The generator, CLI, and golden-test projects were already `net10.0`-only.

The now-dead `#if NET8_0` branches in `TranslationUnit` (`object` vs `System.Threading.Lock`) and `FieldDecl` (string vs `char` `StartsWith`/`EndsWith` overloads) are collapsed to their `net9.0`+ forms, and the `net8.0` reference in the copilot-instructions doc is updated.

----------

**Use `Delegate.EnumerateInvocationList` to enumerate `DllImportResolver`**

`TryResolveLibrary` previously iterated the multicast delegate's invocation list via `System.Linq`'s `GetInvocationList().Cast<DllImportResolver>()`, which allocates a `Delegate[]` plus a LINQ enumerator and pulls in a LINQ dependency that is an AOT/trim smell. With `net8.0` dropped, `net9.0`+ is guaranteed, so this now uses `Delegate.EnumerateInvocationList(resolveLibrary)`, which returns an allocation-free struct enumerator.

Behavior is unchanged: same resolver order, first resolver returning a non-zero `IntPtr` wins and returns immediately, same fall-through when none resolve, and the existing `resolveLibrary is not null` guard is preserved. This was the only `System.Linq` use in the file, so the now-unused `using System.Linq;` is removed.

```diff
-            var resolvers = resolveLibrary.GetInvocationList().Cast<DllImportResolver>();
-
-            foreach (DllImportResolver resolver in resolvers)
+            foreach (DllImportResolver resolver in Delegate.EnumerateInvocationList(resolveLibrary))
```

----------

Full solution builds with 0 warnings / 0 errors (`net10.0` only) and all 3708 generator unit tests pass.

> [!NOTE]
> This PR body was drafted by Copilot on my behalf.