### PR TITLE
Insert explicit byte-pointer casts for void pointer arithmetic

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Predicates.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Predicates.cs
@@ -892,6 +892,10 @@ public sealed partial class PInvokeGenerator
          => IsType<BuiltinType>(cursor, type, out var builtinType)
          && (builtinType.Kind == CXType_Void);
 
+    private static bool IsTypeVoidPointer(Cursor? cursor, Type type)
+         => IsType<PointerType>(cursor, type, out var pointerType)
+         && IsTypeVoid(cursor, pointerType.PointeeType);
+
     internal bool IsSupportedFixedSizedBufferType(string typeName)
     {
         switch (typeName)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -37,7 +37,14 @@ public partial class PInvokeGenerator
     private void VisitBinaryOperator(BinaryOperator binaryOperator)
     {
         var outputBuilder = StartCSharpCode();
-        Visit(binaryOperator.LHS);
+
+        // C/C++ allow pointer arithmetic on `void*` (treating it as byte-sized), but C# does
+        // not. Insert an explicit `(byte*)` cast on any `void*` operand of an additive operator
+        // so the arithmetic is well-defined; `byte*` implicitly converts back to `void*` where
+        // the surrounding context requires it.
+        var isAdditive = binaryOperator.Opcode is CXBinaryOperator_Add or CXBinaryOperator_Sub;
+
+        VisitBinaryOperatorOperand(binaryOperator.LHS, isAdditive);
         outputBuilder.Write(' ');
         outputBuilder.Write(binaryOperator.OpcodeStr);
         outputBuilder.Write(' ');
@@ -92,10 +99,21 @@ public partial class PInvokeGenerator
         }
         else
         {
-            Visit(binaryOperator.RHS);
+            VisitBinaryOperatorOperand(binaryOperator.RHS, isAdditive);
         }
 
         StopCSharpCode();
+    }
+
+    private void VisitBinaryOperatorOperand(Expr operand, bool isAdditive)
+    {
+        if (isAdditive && IsTypeVoidPointer(operand, operand.Type))
+        {
+            StartCSharpCode().Write("(byte*)");
+            StopCSharpCode();
+        }
+
+        Visit(operand);
     }
 
     private void VisitBreakStmt(BreakStmt breakStmt)

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -1214,4 +1214,29 @@ typedef long int intptr_t;
             return ValidateGeneratedCSharpLatestUnixBindingsAsync(inputContents, expectedOutputContents, commandLineArgs: DefaultCClangCommandLineArgs, language: "c", languageStandard: DefaultCStandard);
         }
     }
+
+    [Test]
+    public Task VoidPointerArithmeticTest()
+    {
+        // C/C++ allow pointer arithmetic on `void*` (treating it as byte-sized), but C# does not,
+        // so the generator must insert an explicit `(byte*)` cast on the `void*` operand.
+        var inputContents = @"void* MyFunction(void *buf, unsigned long long size) {
+    return buf + size;
+}
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public static unsafe partial class Methods
+    {
+        public static void* MyFunction(void* buf, [NativeTypeName(""unsigned long long"")] ulong size)
+        {
+            return (byte*)buf + size;
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, commandLineArgs: DefaultCClangCommandLineArgs, language: "c", languageStandard: DefaultCStandard);
+    }
 }


### PR DESCRIPTION
C/C++ allow pointer arithmetic on `void*` (treating it as byte-sized), but C# does not and instead reports `CS0242: The operation in question is undefined on void pointers`. The generator emitted the arithmetic verbatim, producing uncompilable C# for a function body such as `cpy(buf + size * size2, info, size)`.

This inserts an explicit `(byte*)` cast on any `void*` operand of an additive operator so the arithmetic is well-defined; `byte*` implicitly converts back to `void*` where the surrounding context requires it.

```
cpy(buf + size * size2, ...)  ->  cpy((byte*)buf + size * size2, ...)
```

The cast is applied to whichever operand is the `void*` (LHS or RHS), so `buf - n`, `n + buf`, and pointer difference `a - b` are all handled.

----------

Compound assignment (`+=`/`-=`) and `++`/`--` on a `void*` lvalue are out of scope here -- those need a `buf = (void*)((byte*)buf + n)` rewrite rather than a localized operand cast, and are not exercised by the reported repro. Left as a follow-up.

Added a C regression test (`CTest.VoidPointerArithmeticTest`); C++ makes `void*` arithmetic a hard error, so the test uses C mode. No existing golden output changes -- the full `ClangSharp.PInvokeGenerator.UnitTests` suite passes (Failed: 0, Passed: 3725).

Fixes #296
