### PR TITLE
Fix incorrect expectedCursorKind for UsingEnumDecl

### DIFF
--- a/sources/ClangSharp.Interop/Extensions/CXCursor.cs
+++ b/sources/ClangSharp.Interop/Extensions/CXCursor.cs
@@ -1785,6 +1785,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly CXCursor UsedContext => clangsharp.Cursor_getUsedContext(this);
 
+    public readonly CXCursor UsingEnumDeclEnumDecl => clangsharp.Cursor_getUsingEnumDeclEnumDecl(this);
+
     public readonly CXString Usr => clang.getCursorUSR(this);
 
     public readonly CXVisibilityKind Visibility => clang.getCursorVisibility(this);

--- a/sources/ClangSharp.Interop/clangsharp/clangsharp.cs
+++ b/sources/ClangSharp.Interop/clangsharp/clangsharp.cs
@@ -931,6 +931,9 @@ public static unsafe partial class @clangsharp
     [DllImport("libClangSharp", CallingConvention = CallingConvention.Cdecl, EntryPoint = "clangsharp_Cursor_getUsedContext", ExactSpelling = true)]
     public static extern CXCursor Cursor_getUsedContext(CXCursor C);
 
+    [DllImport("libClangSharp", CallingConvention = CallingConvention.Cdecl, EntryPoint = "clangsharp_Cursor_getUsingEnumDeclEnumDecl", ExactSpelling = true)]
+    public static extern CXCursor Cursor_getUsingEnumDeclEnumDecl(CXCursor C);
+
     [DllImport("libClangSharp", CallingConvention = CallingConvention.Cdecl, EntryPoint = "clangsharp_Cursor_getTypeParamHasExplicitBound", ExactSpelling = true)]
     [return: NativeTypeName("unsigned int")]
     public static extern uint Cursor_getTypeParamHasExplicitBound(CXCursor C);

--- a/sources/ClangSharp/Cursors/Decls/UsingEnumDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/UsingEnumDecl.cs
@@ -21,8 +21,5 @@ public sealed class UsingEnumDecl : BaseUsingDecl, IMergeable<UsingEnumDecl>
 
     public EnumDecl EnumDecl => _enumDecl.GetValue(this);
 
-    // TODO: `Handle.Definition` does not resolve to the referenced `EnumDecl` for a `using enum`
-    // (it surfaces as an empty `CXCursor_OverloadedDeclRef`); correctly resolving it requires a
-    // native libClangSharp shim wrapping `UsingEnumDecl::getEnumDecl()`. See dotnet/clangsharp #633.
-    private static unsafe EnumDecl EnumDeclFactory(UsingEnumDecl self) => self.TranslationUnit.GetOrCreate<EnumDecl>(self.Handle.Definition);
+    private static unsafe EnumDecl EnumDeclFactory(UsingEnumDecl self) => self.TranslationUnit.GetOrCreate<EnumDecl>(self.Handle.UsingEnumDeclEnumDecl);
 }

--- a/sources/ClangSharp/Cursors/Decls/UsingEnumDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/UsingEnumDecl.cs
@@ -10,7 +10,9 @@ public sealed class UsingEnumDecl : BaseUsingDecl, IMergeable<UsingEnumDecl>
 {
     private ValueLazy<UsingEnumDecl, EnumDecl> _enumDecl;
 
-    internal unsafe UsingEnumDecl(CXCursor handle) : base(handle, CXCursor_UnexposedDecl, CX_DeclKind_UsingEnum)
+    // libClang surfaces a `using enum` declaration with `cursor.kind == CXCursor_EnumDecl`, even
+    // though its `DeclKind` is `CX_DeclKind_UsingEnum`, so that is the expected cursor kind here.
+    internal unsafe UsingEnumDecl(CXCursor handle) : base(handle, CXCursor_EnumDecl, CX_DeclKind_UsingEnum)
     {
         _enumDecl = new ValueLazy<UsingEnumDecl, EnumDecl>(&EnumDeclFactory);
     }
@@ -19,5 +21,8 @@ public sealed class UsingEnumDecl : BaseUsingDecl, IMergeable<UsingEnumDecl>
 
     public EnumDecl EnumDecl => _enumDecl.GetValue(this);
 
+    // TODO: `Handle.Definition` does not resolve to the referenced `EnumDecl` for a `using enum`
+    // (it surfaces as an empty `CXCursor_OverloadedDeclRef`); correctly resolving it requires a
+    // native libClangSharp shim wrapping `UsingEnumDecl::getEnumDecl()`. See dotnet/clangsharp #633.
     private static unsafe EnumDecl EnumDeclFactory(UsingEnumDecl self) => self.TranslationUnit.GetOrCreate<EnumDecl>(self.Handle.Definition);
 }

--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -5049,6 +5049,18 @@ CXCursor clangsharp_Cursor_getUsedContext(CXCursor C) {
     return clang_getNullCursor();
 }
 
+CXCursor clangsharp_Cursor_getUsingEnumDeclEnumDecl(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const UsingEnumDecl* UED = dyn_cast<UsingEnumDecl>(D)) {
+            return MakeCXCursor(UED->getEnumDecl(), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getTypeParamHasExplicitBound(CXCursor C)
 {
     if (isDeclOrTU(C.kind)) {

--- a/sources/libClangSharp/ClangSharp.h
+++ b/sources/libClangSharp/ClangSharp.h
@@ -773,6 +773,8 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getUninstantiatedDefaultArg(CXCurs
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getUsedContext(CXCursor C);
 
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getUsingEnumDeclEnumDecl(CXCursor C);
+
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getTypeParamHasExplicitBound(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getTypeParamVariance(CXCursor C);

--- a/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
@@ -145,6 +145,33 @@ constexpr int MyVar<int, float> = 1;
     }
 
     [Test]
+    public void UsingEnumDeclTest()
+    {
+        // `using enum` requires C++20 and previously threw because UsingEnumDecl passed the wrong
+        // expectedCursorKind to the base Cursor ctor (libClang surfaces it as CXCursor_EnumDecl).
+        var inputContents = """
+enum class E { A, B };
+
+struct S {
+    using enum E;
+};
+""";
+
+        string[] commandLineArgs = ["-std=c++20", "-Wno-pragma-once-outside-header"];
+        using var translationUnit = CreateTranslationUnit(inputContents, commandLineArgs: commandLineArgs);
+
+        var structDecl = translationUnit.TranslationUnitDecl.Decls.OfType<CXXRecordDecl>().Single((recordDecl) => recordDecl.Name.Equals("S", StringComparison.Ordinal));
+        var usingEnumDecl = structDecl.Decls.OfType<UsingEnumDecl>().Single();
+
+        Assert.That(usingEnumDecl.Handle.kind, Is.EqualTo(CXCursorKind.CXCursor_EnumDecl));
+        Assert.That(usingEnumDecl.Handle.DeclKind, Is.EqualTo(CX_DeclKind.CX_DeclKind_UsingEnum));
+
+        // NOTE: usingEnumDecl.EnumDecl is not asserted here. Handle.Definition does not resolve to
+        // the referenced EnumDecl in the current native lib; a correct fix needs a native
+        // libClangSharp shim wrapping UsingEnumDecl::getEnumDecl(). See dotnet/clangsharp #633.
+    }
+
+    [Test]
     public void IsPodTest()
     {
         var inputContents = $$"""

--- a/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
@@ -165,10 +165,32 @@ struct S {
 
         Assert.That(usingEnumDecl.Handle.kind, Is.EqualTo(CXCursorKind.CXCursor_EnumDecl));
         Assert.That(usingEnumDecl.Handle.DeclKind, Is.EqualTo(CX_DeclKind.CX_DeclKind_UsingEnum));
+    }
 
-        // NOTE: usingEnumDecl.EnumDecl is not asserted here. Handle.Definition does not resolve to
-        // the referenced EnumDecl in the current native lib; a correct fix needs a native
-        // libClangSharp shim wrapping UsingEnumDecl::getEnumDecl(). See dotnet/clangsharp #633.
+    [Test]
+    public void UsingEnumDeclEnumDeclTest()
+    {
+        // Resolving UsingEnumDecl.EnumDecl relies on the native clangsharp_Cursor_getUsingEnumDeclEnumDecl
+        // shim, which the pinned 21.1 prebuilt package predates; skip until the native lib is rebuilt.
+        SkipUntilNativeRebuild();
+
+        var inputContents = """
+enum class E { A, B };
+
+struct S {
+    using enum E;
+};
+""";
+
+        string[] commandLineArgs = ["-std=c++20", "-Wno-pragma-once-outside-header"];
+        using var translationUnit = CreateTranslationUnit(inputContents, commandLineArgs: commandLineArgs);
+
+        var structDecl = translationUnit.TranslationUnitDecl.Decls.OfType<CXXRecordDecl>().Single((recordDecl) => recordDecl.Name.Equals("S", StringComparison.Ordinal));
+        var usingEnumDecl = structDecl.Decls.OfType<UsingEnumDecl>().Single();
+
+        var enumDecl = usingEnumDecl.EnumDecl;
+        Assert.That(enumDecl, Is.Not.Null);
+        Assert.That(enumDecl.Name, Is.EqualTo("E"));
     }
 
     [Test]
@@ -295,9 +317,10 @@ enum E {
         });
     }
 
-    // The fix for these lives in the native libClangSharp shim (clangsharp_Cursor_getNumTemplateArguments
-    // and clangsharp_Cursor_getTemplateArgument). The pinned 21.1 prebuilt native package predates it, so
-    // skip until the native lib is rebuilt for a newer libClang. Rebuilding off 21.1 auto-unskips these.
+    // Some tests depend on native libClangSharp shims that the pinned 21.1 prebuilt package predates
+    // (e.g. clangsharp_Cursor_getNumTemplateArguments / getTemplateArgument and
+    // clangsharp_Cursor_getUsingEnumDeclEnumDecl). Skip those until the native lib is rebuilt for a
+    // newer libClang. Rebuilding off 21.1 auto-unskips them.
     private static void SkipUntilNativeRebuild()
     {
         using var versionString = clang.getClangVersion();

--- a/tests/ClangSharp.UnitTests/TranslationUnitTest.cs
+++ b/tests/ClangSharp.UnitTests/TranslationUnitTest.cs
@@ -24,7 +24,7 @@ public abstract class TranslationUnitTest
         "-Wno-pragma-once-outside-header"       // We are processing files which may be header files
     ];
 
-    protected static TranslationUnit CreateTranslationUnit(string inputContents, string language = "c++" /* input files are C++ by default */)
+    protected static TranslationUnit CreateTranslationUnit(string inputContents, string language = "c++" /* input files are C++ by default */, string[]? commandLineArgs = null)
     {
         Assert.That(DefaultInputFileName, Does.Exist);
 
@@ -32,7 +32,7 @@ public abstract class TranslationUnitTest
         var unsavedFiles = new CXUnsavedFile[] { unsavedFile };
 
         var index = CXIndex.Create();
-        var arguments = new List<string>(DefaultClangCommandLineArgs)
+        var arguments = new List<string>(commandLineArgs ?? DefaultClangCommandLineArgs)
         {
             "-x",
             language,


### PR DESCRIPTION
Fixes #633.

`UsingEnumDecl` passed `CXCursor_UnexposedDecl` as its expected cursor kind, but libClang surfaces a `using enum` declaration with `cursor.kind == CXCursor_EnumDecl` (its `DeclKind` is `CX_DeclKind_UsingEnum`). The base `Cursor` ctor kind-check therefore threw `ArgumentOutOfRangeException` when walking any decl tree that contained a `using enum`. Fixed by expecting `CXCursor_EnumDecl`.

----------

Also resolves `UsingEnumDecl.EnumDecl`. `Handle.Definition` surfaces as an empty `CXCursor_OverloadedDeclRef` for a `using enum`, so the accessor could not resolve the referenced enum. Added a native `clangsharp_Cursor_getUsingEnumDeclEnumDecl` shim wrapping clang's `UsingEnumDecl::getEnumDecl()`, exposed the matching interop, and routed `EnumDeclFactory` through it.

The two changes are split into separate commits:
- **9fad0459** `Fix incorrect expectedCursorKind for UsingEnumDecl` — managed-only, fully verified here (unguarded construction test).
- **0bfb5818** `Resolve UsingEnumDecl.EnumDecl via a native getEnumDecl shim` — the native shim + interop. The pinned 21.1 prebuilt `libClangSharp` package predates the new entry point, so its `UsingEnumDeclEnumDeclTest` is guarded by `SkipUntilNativeRebuild` and stays skipped until the native lib is rebuilt for a newer libClang. **This commit needs a native `libClangSharp` rebuild to validate.**

Tests: `dotnet test tests/ClangSharp.UnitTests` -> 56 passed, 3 skipped (2 pre-existing template-arg + the new guarded accessor test), 0 failed. Build is clean (0 warnings). No generator/golden churn.