### PR TITLE
Add opt-in uint, nint, and nuint indexers for fixed buffer helper structs

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
@@ -1879,39 +1879,53 @@ public partial class PInvokeGenerator
 
             if (generateCompatibleCode || isUnsafeElementType)
             {
-                _outputBuilder.BeginIndexer(AccessSpecifier.Public, isUnsafe: generateCompatibleCode && !isUnsafeElementType, needsUnscopedRef: false);
-                _outputBuilder.WriteIndexer($"ref {arrayTypeName}");
-                _outputBuilder.BeginIndexerParameters();
-                var param = new ParameterDesc {
-                    Name = "index",
-                    Type = "int",
-                };
-                _outputBuilder.BeginParameter(in param);
-                _outputBuilder.EndParameter(in param);
-                _outputBuilder.EndIndexerParameters();
-                _outputBuilder.BeginBody();
+                // Always emit the int indexer; when GenerateFixedBufferIndexerOverloads is set, also
+                // emit uint, nint, and nuint overloads so callers can index without casting. Pointer
+                // element access accepts all four types, so the body is identical.
+                var indexTypes = _config.GenerateFixedBufferIndexerOverloads
+                                 ? (ReadOnlySpan<string>)["int", "uint", "nint", "nuint"]
+                                 : (ReadOnlySpan<string>)["int"];
 
-                _outputBuilder.BeginGetter(_config.GenerateAggressiveInlining, isReadOnly: false);
-                var code = _outputBuilder.BeginCSharpCode();
+                foreach (var indexType in indexTypes)
+                {
+                    _outputBuilder.BeginIndexer(AccessSpecifier.Public, isUnsafe: generateCompatibleCode && !isUnsafeElementType, needsUnscopedRef: false);
+                    _outputBuilder.WriteIndexer($"ref {arrayTypeName}");
+                    _outputBuilder.BeginIndexerParameters();
+                    var param = new ParameterDesc {
+                        Name = "index",
+                        Type = indexType,
+                    };
+                    _outputBuilder.BeginParameter(in param);
+                    _outputBuilder.EndParameter(in param);
+                    _outputBuilder.EndIndexerParameters();
+                    _outputBuilder.BeginBody();
 
-                code.WriteIndented("fixed (");
-                code.Write(arrayTypeName);
-                code.Write("* pThis = &");
-                code.Write(firstFieldName);
-                code.WriteLine(')');
-                code.WriteBlockStart();
-                code.WriteIndented("return ref pThis[index]");
-                code.WriteSemicolon();
-                code.WriteNewline();
-                code.WriteBlockEnd();
-                _outputBuilder.EndCSharpCode(code);
+                    _outputBuilder.BeginGetter(_config.GenerateAggressiveInlining, isReadOnly: false);
+                    var code = _outputBuilder.BeginCSharpCode();
 
-                _outputBuilder.EndGetter();
-                _outputBuilder.EndBody();
-                _outputBuilder.EndIndexer();
+                    code.WriteIndented("fixed (");
+                    code.Write(arrayTypeName);
+                    code.Write("* pThis = &");
+                    code.Write(firstFieldName);
+                    code.WriteLine(')');
+                    code.WriteBlockStart();
+                    code.WriteIndented("return ref pThis[index]");
+                    code.WriteSemicolon();
+                    code.WriteNewline();
+                    code.WriteBlockEnd();
+                    _outputBuilder.EndCSharpCode(code);
+
+                    _outputBuilder.EndGetter();
+                    _outputBuilder.EndBody();
+                    _outputBuilder.EndIndexer();
+                }
             }
             else if (totalSizeString is null)
             {
+                // This non-compatible path uses Unsafe.Add/AsSpan()[index], which only accept an int
+                // index, so it only emits the int indexer. Adding uint/nint/nuint overloads here is
+                // deferred -- it needs casts or different helpers -- see #450 which covered the
+                // compatible fixed (T* pThis...) path above.
                 _outputBuilder.BeginIndexer(AccessSpecifier.Public, isUnsafe: false, needsUnscopedRef: !_config.GenerateCompatibleCode);
                 _outputBuilder.WriteIndexer($"ref {arrayTypeName}");
                 _outputBuilder.BeginIndexerParameters();

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -233,6 +233,8 @@ public sealed class PInvokeGeneratorConfiguration
 
     public bool GenerateFileScopedNamespaces => (_options & PInvokeGeneratorConfigurationOptions.GenerateFileScopedNamespaces) != 0;
 
+    public bool GenerateFixedBufferIndexerOverloads => (_options & PInvokeGeneratorConfigurationOptions.GenerateFixedBufferIndexerOverloads) != 0;
+
     public bool GenerateGenericPointerWrapper => (_options & PInvokeGeneratorConfigurationOptions.GenerateGenericPointerWrapper) != 0;
 
     public bool GenerateGuidMember => (_options & PInvokeGeneratorConfigurationOptions.GenerateGuidMember) != 0;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -90,4 +90,6 @@ public enum PInvokeGeneratorConfigurationOptions : long
     StripEnumMemberTypeName = 1L << 39,
 
     DontUseUsingStaticsForGuidMember = 1L << 40,
+
+    GenerateFixedBufferIndexerOverloads = 1L << 41,
 }

--- a/sources/ClangSharpPInvokeGenerator/Program.Options.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.Options.cs
@@ -158,6 +158,7 @@ internal static partial class Program
         new TwoColumnHelpRow("generate-disable-runtime-marshalling", "[assembly: DisableRuntimeMarshalling] should be generated."),
         new TwoColumnHelpRow("generate-doc-includes", "<include> xml documentation tags should be generated for declarations."),
         new TwoColumnHelpRow("generate-file-scoped-namespaces", "Namespaces should be scoped to the file to reduce nesting."),
+        new TwoColumnHelpRow("generate-fixed-buffer-indexer-overloads", "Fixed sized buffer helper types should generate additional uint, nint, and nuint indexer overloads."),
         new TwoColumnHelpRow("generate-guid-member", "Types with an associated GUID should have a corresponding member generated."),
         new TwoColumnHelpRow("generate-helper-types", "Code files should be generated for various helper attributes and declared transparent structs."),
         new TwoColumnHelpRow("generate-macro-bindings", "Bindings for macro-definitions should be generated. This currently only works with value like macros and not function-like ones."),

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -379,6 +379,12 @@ internal static partial class Program
                     break;
                 }
 
+                case "generate-fixed-buffer-indexer-overloads":
+                {
+                    configOptions |= PInvokeGeneratorConfigurationOptions.GenerateFixedBufferIndexerOverloads;
+                    break;
+                }
+
                 case "generate-guid-member":
                 {
                     configOptions |= PInvokeGeneratorConfigurationOptions.GenerateGuidMember;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FixedBufferIndexerOverloadsTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FixedBufferIndexerOverloadsTest.cs
@@ -1,0 +1,150 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>
+/// Tests for https://github.com/dotnet/ClangSharp/issues/450.
+/// When <c>generate-fixed-buffer-indexer-overloads</c> is set, the generated <c>_e__FixedBuffer</c>
+/// helper struct should expose additional <c>uint</c>, <c>nint</c>, and <c>nuint</c> indexers alongside
+/// the default <c>int</c> one so callers can index without casting. Without the switch, only the
+/// <c>int</c> indexer is generated.
+/// </summary>
+[Platform("win")]
+public sealed class FixedBufferIndexerOverloadsTest : PInvokeGeneratorTest
+{
+    [Test]
+    public Task GeneratesOverloadsWhenEnabled()
+    {
+        var inputContents = @"struct MyStruct
+{
+    int value;
+};
+
+struct MyOtherStruct
+{
+    MyStruct c[3];
+};
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int value;
+    }
+
+    public partial struct MyOtherStruct
+    {
+        [NativeTypeName(""MyStruct[3]"")]
+        public _c_e__FixedBuffer c;
+
+        public partial struct _c_e__FixedBuffer
+        {
+            public MyStruct e0;
+            public MyStruct e1;
+            public MyStruct e2;
+
+            public unsafe ref MyStruct this[int index]
+            {
+                get
+                {
+                    fixed (MyStruct* pThis = &e0)
+                    {
+                        return ref pThis[index];
+                    }
+                }
+            }
+
+            public unsafe ref MyStruct this[uint index]
+            {
+                get
+                {
+                    fixed (MyStruct* pThis = &e0)
+                    {
+                        return ref pThis[index];
+                    }
+                }
+            }
+
+            public unsafe ref MyStruct this[nint index]
+            {
+                get
+                {
+                    fixed (MyStruct* pThis = &e0)
+                    {
+                        return ref pThis[index];
+                    }
+                }
+            }
+
+            public unsafe ref MyStruct this[nuint index]
+            {
+                get
+                {
+                    fixed (MyStruct* pThis = &e0)
+                    {
+                        return ref pThis[index];
+                    }
+                }
+            }
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateFixedBufferIndexerOverloads);
+    }
+
+    [Test]
+    public Task GeneratesOnlyIntIndexerWhenDisabled()
+    {
+        var inputContents = @"struct MyStruct
+{
+    int value;
+};
+
+struct MyOtherStruct
+{
+    MyStruct c[3];
+};
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int value;
+    }
+
+    public partial struct MyOtherStruct
+    {
+        [NativeTypeName(""MyStruct[3]"")]
+        public _c_e__FixedBuffer c;
+
+        public partial struct _c_e__FixedBuffer
+        {
+            public MyStruct e0;
+            public MyStruct e1;
+            public MyStruct e2;
+
+            public unsafe ref MyStruct this[int index]
+            {
+                get
+                {
+                    fixed (MyStruct* pThis = &e0)
+                    {
+                        return ref pThis[index];
+                    }
+                }
+            }
+        }
+    }
+}
+";
+
+        return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(inputContents, expectedOutputContents);
+    }
+}


### PR DESCRIPTION
Adds an opt-in `generate-fixed-buffer-indexer-overloads` config switch (`GenerateFixedBufferIndexerOverloads`). When set, the compatible-codegen `_e__FixedBuffer` helper emits `uint`, `nint`, and `nuint` indexer overloads alongside the default `ref T this[int index]` one, so callers can index without casting. Pointer element access accepts all four index types, so the getter body is identical for each overload.

The switch defaults off, so the emitted `int` indexer is byte-identical and there is zero golden churn -- default-off correctness is covered by the existing goldens passing unchanged.

The non-compatible `Unsafe.Add`/`AsSpan()[index]` path only accepts an `int` index and is intentionally left as-is (those APIs have no `uint`/`nint`/`nuint` overloads without casts).

----------

The switch is not yet added to the `.rsp` files, so the self-hosted `sources/ClangSharp.Interop` bindings are unchanged. Enabling it there and regenerating can be a follow-up.

Fixes #450