### PR TITLE
Fix method class over-indentation under file-scoped namespaces

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -672,7 +672,7 @@ public sealed partial class PInvokeGenerator : IDisposable
 
         void ForCSharp(CSharpOutputBuilder outputBuilder)
         {
-            var indentationString = outputBuilder.IndentationString;
+            var indentationString = Config.GenerateFileScopedNamespaces ? "" : outputBuilder.IndentationString;
             var nonTestName = outputBuilder.IsTestOutput ? outputBuilder.Name.AsSpan()[..^5] : outputBuilder.Name;
 
             if (emitNamespaceDeclaration)
@@ -689,7 +689,6 @@ public sealed partial class PInvokeGenerator : IDisposable
                 {
                     sw.WriteLine(';');
                     sw.WriteLine();
-                    indentationString = "";
                 }
                 else
                 {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FileScopedNamespaceTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FileScopedNamespaceTest.cs
@@ -8,7 +8,8 @@ namespace ClangSharp.UnitTests;
 /// <summary>
 /// Regression test for https://github.com/dotnet/ClangSharp/issues/555.
 /// When <c>generate-file-scoped-namespaces</c> is used with a single output file, no namespace
-/// opening brace is emitted, so no closing brace must be emitted either.
+/// opening brace is emitted, so no closing brace must be emitted either. Members after the first
+/// must also not be indented as if they were nested inside a namespace block.
 /// </summary>
 [Platform("win")]
 public sealed class FileScopedNamespaceTest : PInvokeGeneratorTest
@@ -50,6 +51,51 @@ public partial struct Point
     public int x;
 
     public int y;
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateFileScopedNamespaces);
+    }
+
+    [Test]
+    public Task MembersAfterFirstAreNotOverIndented()
+    {
+        var inputContents = @"struct Point
+{
+    int x;
+    int y;
+};
+
+enum Color
+{
+    Red,
+    Green,
+};
+
+extern ""C"" void MyFunction();
+";
+
+        var expectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test;
+
+public partial struct Point
+{
+    public int x;
+
+    public int y;
+}
+
+public enum Color
+{
+    Red,
+    Green,
+}
+
+public static partial class Methods
+{
+    [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern void MyFunction();
 }
 ";
 


### PR DESCRIPTION
Under file-scoped namespaces the base indentation was only reset to empty for the first output builder (the one emitting the namespace declaration). Every subsequent top-level member kept the default one-level indent and was written as if it were nested inside a `namespace { ... }` block. Because the method class is always emitted after the other top-level members, its body was the most visible case, but any struct/enum emitted after the first was affected too.

The fix derives the base indent from `Config.GenerateFileScopedNamespaces` up front instead of resetting it only inside the (first-builder-only) `emitNamespaceDeclaration` branch in `CloseOutputBuilder` -> `ForCSharp`.

----------

Added the regression test `FileScopedNamespaceTest.MembersAfterFirstAreNotOverIndented` covering a struct + enum + free function. No existing golden exercised file-scoped namespaces with more than one top-level output builder, so there is no golden churn.

Full `ClangSharp.PInvokeGenerator.UnitTests` suite passes (Failed: 0, Passed: 3725).