### PR TITLE
Don't dereference a null type when building a template argument name

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -249,7 +249,12 @@ public sealed partial class PInvokeGenerator
             {
                 case CXTemplateArgumentKind_Type:
                 {
-                    _ = qualifiedName.Append(templateArgument.AsType.AsString);
+                    // AsType is null when the argument's type maps to an invalid CXType
+                    // (an unsupported type the shim can't represent). Fall back to the
+                    // same '?' placeholder used for other unsupported argument kinds
+                    // rather than dereferencing null.
+                    var argType = templateArgument.AsType;
+                    _ = qualifiedName.Append((argType is not null) ? argType.AsString : "?");
                     break;
                 }
 


### PR DESCRIPTION
Fixes #580.

Generation crashes with a `NullReferenceException` while building the qualified name of a class template specialization:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at ClangSharp.PInvokeGenerator.<GetCursorQualifiedName>g__AppendTemplateArgument|...
   at ClangSharp.PInvokeGenerator.<GetCursorQualifiedName>g__AppendTemplateArguments|...
   at ClangSharp.PInvokeGenerator.GetCursorQualifiedName(NamedDecl, Boolean)
   at ClangSharp.PInvokeGenerator.<VisitTypedefDecl>g__ForUnderlyingType|...
```

**Root cause.** `AppendTemplateArgument` handles a `Type`-kind argument with `templateArgument.AsType.AsString`. `AsType` routes through `TranslationUnit.GetOrCreate<Type>`, which returns `null` for a `CXType_Invalid` handle (the `Debug.Assert` guarding that path is compiled out of Release). So when an argument's underlying `QualType` maps to an invalid `CXType` — an unsupported/exotic type the shim can't represent, as happens deep in the `sol2` / `spdlog` / C++20 template instantiations from the report — `AsType` is `null` and `.AsString` throws. `AsIntegral` returns a `long` and the `default` branch is already safe, so this is the only unguarded deref.

**Fix.** Guard the access and fall back to the same `'?'` placeholder the `default` branch already uses for unsupported argument kinds:

```csharp
var argType = templateArgument.AsType;
_ = qualifiedName.Append((argType is not null) ? argType.AsString : ""?"");
```

The success path is byte-identical (non-null `AsType` still yields `AsType.AsString`); the only new behavior is that a previously-fatal NRE now renders as `Foo<?>` in the qualified name (used for diagnostics and remapping keys), matching how unsupported kinds already render.

**On testing.** I verified the mechanism directly from source and confirmed it's the only null-deref in the method. I could not build a minimal standalone repro — the invalid-`CXType` argument only arises from the specific deeply-nested standard-library instantiations in the original report, which need the full ModEngine2 + sol2 + spdlog include tree and toolchain to stand up. This mirrors the earlier `harden generator against malformed inputs` change, which likewise guards a native-only crash path that isn't expressible through the golden-file harness. Full suite green with zero golden changes.

> [!NOTE]
> This PR description and the code change were drafted by Copilot on my behalf.