### PR TITLE
Map nullptr type to void* instead of the invalid type name null

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
@@ -274,7 +274,7 @@ public sealed partial class PInvokeGenerator
 
                     case CXType_NullPtr:
                     {
-                        result.typeName = "null";
+                        result.typeName = "void*";
                         break;
                     }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/NullPtrMacroBindingTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/NullPtrMacroBindingTest.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>Provides validation that a <c>nullptr</c> macro is generated as a <c>void*</c> constant rather than the invalid type name <c>null</c>.</summary>
+public sealed class NullPtrMacroBindingTest : PInvokeGeneratorTest
+{
+    [Test]
+    public Task NullPtrMacroTest()
+    {
+        var inputContents = @"#define MY_NULL_HANDLE nullptr";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static unsafe partial class Methods
+    {
+        [NativeTypeName(""#define MY_NULL_HANDLE nullptr"")]
+        public static readonly void* MY_NULL_HANDLE = null;
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
+}


### PR DESCRIPTION
Fixes #601.

A macro such as `#define VK_NULL_HANDLE nullptr` was resolving its `CXType_NullPtr` type to the literal string `null`, so `--generate-macro-bindings` emitted uncompilable code:

```csharp
[NativeTypeName("#define VK_NULL_HANDLE nullptr")]
public static readonly null VK_NULL_HANDLE = null;
```

`null` is not a valid type name. This maps `CXType_NullPtr` to `void*` instead, which is exactly how an equivalent `#define X ((void*)0)` macro is already handled -- it also correctly triggers the `unsafe` modifier on the containing class via the existing `IsUnsafe` check:

```csharp
public static unsafe partial class Methods
{
    [NativeTypeName("#define VK_NULL_HANDLE nullptr")]
    public static readonly void* VK_NULL_HANDLE = null;
}
```

Added `NullPtrMacroBindingTest` covering the macro-binding case. Full generator suite is green (3719 passed, 0 failed) with zero golden churn.

> [!NOTE]
> This PR was authored with the assistance of Copilot.