### PR TITLE
Return a success exit code for --version

### DIFF
--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -100,7 +100,7 @@ internal static partial class Program
             context.Console.WriteLine($"{s_rootCommand.Description} version 21.1.8");
             context.Console.WriteLine($"  {clang.getClangVersion()}");
             context.Console.WriteLine($"  {clangsharp.getVersion()}");
-            context.ExitCode = -1;
+            context.ExitCode = 0;
             return;
         }
 


### PR DESCRIPTION
The `--version` handler printed the version banner and then set `context.ExitCode = -1`, copied from the surrounding argument-error return paths. `--version` is an informational request that completed successfully, so it should exit `0` -- matching the convention of `clang --version` and `dotnet --version`, and avoiding a spurious failure signal for anything that shells out to query the version.

> [!NOTE]
> This PR description was drafted by Copilot on my behalf.