### PR TITLE
Harden generator against malformed macro and uuid inputs

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitPreprocessedEntity.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitPreprocessedEntity.cs
@@ -24,6 +24,12 @@ public partial class PInvokeGenerator
         var translationUnitHandle = macroDefinitionRecord.TranslationUnit.Handle;
         var tokens = translationUnitHandle.Tokenize(macroDefinitionRecord.Extent).ToArray();
 
+        if (tokens.Length == 0)
+        {
+            // Nothing to do for macro definitions with no tokens (e.g. command-line or builtin macros)
+            return;
+        }
+
         if ((tokens[0].Kind == CXToken_Identifier) && (tokens[0].GetSpelling(translationUnitHandle).CString == macroDefinitionRecord.Spelling))
         {
             if (tokens.Length == 1)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -550,7 +550,7 @@ public partial class PInvokeGenerator
                     else if (IsPrevContextStmt<BinaryOperator>(out var binaryOperator, out _))
                     {
                         var targetType = binaryOperator.Type;
-                        targetTypeName = GetRemappedTypeName(implicitCastExpr, context: null, targetType, out _, skipUsing: true);
+                        targetTypeName = GetRemappedTypeName(binaryOperator, context: null, targetType, out _, skipUsing: true);
                         targetTypeNumBits = targetType.Handle.NumBits;
                     }
                     else if (PreviousContext.Cursor is VarDecl varDecl)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -58,14 +58,14 @@ public partial class PInvokeGenerator
                     var value = sign * literal.Value;
                     if (value is > int.MaxValue or < int.MinValue)
                     {
-                        // Literal is in int32 range
+                        // Literal is not in int32 range
                         outputBuilder.Write("(int)(");
                         outputBuilder.Write(sign * literal.Value);
                         outputBuilder.Write(")");
                     }
                     else
                     {
-                        // Literal is not in int32 range
+                        // Literal is in int32 range
                         outputBuilder.Write(sign * literal.Value);
                     }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1684,7 +1684,16 @@ public sealed partial class PInvokeGenerator : IDisposable
 
         var uuidAttr = uuidAttrs[0];
         var uuidAttrText = GetSourceRangeContents(recordDecl.TranslationUnit.Handle, uuidAttr.Extent);
-        var uuidText = uuidAttrText.Split(s_doubleQuoteSeparator, StringSplitOptions.RemoveEmptyEntries)[1];
+        var uuidTextParts = uuidAttrText.Split(s_doubleQuoteSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+        if (uuidTextParts.Length < 2)
+        {
+            AddDiagnostic(DiagnosticLevel.Warning, $"Failed to parse uuid attr text '{uuidAttrText}'.", recordDecl);
+            uuid = Guid.Empty;
+            return false;
+        }
+
+        var uuidText = uuidTextParts[1];
 
         if (!Guid.TryParse(uuidText, out uuid))
         {


### PR DESCRIPTION
Fixes a small set of verified latent robustness/correctness gaps in the managed generator. All are behavior-preserving for valid input.

- **Guard empty macro token arrays** -- `VisitMacroDefinitionRecord` dereferenced `tokens[0]` before any length check, throwing `IndexOutOfRangeException` for macros with an empty extent (e.g. command-line/builtin macros). Now returns gracefully when `tokens.Length == 0`.
- **Bounds-check the uuid attribute text split** -- `TryGetUuid` indexed `[1]` on the split result with no bounds check, crashing before the existing `Guid.TryParse` fallback could run when the attribute source has no double-quoted string. Now emits a `Warning` diagnostic and returns `false`.
- **Fix swapped int32-range comments** in `VisitIntegerLiteral` -- comment-only; the two comments were on the wrong branches.

----------

- **Fix null cursor passed to `GetRemappedTypeName`** -- in `VisitCharacterLiteral`, the `BinaryOperator` branch passed the always-null `implicitCastExpr` (from the sibling `ImplicitCastExpr` branch) instead of `binaryOperator`.

Build is `0 warnings / 0 errors`; all 3708 generator unit tests pass with byte-identical golden output. No regression tests added -- the unit-test project is purely golden-file (`inputContents` -> `expectedOutputContents`) and these triggering inputs aren't reproducible through C fixtures.

> [!NOTE]
> This PR body was drafted by Copilot.