### PR TITLE
Qualify anonymous enum references with their backing class for exclude-using-statics-for-enums

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -1052,6 +1052,14 @@ public partial class PInvokeGenerator
                 }
                 else
                 {
+                    if (IsAnonymousEnum(enumName))
+                    {
+                        // Anonymous enum members are emitted as constants on the enum's
+                        // backing class rather than a generated enum type, so qualify the
+                        // reference with that class instead of the non-existent enum name.
+                        enumName = GetClass(enumName);
+                    }
+
                     outputBuilder.Write(enumName);
                     outputBuilder.Write(".");
                 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/AnonymousEnumReferenceExcludeUsingStaticsTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/AnonymousEnumReferenceExcludeUsingStaticsTest.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>
+/// Regression test for https://github.com/dotnet/ClangSharp/issues/681.
+/// When <c>exclude-using-statics-for-enums</c> is used, a reference to an anonymous enum member
+/// must be qualified with the backing class the constants are emitted on (e.g. <c>Methods</c>)
+/// rather than the non-existent <c>__AnonymousEnum_*</c> enum name.
+/// </summary>
+[Platform("win")]
+public sealed class AnonymousEnumReferenceExcludeUsingStaticsTest : PInvokeGeneratorTest
+{
+    [Test]
+    public Task ReferenceIsQualifiedWithBackingClass()
+    {
+        var inputContents = @"enum
+{
+    MyEnum1_Value1 = 1,
+};
+
+enum MyEnum2 : int
+{
+    MyEnum2_Value1 = MyEnum1_Value1,
+};
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public enum MyEnum2
+    {
+        MyEnum2_Value1 = Methods.MyEnum1_Value1,
+    }
+
+    public static partial class Methods
+    {
+        public const int MyEnum1_Value1 = 1;
+    }
+}
+";
+
+        var diagnostics = new[] { new Diagnostic(DiagnosticLevel.Info, "Found anonymous enum: __AnonymousEnum_ClangUnsavedFile_L1_C1. Mapping values as constants in: Methods", "Line 1, Column 1 in ClangUnsavedFile.h") };
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.DontUseUsingStaticsForEnums, expectedDiagnostics: diagnostics);
+    }
+}


### PR DESCRIPTION
Fixes #681.

With `exclude-using-statics-for-enums`, a cross-context enum constant reference is emitted as `EnumName.Member`. For an **anonymous** enum there is no generated enum type — the members are lowered to `const` fields on the enum's backing class (`Methods` here) — so qualifying with the synthesized `__AnonymousEnum_*` name referenced a type that doesn't exist:

```csharp
public enum MyEnum2
{
    MyEnum2_Value1 = __AnonymousEnum_header_L1_C1.MyEnum1_Value1,  // doesn't compile
}
```

`VisitDeclRefExpr`'s `DontUseUsingStaticsForEnums` branch wrote `enumName` unconditionally. The using-statics branch already special-cases anonymous enums via `GetClass(enumName)`; this mirrors that, so the reference now qualifies with the backing class:

```csharp
public enum MyEnum2
{
    MyEnum2_Value1 = Methods.MyEnum1_Value1,
}
```

Verified live:
- anonymous enum + `exclude-using-statics-for-enums` → `Methods.MyEnum1_Value1` (was `__AnonymousEnum_*.`)
- default (using-statics) path unchanged → `using static ...Methods;` + unqualified `MyEnum1_Value1`
- named cross-enum ref + `exclude-using-statics-for-enums` unchanged → `MyEnum1.MyEnum1_Value1`

Added `AnonymousEnumReferenceExcludeUsingStaticsTest`. Build `0 warning / 0 error`; full suite green with no golden changes.

> [!NOTE]
> This PR description and the code change were drafted by Copilot on my behalf.