### PR TITLE
Concatenate adjacent string literals in deprecated attribute messages

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -2060,14 +2060,11 @@ public sealed partial class PInvokeGenerator : IDisposable
                         }
 
                         var attrText = GetSourceRangeContents(namedDecl.TranslationUnit.Handle, attr.Extent);
+                        var message = GetDeprecatedMessage(attrText);
 
-                        var textStart = attrText.IndexOf('"', StringComparison.Ordinal);
-                        var textLength = attrText.LastIndexOf('"') - textStart;
-
-                        if (textLength > 1)
+                        if (!string.IsNullOrEmpty(message))
                         {
-                            var text = attrText.AsSpan(textStart + 1, textLength - 1);
-                            outputBuilder.WriteCustomAttribute($"Obsolete(\"{text}\")");
+                            outputBuilder.WriteCustomAttribute($"Obsolete(\"{message}\")");
                         }
                         else
                         {
@@ -2107,6 +2104,48 @@ public sealed partial class PInvokeGenerator : IDisposable
                 }
             }
         }
+    }
+
+    private static string? GetDeprecatedMessage(string attrText)
+    {
+        // The attribute source looks like `deprecated("message")`, but C allows the message to be
+        // written as adjacent string literals (e.g. `deprecated("part1" "part2")`), which the
+        // compiler concatenates into a single value. Gather the contents of every literal and join
+        // them so the emitted `Obsolete("...")` is a single, valid C# string.
+
+        var builder = new StringBuilder();
+        var hasLiteral = false;
+        var index = 0;
+
+        while (index < attrText.Length)
+        {
+            if (attrText[index] != '"')
+            {
+                index++;
+                continue;
+            }
+
+            hasLiteral = true;
+            index++;
+
+            while ((index < attrText.Length) && (attrText[index] != '"'))
+            {
+                // Preserve escape sequences verbatim so an escaped quote isn't treated as the end
+                // of the literal and the contents are emitted unchanged (as before).
+                if ((attrText[index] == '\\') && ((index + 1) < attrText.Length))
+                {
+                    _ = builder.Append(attrText[index]);
+                    index++;
+                }
+
+                _ = builder.Append(attrText[index]);
+                index++;
+            }
+
+            index++;
+        }
+
+        return hasLiteral ? builder.ToString() : null;
     }
 
     private string GetLibraryPath(string remappedName)

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/DeprecatedAdjacentStringTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/DeprecatedAdjacentStringTest.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>
+/// Regression test for https://github.com/dotnet/ClangSharp/issues/694.
+/// A deprecated message written as adjacent C string literals must be concatenated into a single
+/// C# string literal, otherwise the emitted <c>[Obsolete(...)]</c> attribute is invalid C#.
+/// </summary>
+[Platform("win")]
+public sealed class DeprecatedAdjacentStringTest : PInvokeGeneratorTest
+{
+    [Test]
+    public Task AdjacentStringLiteralsAreConcatenated()
+    {
+        var inputContents = @"extern ""C"" [[deprecated(""Use Bar() or ""
+                            ""Baz() instead"")]]
+void MyFunction();
+";
+
+        var expectedOutputContents = @"using System;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [Obsolete(""Use Bar() or Baz() instead"")]
+        public static extern void MyFunction();
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
+}


### PR DESCRIPTION
Fixes #694.

A C `deprecated` message can be written as **adjacent string literals**, which the compiler concatenates into a single value:

```c
[[deprecated("Use Bar() or "
             "Baz() instead")]]
void MyFunction();
```

The generator extracted the message as the substring between the *first* `"` (via `IndexOf`) and the *last* `"` (via `LastIndexOf`) and emitted it verbatim. For adjacent literals that span text includes the interior boundary quotes and inter-literal whitespace/newlines, so it emitted invalid C#:

```csharp
[Obsolete("Use Bar() or "
    "Baz() instead")]
```

The fix replaces the fragile first/last-quote slice with a proper scan (`GetDeprecatedMessage`) that walks the attribute source, gathers the contents of every string literal (respecting escaped quotes so `\"` isn't treated as a terminator), and joins them into a single value:

```csharp
[Obsolete("Use Bar() or Baz() instead")]
```

The common single-literal path is byte-identical (verified: no golden output changed), escaped quotes are preserved, and a missing/empty message still emits a bare `[Obsolete]`.

Added `DeprecatedAdjacentStringTest` covering the adjacent-literal case. Build `0 warning / 0 error` (Release, `TreatWarningsAsErrors` + `EnforceCodeStyleInBuild`); full suite green (3713 passed / 0 failed).

> [!NOTE]
> This PR description and the code change were drafted by Copilot on my behalf.