### PR TITLE
Lower a type remapped to a fixed-size buffer to a pointer

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -812,6 +812,19 @@ public sealed partial class PInvokeGenerator
             nativeTypeName = string.Empty;
         }
 
+        if (remappedName.IndexOf('[', StringComparison.Ordinal) is int bracketIndex and >= 0 &&
+            (bracketIndex + 1) < remappedName.Length && char.IsAsciiDigit(remappedName[bracketIndex + 1]))
+        {
+            // A type remapped to a fixed-size-buffer shape, such as `sbyte[8]`, is not a
+            // legal C# type in an unmanaged signature. Lower it to the equivalent pointer,
+            // matching how C decays an array to a pointer at the ABI boundary. This also
+            // ensures the containing member is correctly detected as unsafe via the `*`.
+            // A managed array such as `int[]` has an empty subscript and is left untouched.
+
+            var rank = remappedName.AsSpan().Count('[');
+            remappedName = string.Concat(remappedName.AsSpan(0, bracketIndex), new string('*', rank));
+        }
+
         return remappedName;
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/UnsafeFixedSizeBufferTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/UnsafeFixedSizeBufferTest.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+public sealed class UnsafeFixedSizeBufferTest : PInvokeGeneratorTest
+{
+    [Test]
+    public Task RemappedFixedSizeBufferLowersToPointerAndMarksClassUnsafe()
+    {
+        var inputContents = @"typedef int MyBuffer;
+
+extern ""C"" void MyFunction(MyBuffer value);
+extern ""C"" MyBuffer MyOtherFunction();";
+
+        var expectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public static unsafe partial class Methods
+    {
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void MyFunction([NativeTypeName(""MyBuffer"")] sbyte* value);
+
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName(""MyBuffer"")]
+        public static extern sbyte* MyOtherFunction();
+    }
+}
+";
+
+        var remappedNames = new Dictionary<string, string> {
+            ["MyBuffer"] = "sbyte[8]"
+        };
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, remappedNames: remappedNames);
+    }
+}


### PR DESCRIPTION
A type remapped to a fixed-size-buffer shape such as `sbyte[8]` was emitted verbatim, which is not a legal C# type in an unmanaged signature and was not detected as unsafe (yielding `CS0214`). Lower it to the equivalent pointer in `GetRemappedTypeName`, matching how C decays an array to a pointer at the ABI boundary. This makes the emission legal and marks the containing member `unsafe` via the existing `*` check.

The lowering is gated on a numeric subscript (`[<digit>`), so a managed array such as `int[]` (empty subscript) is left untouched.

----------

Notably, no legal C input reaches this path -- real array parameters/returns already decay to `*`, pointer-to-array (`int (*)[8]`) decays to `int**`, and array fields lower to `_e__FixedBuffer`/`InlineArray`/`fixed`. The only trigger is an explicit `--remap X=T[N]`, so this supersedes the substring `]` heuristic previously considered for #593; pointer lowering is both legal and correctly `unsafe`.

Fixes #593

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
