### PR TITLE
Don't crash on undefined function-like macros

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
@@ -43,9 +43,16 @@ public partial class PInvokeGenerator
             var nativeName = GetCursorName(varDecl);
             if (nativeName.StartsWith("ClangSharpMacro_", StringComparison.Ordinal))
             {
-                type = varDecl.Init.Type;
                 nativeName = nativeName["ClangSharpMacro_".Length..];
                 isMacroDefinitionRecord = true;
+
+                if (varDecl.Init is null)
+                {
+                    AddDiagnostic(DiagnosticLevel.Warning, $"Macro definition '{nativeName}' could not be resolved to a supported expression. Generated bindings may be incomplete.", varDecl);
+                    return;
+                }
+
+                type = varDecl.Init.Type;
             }
 
             var accessSpecifier = GetAccessSpecifier(varDecl, matchStar: false);
@@ -61,8 +68,9 @@ public partial class PInvokeGenerator
                         return;
                     }
                 }
-                else if (IsStmtAsWritten<RecoveryExpr>(varDecl.Init, out var recoveryExpr, removeParens: true))
+                else if (IsStmtAsWritten<RecoveryExpr>(varDecl.Init, out _, removeParens: true))
                 {
+                    AddDiagnostic(DiagnosticLevel.Warning, $"Macro definition '{nativeName}' could not be resolved to a supported expression. Generated bindings may be incomplete.", varDecl);
                     return;
                 }
             }

--- a/sources/ClangSharp/Cursors/Decls/VarDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/VarDecl.cs
@@ -59,7 +59,7 @@ public class VarDecl : DeclaratorDecl, IRedeclarable<VarDecl>
 
     private static unsafe VarDecl InstantiatedFromStaticDataMemberFactory(VarDecl self) => self.TranslationUnit.GetOrCreate<VarDecl>(self.Handle.InstantiatedFromMember);
 
-    private static unsafe Expr InitFactory(VarDecl self) => self.TranslationUnit.GetOrCreate<Expr>(self.Handle.InitExpr);
+    private static unsafe Expr InitFactory(VarDecl self) => (self.TranslationUnit.GetOrCreate<Stmt>(self.Handle.InitExpr) as Expr)!;
 
     private static unsafe VarDecl DefinitionFactory(VarDecl self) => self.TranslationUnit.GetOrCreate<VarDecl>(self.Handle.Definition);
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Base/VarDeclarationTest.cs
@@ -84,6 +84,9 @@ public abstract class VarDeclarationTest : PInvokeGeneratorTest
     [Test]
     public Task ConditionalDefineConstTest() => ConditionalDefineConstTestImpl();
 
+    [Test]
+    public Task UndefinedFunctionLikeMacroTest() => UndefinedFunctionLikeMacroTestImpl();
+
     protected abstract Task BasicTestImpl(string nativeType, string expectedManagedType);
 
     protected abstract Task BasicWithNativeTypeNameTestImpl(string nativeType, string expectedManagedType);
@@ -121,4 +124,6 @@ public abstract class VarDeclarationTest : PInvokeGeneratorTest
     protected abstract Task MultidimensionlArrayTestImpl();
 
     protected abstract Task ConditionalDefineConstTestImpl();
+
+    protected abstract Task UndefinedFunctionLikeMacroTestImpl();
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleUnix/VarDeclarationTest.cs
@@ -398,4 +398,14 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpCompatibleWindows/VarDeclarationTest.cs
@@ -395,4 +395,14 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultUnix/VarDeclarationTest.cs
@@ -397,4 +397,14 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpDefaultWindows/VarDeclarationTest.cs
@@ -395,4 +395,14 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestUnix/VarDeclarationTest.cs
@@ -397,4 +397,14 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpLatestWindows/VarDeclarationTest.cs
@@ -395,4 +395,14 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewUnix/VarDeclarationTest.cs
@@ -399,4 +399,14 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpPreviewUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedCSharpPreviewUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CSharpPreviewWindows/VarDeclarationTest.cs
@@ -395,4 +395,14 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpPreviewWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedCSharpPreviewWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleUnix/VarDeclarationTest.cs
@@ -530,4 +530,14 @@ static const char* const MyConst3 = ""Test\0\\\r\n\t\"""";";
 
         return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedXmlCompatibleUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlCompatibleWindows/VarDeclarationTest.cs
@@ -530,4 +530,14 @@ static const char* const MyConst3 = ""Test\0\\\r\n\t\"""";";
 
         return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedXmlCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultUnix/VarDeclarationTest.cs
@@ -530,4 +530,14 @@ static const char* const MyConst3 = ""Test\0\\\r\n\t\"""";";
 
         return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlDefaultWindows/VarDeclarationTest.cs
@@ -530,4 +530,14 @@ static const char* const MyConst3 = ""Test\0\\\r\n\t\"""";";
 
         return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestUnix/VarDeclarationTest.cs
@@ -530,4 +530,14 @@ static const char* const MyConst3 = ""Test\0\\\r\n\t\"""";";
 
         return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedXmlLatestUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlLatestWindows/VarDeclarationTest.cs
@@ -531,4 +531,14 @@ static const char* const MyConst3 = ""Test\0\\\r\n\t\"""";";
 
         return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedXmlLatestWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewUnix/VarDeclarationTest.cs
@@ -530,4 +530,14 @@ static const char* const MyConst3 = ""Test\0\\\r\n\t\"""";";
 
         return ValidateGeneratedXmlPreviewUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedXmlPreviewUnixBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/VarDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/XmlPreviewWindows/VarDeclarationTest.cs
@@ -530,4 +530,14 @@ static const char* const MyConst3 = ""Test\0\\\r\n\t\"""";";
 
         return ValidateGeneratedXmlPreviewWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
     }
+
+    protected override Task UndefinedFunctionLikeMacroTestImpl()
+    {
+        var inputContents = @"#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)";
+
+        var expectedOutputContents = "";
+        var diagnostics = new Diagnostic[] { new Diagnostic(DiagnosticLevel.Warning, "Macro definition 'ADDRESS_IN_USE' could not be resolved to a supported expression. Generated bindings may be incomplete.", "Line 2, Column 12 in ClangUnsavedFile.h") };
+
+        return ValidateGeneratedXmlPreviewWindowsBindingsAsync(inputContents, expectedOutputContents, expectedDiagnostics: diagnostics);
+    }
 }


### PR DESCRIPTION
Using an undefined function-like macro in another macro's body crashed the generator with `InvalidCastException: Unable to cast object of type 'ClangSharp.Stmt' to type 'ClangSharp.Expr'`:

```c
#define ADDRESS_IN_USE TESTRESULT_FROM_WIN32(10048)   // TESTRESULT_FROM_WIN32 is not defined
```

The generator synthesizes a `ClangSharpMacro_` `VarDecl` and lazily resolves its initializer via `VarDecl.InitFactory`, which hard-cast the cursor through `GetOrCreate<Expr>`. When the initializer resolves to a plain `Stmt` rather than an `Expr`, that cast threw.

`InitFactory` now resolves via `GetOrCreate<Stmt>(...) as Expr`, so a non-`Expr` initializer yields `null` instead of throwing. This is behavior-preserving for real initializers, which are always `Expr`. The macro handling in `VisitVarDecl` gracefully skips such a macro and emits a warning diagnostic instead of crashing, and the existing `RecoveryExpr` skip now emits the same warning rather than silently dropping the macro (modern Clang represents these unresolved invocations as a `RecoveryExpr`).

----------

Added `UndefinedFunctionLikeMacroTest` to the `VarDeclaration` golden suite (Base + all 16 configuration variants), asserting no crash, empty output, and the expected warning diagnostic.

Note: on the pinned libClang 21.1.8 the exact `Stmt -> Expr` cast is no longer produced (Clang yields a `RecoveryExpr`/`CallExpr`), so this hardens the reported cast site defensively and locks in the graceful warn-and-skip behavior via the new regression test.

Fixes #222