### PR TITLE
Qualify nested type references with their containing types

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
@@ -388,6 +388,20 @@ public sealed partial class PInvokeGenerator
                 {
                     result.typeName = result.typeName.Split(s_doubleColonSeparator, StringSplitOptions.RemoveEmptyEntries).Last();
                     result.typeName = GetRemappedName(result.typeName, cursor, tryRemapOperatorName: false, out _, skipUsing: true);
+
+                    // A nested type needs to be qualified by its containing type(s) so it resolves
+                    // when referenced from another scope (e.g. `A::Inner` -> `A.Inner`). Namespaces
+                    // are flattened away, so only walk the enclosing record decls.
+
+                    var qualificationBuilder = new StringBuilder();
+
+                    for (var declContext = tagType.Decl.DeclContext; declContext is RecordDecl parentRecordDecl; declContext = parentRecordDecl.DeclContext)
+                    {
+                        var parentRecordDeclName = GetRemappedCursorName(parentRecordDecl, out _, skipUsing: true);
+                        _ = qualificationBuilder.Insert(0, '.').Insert(0, EscapeName(parentRecordDeclName));
+                    }
+
+                    result.typeName = qualificationBuilder.Append(result.typeName).ToString();
                 }
             }
             else if (type is TemplateSpecializationType templateSpecializationType)

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/NestedTypeReferenceTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/NestedTypeReferenceTest.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>
+/// Regression test for https://github.com/dotnet/ClangSharp/issues/579.
+/// A nested type referenced from another scope must be qualified by its containing type(s)
+/// (e.g. <c>A::Inner</c> -&gt; <c>A.Inner</c>) so it resolves in the generated C#.
+/// </summary>
+[Platform("win")]
+public sealed class NestedTypeReferenceTest : PInvokeGeneratorTest
+{
+    [Test]
+    public Task NestedTypeIsQualified()
+    {
+        var inputContents = @"struct A
+{
+    struct Inner
+    {
+        int value;
+    };
+};
+
+struct B
+{
+    A::Inner inner;
+};
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct A
+    {
+
+        public partial struct Inner
+        {
+            public int value;
+        }
+    }
+
+    public partial struct B
+    {
+        [NativeTypeName(""A::Inner"")]
+        public A.Inner inner;
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
+}


### PR DESCRIPTION
Fixes #579.

A reference to a nested type was reduced to only its last `::` segment, so using it from another scope emitted an unqualified name that doesn't resolve:

```csharp
public void Method([NativeTypeName(""A::Inner &"")] Inner* inner)   // Inner is undefined here
```

In `GetTypeName`'s `TagType` handling, the `::` case did `Split(""::"").Last()` and dropped all qualification. Nested types are emitted as nested C# types, so a reference needs the containing type(s) as a prefix. Walk the enclosing `RecordDecl` chain (mirroring the existing idiom in `VisitIndirectFieldDecl`) and prepend each remapped name, while still flattening namespaces (only record parents are added):

```csharp
public void Method([NativeTypeName(""A::Inner &"")] A.Inner* inner)
```

Verified against the full matrix:
- `A::Inner` -> `A.Inner` (fields, params, return types, and the vtbl delegate signature)
- `A::B::Inner` -> `A.B.Inner` (deep nesting)
- `A::Color` (enum nested in a struct) -> `A.Color`
- `ns::Foo` -> `Foo` (namespaces still flattened)

No existing golden output changed. Added `NestedTypeReferenceTest`. Build `0 warning / 0 error`; full suite green.

> [!NOTE]
> This PR description and the code change were drafted by Copilot on my behalf.