### PR TITLE
Fix compatible-mode remap of pointer-to-fnptr-typedef fields

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
@@ -705,9 +705,19 @@ public sealed partial class PInvokeGenerator
 
             if (wasRemapped)
             {
-                name = isTemplate && Config.GenerateGenericPointerWrapper
-                     ? $"Pointer<{remappedName}>"
-                     : $"{remappedName}*";
+                if (_config.ExcludeFnptrCodegen && IsType<FunctionType>(cursor, typedefType.Decl.UnderlyingType))
+                {
+                    // In compatible mode the typedef resolves to a managed delegate, so a
+                    // pointer to it is a pointer to a managed type and is invalid. Match the
+                    // non-remapped path and emit IntPtr instead.
+                    name = "IntPtr";
+                }
+                else
+                {
+                    name = isTemplate && Config.GenerateGenericPointerWrapper
+                         ? $"Pointer<{remappedName}>"
+                         : $"{remappedName}*";
+                }
             }
             else
             {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionPointerRemapTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/FunctionPointerRemapTest.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>
+/// Regression test for https://github.com/dotnet/ClangSharp/issues/462.
+/// In compatible mode a function-pointer typedef is emitted as a managed delegate, so a field that
+/// is a pointer to that typedef must be emitted as <c>IntPtr</c> (a pointer to a managed type is
+/// invalid and produces CS8500). Remapping the typedef must not change that: only the delegate name
+/// is renamed while the field stays <c>IntPtr</c> and the containing struct stays non-<c>unsafe</c>.
+/// </summary>
+public sealed class FunctionPointerRemapTest : PInvokeGeneratorTest
+{
+    private const string InputContents = @"typedef void (ApiPFoo)(int);
+struct ApiCallbacks { ApiPFoo* Foo; };
+";
+
+    private static readonly Dictionary<string, string> RemappedNames = new()
+    {
+        ["ApiCallbacks"] = "Callbacks",
+        ["ApiPFoo"] = "PFoo"
+    };
+
+    private const string ExpectedOutputContents = @"using System;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void PFoo(int param0);
+
+    public partial struct Callbacks
+    {
+        [NativeTypeName(""ApiPFoo *"")]
+        public IntPtr Foo;
+    }
+}
+";
+
+    [Test]
+    public Task RemappedFnptrTypedefFieldStaysIntPtrWindows()
+    {
+        return ValidateGeneratedCSharpCompatibleWindowsBindingsAsync(InputContents, ExpectedOutputContents, remappedNames: RemappedNames, commandLineArgs: DefaultCClangCommandLineArgs, language: "c", languageStandard: DefaultCStandard);
+    }
+
+    [Test]
+    public Task RemappedFnptrTypedefFieldStaysIntPtrUnix()
+    {
+        return ValidateGeneratedCSharpCompatibleUnixBindingsAsync(InputContents, ExpectedOutputContents, remappedNames: RemappedNames, commandLineArgs: DefaultCClangCommandLineArgs, language: "c", languageStandard: DefaultCStandard);
+    }
+}


### PR DESCRIPTION
In compatible mode (`ExcludeFnptrCodegen`) a function-pointer typedef is emitted as a managed delegate. `GetTypeNameForPointeeType` short-circuited a remapped typedef to a pointer of the remapped name, so a field pointing at such a typedef emitted a pointer to the managed delegate (e.g. `PFoo*`), which is invalid -- it produces `CS8500` and forces the containing struct `unsafe`.

Given:
```c
typedef void (ApiPFoo)(int);
struct ApiCallbacks { ApiPFoo* Foo; };
```
with `--remap ApiCallbacks=Callbacks ApiPFoo=PFoo` in compatible mode.

Before:
```csharp
public unsafe partial struct Callbacks
{
    [NativeTypeName("ApiPFoo *")]
    public PFoo* Foo;
}
```

After (matches the no-remap case; the delegate is still renamed to `PFoo`, only the field changes):
```csharp
public partial struct Callbacks
{
    [NativeTypeName("ApiPFoo *")]
    public IntPtr Foo;
}
```

The fix mirrors the non-remapped path: in the `wasRemapped` branch, when `ExcludeFnptrCodegen` is set and the typedef's underlying type is a function type, emit `IntPtr`. The `unsafe` modifier drops automatically once the field is `IntPtr`.

----------

Scoped to compatible mode only. Latest/preview (function-pointer) codegen for remapped fnptr typedefs is intentionally untouched -- there's no named delegate there, so the correct rendering is a separate, ill-defined design question.

Added `FunctionPointerRemapTest` covering compatible Windows + Unix. Full generator suite passes (Failed: 0, Passed: 3726), zero golden churn.

Fixes #462