### PR TITLE
Fix template-argument accessors for function and variable template specializations

### DIFF
--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -3632,7 +3632,7 @@ int clangsharp_Cursor_getNumTemplateArguments(CXCursor C) {
 
         if (const FunctionDecl* FD = dyn_cast<FunctionDecl>(D)) {
             const TemplateArgumentList* TAL = FD->getTemplateSpecializationArgs();
-            return TAL && TAL->size();
+            return TAL ? TAL->size() : 0;
         }
 
         if (FunctionTemplateDecl* FTD = const_cast<FunctionTemplateDecl*>(dyn_cast<FunctionTemplateDecl>(D))) {
@@ -4522,9 +4522,9 @@ CX_TemplateArgument clangsharp_Cursor_getTemplateArgument(CXCursor C, unsigned i
             }
         }
 
-        if (const VarTemplatePartialSpecializationDecl* VTPSD = dyn_cast<VarTemplatePartialSpecializationDecl>(D)) {
-            if (i < VTPSD->getTemplateArgs().size()) {
-                const TemplateArgument* TA = &VTPSD->getTemplateArgs()[i];
+        if (const VarTemplateSpecializationDecl* VTSD = dyn_cast<VarTemplateSpecializationDecl>(D)) {
+            if (i < VTSD->getTemplateArgs().size()) {
+                const TemplateArgument* TA = &VTSD->getTemplateArgs()[i];
                 return MakeCXTemplateArgument(TA, getCursorTU(C));
             }
         }

--- a/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using ClangSharp.Interop;
 using NUnit.Framework;
 using static ClangSharp.Interop.CX_CXXAccessSpecifier;
@@ -96,6 +98,50 @@ tuple<int, long> SomeFunction();
         Assert.That(packElements.Count, Is.EqualTo(2));
         Assert.That(packElements[0].AsType.AsString, Is.EqualTo("int"));
         Assert.That(packElements[1].AsType.AsString, Is.EqualTo("long"));
+    }
+
+    [Test]
+    public void FunctionTemplateSpecializationArgsTest()
+    {
+        SkipUntilNativeRebuild();
+
+        var inputContents = $@"template<class T, class U>
+void MyFunction(T t, U u);
+
+template<>
+void MyFunction<int, float>(int t, float u);
+";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var functionDecl = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>().Single((functionDecl) => functionDecl.TemplateSpecializationArgs.Count != 0);
+
+        Assert.That(functionDecl.TemplateSpecializationArgs.Count, Is.EqualTo(2));
+        Assert.That(functionDecl.TemplateSpecializationArgs[0].AsType.AsString, Is.EqualTo("int"));
+        Assert.That(functionDecl.TemplateSpecializationArgs[1].AsType.AsString, Is.EqualTo("float"));
+    }
+
+    [Test]
+    public void VarTemplateSpecializationArgsTest()
+    {
+        SkipUntilNativeRebuild();
+
+        var inputContents = $@"template<class T, class U>
+constexpr int MyVar = 0;
+
+template<>
+constexpr int MyVar<int, float> = 1;
+";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var varTemplateSpecializationDecl = translationUnit.TranslationUnitDecl.Decls.OfType<VarTemplateSpecializationDecl>().Single();
+
+        Assert.That(varTemplateSpecializationDecl.TemplateArgs.Count, Is.EqualTo(2));
+        Assert.That(varTemplateSpecializationDecl.TemplateArgs[0].IsNull, Is.False);
+        Assert.That(varTemplateSpecializationDecl.TemplateArgs[1].IsNull, Is.False);
+        Assert.That(varTemplateSpecializationDecl.TemplateArgs[0].AsType.AsString, Is.EqualTo("int"));
+        Assert.That(varTemplateSpecializationDecl.TemplateArgs[1].AsType.AsString, Is.EqualTo("float"));
     }
 
     [Test]
@@ -220,5 +266,21 @@ enum E {
             checkField("G", 4294967296, 4294967296, true);
             checkField("H", -1, 18446744073709551615UL, true);
         });
+    }
+
+    // The fix for these lives in the native libClangSharp shim (clangsharp_Cursor_getNumTemplateArguments
+    // and clangsharp_Cursor_getTemplateArgument). The pinned 21.1 prebuilt native package predates it, so
+    // skip until the native lib is rebuilt for a newer libClang. Rebuilding off 21.1 auto-unskips these.
+    private static void SkipUntilNativeRebuild()
+    {
+        using var versionString = clang.getClangVersion();
+        var match = Regex.Match(versionString.ToString(), @"version (\d+)\.(\d+)");
+
+        if (match.Success
+            && (int.Parse(match.Groups[1].ValueSpan, CultureInfo.InvariantCulture) == 21)
+            && (int.Parse(match.Groups[2].ValueSpan, CultureInfo.InvariantCulture) == 1))
+        {
+            Assert.Ignore("Requires a native libClangSharp rebuild that includes the template-argument accessor fix; the pinned 21.1 prebuilt package predates it. Remove this guard once libClang moves off 21.1 and the native lib is rebuilt.");
+        }
     }
 }


### PR DESCRIPTION
Fixes two correctness bugs in the native libClangSharp shim, both in the template-argument accessors and both the same class of bug.

----------

`clangsharp_Cursor_getNumTemplateArguments` returned `TAL && TAL->size()` for a `FunctionDecl` template specialization -- i.e. a `bool` (`0`/`1`), not the count. So a specialization with more than one template argument wrongly reported `1`. Every sibling in the function returns the real `.size()`; this now does too via a guard-then-size (`TAL ? TAL->size() : 0`), matching the guard in the sibling `getTemplateArgument`.

`clangsharp_Cursor_getTemplateArgument` only handled the derived `VarTemplatePartialSpecializationDecl`, where-as the sibling `getNumTemplateArguments` handles the base `VarTemplateSpecializationDecl`. For a full (non-partial) variable template specialization, `getNum` returned `N` but `getTemplateArgument(i)` returned a null `CX_TemplateArgument` for every `i`. Handling the base subsumes the partial case (partial derives from it), so partial behavior is unchanged and full specializations now return real arguments.

----------

Adds regression tests in `ClangSharp.UnitTests` (`FunctionTemplateSpecializationArgsTest`, `VarTemplateSpecializationArgsTest`) covering a function-template specialization with >1 argument and a full variable-template specialization. Confirmed both fail against the current prebuilt native package exactly as the bugs predict (count `1` vs `2`; args `IsNull` for the var spec) and are structurally correct.

The tests are gated behind a runtime libClang-version check that `Assert.Ignore`s while the pinned `21.1` prebuilt native package is in use, since that package predates this native fix. Rebuilding the native lib off `21.1` auto-unskips them.