### PR TITLE
Use global.json SDK for the nightly publish jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
         path: ./artifacts/pkg
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        global-json-file: ./global.json
         source-url: https://pkgs.clangsharp.dev/index.json
       env:
         NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_PAT }}
@@ -190,5 +190,5 @@ jobs:
         path: ./artifacts/pkg
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        global-json-file: ./global.json
     - run: dotnet nuget push "./artifacts/pkg/Release/*.nupkg" --source https://nuget.pkg.github.com/dotnet/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate


### PR DESCRIPTION
The two nightly publish jobs (`publish-nightlies-azure` and the currently-disabled `publish-nightlies-github`) pinned `dotnet-version: '8.0.x'`, while every other job in the workflow resolves the SDK from `global.json`. This aligns them on the same single source of truth so the publish jobs can't silently drift from the version the rest of CI builds/packs with.

No behavioral risk -- these jobs only run `dotnet nuget push`, which works fine on the `global.json` SDK.

> [!NOTE]
> This PR description was drafted by Copilot on my behalf.