### PR TITLE
Ensure SAL/C++ attributes on fields generate a CppAttributeList

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/FieldDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/FieldDesc.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Collections.Generic;
 using ClangSharp.Interop;
 
 namespace ClangSharp.Abstractions;
@@ -9,6 +10,7 @@ internal struct FieldDesc
 {
     public AccessSpecifier AccessSpecifier { get; set; }
     public string? NativeTypeName { get; set; }
+    public IEnumerable<string>? CppAttributes { get; set; }
     public string EscapedName { get; set; }
     public string ParentName { get; set; }
     public int? Offset { get; set; }

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -308,6 +308,11 @@ internal partial class CSharpOutputBuilder : IOutputBuilder
             AddNativeTypeNameAttribute(desc.NativeTypeName);
         }
 
+        if (desc.CppAttributes is not null)
+        {
+            AddCppAttributes(desc.CppAttributes);
+        }
+
         if (desc.Location is { } location)
         {
             WriteSourceLocation(location, false);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -449,6 +449,9 @@ public partial class PInvokeGenerator
         var desc = new FieldDesc {
             AccessSpecifier = accessSpecifier,
             NativeTypeName = nativeTypeName,
+            CppAttributes = _config.GenerateCppAttributes
+                ? fieldDecl.Attrs.Select(x => EscapeString(x.Spelling))
+                : null,
             EscapedName = escapedName,
             ParentName = GetRemappedCursorName(parent),
             Offset = offset,

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/SalFieldAttributeTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/SalFieldAttributeTest.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>
+/// Regression test for https://github.com/dotnet/ClangSharp/issues/444.
+/// Under <c>generate-cpp-attributes</c>, a C++ attribute (e.g. a SAL <c>_Field_size_full_</c>
+/// annotation surfaced as an <c>annotate</c> attribute) on a struct field was not emitted as a
+/// <c>[CppAttributeList("...")]</c>, even though the same attribute on a parameter was. Fields now
+/// emit the attribute the same way parameters do.
+/// </summary>
+[Platform("win")]
+public sealed class SalFieldAttributeTest : PInvokeGeneratorTest
+{
+    private const string InputContents = @"#define _Field_size_full_(x) __attribute__((annotate(""_Field_size_full_("" #x "")"")))
+
+struct MyStruct
+{
+    int count;
+    _Field_size_full_(count) int* data;
+};
+";
+
+    [Test]
+    public Task FieldSalAnnotationGeneratesCppAttributeList()
+    {
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public unsafe partial struct MyStruct
+    {
+        public int count;
+
+        [CppAttributeList(""_Field_size_full_(count)"")]
+        [NativeAnnotation(""_Field_size_full_(count)"")]
+        public int* data;
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new Diagnostic(DiagnosticLevel.Warning, "Function like macro definition records are not supported: '_Field_size_full_'. Generated bindings may be incomplete.", "Line 1, Column 9 in ClangUnsavedFile.h")
+        };
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(InputContents, expectedOutputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateCppAttributes, expectedDiagnostics: expectedDiagnostics);
+    }
+}


### PR DESCRIPTION
Under `generate-cpp-attributes`, a C++ attribute on a parameter was surfaced as `[CppAttributeList("...")]`, but the same attribute on a struct field was silently dropped. `CppAttributes` was only ever wired for `ParameterDesc`/`BeginParameter`, never for `FieldDesc`/`BeginField`, so SAL buffer annotations (e.g. `_Field_size_full_`, `_Field_size_`) surfaced as `annotate` attributes never reached the field's `CppAttributeList`.

This mirrors the existing parameter path for fields:

- `Abstractions/FieldDesc.cs` — add `IEnumerable<string>? CppAttributes`.
- `PInvokeGenerator.VisitDecl.cs` `VisitFieldDecl` — populate it from `fieldDecl.Attrs` when `GenerateCppAttributes` is set (identical shape to the parameter path).
- `CSharp/CSharpOutputBuilder.VisitDecl.cs` `BeginField` — emit it via `AddCppAttributes`, right after the `NativeTypeName` block so ordering matches parameters (`CppAttributeList` before `NativeAnnotation`).

`CppAttributeList` is the opt-in, full-fidelity dump of the raw C++ attribute list (all kinds, `^`-joined, gated on `generate-cpp-attributes`), distinct from the always-on `NativeAnnotation` that surfaces only `annotate` spellings. Only the former was missing on fields.

Example (field now matches the equivalent parameter):

```cpp
#define _Field_size_full_(x) __attribute__((annotate("_Field_size_full_(" #x ")")))
struct MyStruct { int count; _Field_size_full_(count) int* data; };
```

```csharp
[CppAttributeList("_Field_size_full_(count)")]
[NativeAnnotation("_Field_size_full_(count)")]
public int* data;
```

----------

Adds a standalone regression test (`SalFieldAttributeTest`, `[Platform("win")]`) under `generate-cpp-attributes` asserting the field's `CppAttributeList`. No existing goldens changed (no prior test enabled `generate-cpp-attributes`). Full `ClangSharp.PInvokeGenerator.UnitTests` run: 3725 passed, 0 failed, 0 warnings.

The indirect-field accessor path (nested-anonymous accessor properties) is intentionally left out of scope.

Fixes #444

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
