### PR TITLE
Strip enum member type name from sibling references in initializers

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -1020,6 +1020,16 @@ public partial class PInvokeGenerator
 
         if (declRefExpr.Decl is EnumConstantDecl enumConstantDecl)
         {
+            if (enumConstantDecl.DeclContext is NamedDecl enumTypeDecl)
+            {
+                var enumTypeName = GetRemappedCursorName(enumTypeDecl, out _, skipUsing: true);
+
+                if (!IsAnonymousEnum(enumTypeName))
+                {
+                    escapedName = EscapeAndStripEnumMemberName(name, enumTypeName);
+                }
+            }
+
             if ((declRefExpr.DeclContext != enumConstantDecl.DeclContext) && (enumConstantDecl.DeclContext is NamedDecl namedDecl))
             {
                 var enumName = GetRemappedCursorName(namedDecl, out _, skipUsing: true);

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/StripEnumMemberReferenceTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/StripEnumMemberReferenceTest.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>
+/// Regression test for https://github.com/dotnet/ClangSharp/issues/576.
+/// When <c>strip-enum-member-type-name</c> is used, references to sibling enum members inside
+/// an initializer expression must be stripped the same way as the member declarations, otherwise
+/// the emitted code references undefined names.
+/// </summary>
+[Platform("win")]
+public sealed class StripEnumMemberReferenceTest : PInvokeGeneratorTest
+{
+    [Test]
+    public Task SiblingReferencesAreStripped()
+    {
+        var inputContents = @"typedef enum WGPUInstanceBackend
+{
+    WGPUInstanceBackend_Vulkan = 1 << 0,
+    WGPUInstanceBackend_GL = 1 << 1,
+    WGPUInstanceBackend_Metal = 1 << 2,
+    WGPUInstanceBackend_Primary = WGPUInstanceBackend_Vulkan | WGPUInstanceBackend_Metal,
+    WGPUInstanceBackend_Secondary = WGPUInstanceBackend_GL
+} WGPUInstanceBackend;
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public enum WGPUInstanceBackend
+    {
+        Vulkan = 1 << 0,
+        GL = 1 << 1,
+        Metal = 1 << 2,
+        Primary = Vulkan | Metal,
+        Secondary = GL,
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.StripEnumMemberTypeName);
+    }
+}


### PR DESCRIPTION
Fixes #576.

With `strip-enum-member-type-name`, member *declarations* were stripped but *references* to sibling members inside an initializer kept the enum type prefix, so the output referenced undefined names:

```csharp
public enum WGPUInstanceBackend
{
    Vulkan = 1 << 0,
    Metal = 1 << 2,
    Primary = WGPUInstanceBackend_Vulkan | WGPUInstanceBackend_Metal,  // undefined
}
```

`VisitDeclRefExpr` computed the reference name with `EscapeName` and never applied the same stripping used when emitting the declaration (`EscapeAndStripEnumMemberName` in `VisitEnumConstantDecl`). Apply that transform to enum constant references, keyed off the referenced member's own enum type name, so references match their declarations:

```csharp
    Primary = Vulkan | Metal,
```

`EscapeAndStripEnumMemberName` is a no-op when the option is off, so non-strip output is byte-identical (verified: no golden changed). Anonymous enums are left untouched, and cross-enum references still resolve via the existing `using static` path.

Added `StripEnumMemberReferenceTest`. Build `0 warning / 0 error`; full suite green.

> [!NOTE]
> This PR description and the code change were drafted by Copilot on my behalf.