### PR TITLE
Centralize anonymous type-kind tag literal and use range slicing

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -475,10 +475,10 @@ public sealed partial class PInvokeGenerator
                 // For fields of anonymous types, use the name of the type but clean off the type
                 // kind tag at the end.
                 var typeName = GetRemappedNameForAnonymousRecord(fieldDecl.Type.AsCXXRecordDecl);
-                var tagIndex = typeName.LastIndexOf("_e__", StringComparison.Ordinal);
+                var tagIndex = typeName.LastIndexOf(AnonymousTypeKindTag, StringComparison.Ordinal);
                 Debug.Assert(typeName[0] == '_');
                 Debug.Assert(tagIndex >= 0);
-                remappedName = typeName.Substring(1, tagIndex - 1);
+                remappedName = typeName[1..tagIndex];
             }
             else
             {
@@ -580,13 +580,13 @@ public sealed partial class PInvokeGenerator
             }
 
             // Add the type kind tag.
-            _ = remappedNameBuilder.Append("_e__");
+            _ = remappedNameBuilder.Append(AnonymousTypeKindTag);
             _ = remappedNameBuilder.Append(recordDecl.IsUnion ? "Union" : "Struct");
             return remappedNameBuilder.ToString();
         }
         else
         {
-            return $"_Anonymous_e__{(recordDecl.IsUnion ? "Union" : "Struct")}";
+            return $"_Anonymous{AnonymousTypeKindTag}{(recordDecl.IsUnion ? "Union" : "Struct")}";
         }
     }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -884,10 +884,10 @@ public partial class PInvokeGenerator
             // The name of a field of an anonymous type should be same as the type's name minus the
             // type kind tag at the end and the leading `_`.
             var contextNamePart = GetRemappedCursorName(rootRecordDecl);
-            var tagIndex = contextNamePart.LastIndexOf("_e__", StringComparison.Ordinal);
+            var tagIndex = contextNamePart.LastIndexOf(AnonymousTypeKindTag, StringComparison.Ordinal);
             Debug.Assert(contextNamePart[0] == '_');
             Debug.Assert(tagIndex >= 0);
-            contextNamePart = contextNamePart.Substring(1, tagIndex - 1);
+            contextNamePart = contextNamePart[1..tagIndex];
 
             contextNameParts.Push(EscapeName(contextNamePart));
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -40,6 +40,7 @@ public sealed partial class PInvokeGenerator : IDisposable
     private const string AnonymousEnumPrefix = $"{AnonymousNamePrefix}Enum_";
     private const string AnonymousFieldDeclPrefix = $"{AnonymousNamePrefix}FieldDecl_";
     private const string AnonymousRecordPrefix = $"{AnonymousNamePrefix}Record_";
+    private const string AnonymousTypeKindTag = "_e__";
 
     private static readonly Encoding s_defaultStreamWriterEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
     private static readonly string[] s_doubleColonSeparator = ["::"];
@@ -1092,7 +1093,7 @@ public sealed partial class PInvokeGenerator : IDisposable
     private string GetArtificialFixedSizedBufferName(FieldDecl fieldDecl)
     {
         var name = GetRemappedCursorName(fieldDecl);
-        return $"_{name}_e__FixedBuffer";
+        return $"_{name}{AnonymousTypeKindTag}FixedBuffer";
     }
 
     private BitfieldDesc[] GetBitfieldDescs(RecordDecl recordDecl)


### PR DESCRIPTION
Centralizes the `_e__` anonymous type-kind tag literal into a single `AnonymousTypeKindTag` const (next to the existing `__Anonymous*` consts) so the produce and consume sites share one definition rather than repeating the magic string across five sites. Also swaps the two adjacent `Substring(1, tagIndex - 1)` calls for range indexing (`[1..tagIndex]`).

No functional change -- generator output is byte-identical (3708 golden tests pass, build 0 warnings / 0 errors).

> [!NOTE]
> This PR description was drafted by Copilot on my behalf.