### PR TITLE
Fix missing semicolon on non-const global struct initializers

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -224,6 +224,10 @@ internal partial class CSharpOutputBuilder : IOutputBuilder
                         WriteLine(';');
                     }
                 }
+                else
+                {
+                    WriteLine(';');
+                }
                 break;
             }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/GlobalStructInitializerTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/GlobalStructInitializerTest.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+public sealed class GlobalStructInitializerTest : PInvokeGeneratorTest
+{
+    // Regression test for https://github.com/dotnet/clangsharp/issues/503
+    // A non-const global variable initialized with a struct initializer list was
+    // missing its terminating semicolon, which corrupted the rest of the file.
+    [Test]
+    public Task NonConstGlobalTest()
+    {
+        var inputContents = @"typedef struct Point { int x; int y; } Point;
+
+Point MyGlobalPoint = { .x = 10, .y = 20 };
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct Point
+    {
+        public int x;
+
+        public int y;
+    }
+
+    public static partial class Methods
+    {
+        public static Point MyGlobalPoint = new Point
+        {
+            x = 10,
+            y = 20,
+        };
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
+}


### PR DESCRIPTION
Fixes #503.

A non-const global variable initialized with a struct initializer list was emitted with a closing `}` but **no terminating `;`**, which broke the rest of the generated file:

```csharp
public static Point MyGlobalPoint = new Point
{
    x = 10,
    y = 20,
}   // <-- missing ';'
```

## Root cause

`CSharpOutputBuilder.EndValue` only wrote the terminating semicolon for `ValueKind.Unmanaged` when `desc.IsConstant` was true. `const` globals (emitted as `static readonly`) and arrays (flagged constant via `IsTypeConstantOrIncompleteArray`) therefore terminated correctly, but a plain non-const global struct fell through and emitted nothing. `ForRecordType` had already set `NeedsSemicolon`, but nothing flushed it on this path.

## Fix

Emit the semicolon for the non-const case as well, matching the constant branch and the `Primitive`/`String`/`GuidMember` value kinds.

XML output is unaffected -- `XmlOutputBuilder.EndValue` closes `<value>` unconditionally. The fix is language/platform-invariant (the struct renders identically across all C# variants), so a single `ClangSharp.PInvokeGenerator.UnitTests` regression test (`GlobalStructInitializerTest`) covers it; `generate-helper-types` is not involved.

## Validation

- Build: 0 warnings / 0 errors (Release).
- Tests: **3709 passed, 0 failed** (3708 existing byte-identical + 1 new).

> [!NOTE]
> This PR description and the change were drafted with Copilot.