### PR TITLE
Add a log-invalid-remappings switch for ABI-illegal remappings

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -812,6 +812,16 @@ public sealed partial class PInvokeGenerator
             nativeTypeName = string.Empty;
         }
 
+        if (TryLowerFixedSizeBufferRemapping(remappedName, out var loweredName))
+        {
+            remappedName = loweredName;
+        }
+
+        return remappedName;
+    }
+
+    private static bool TryLowerFixedSizeBufferRemapping(string remappedName, out string loweredName)
+    {
         if (remappedName.IndexOf('[', StringComparison.Ordinal) is int bracketIndex and >= 0 &&
             (bracketIndex + 1) < remappedName.Length && char.IsAsciiDigit(remappedName[bracketIndex + 1]))
         {
@@ -822,10 +832,12 @@ public sealed partial class PInvokeGenerator
             // A managed array such as `int[]` has an empty subscript and is left untouched.
 
             var rank = remappedName.AsSpan().Count('[');
-            remappedName = string.Concat(remappedName.AsSpan(0, bracketIndex), new string('*', rank));
+            loweredName = string.Concat(remappedName.AsSpan(0, bracketIndex), new string('*', rank));
+            return true;
         }
 
-        return remappedName;
+        loweredName = remappedName;
+        return false;
     }
 }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -523,6 +523,20 @@ public sealed partial class PInvokeGenerator : IDisposable
                     return result;
                 }
             }
+
+            if (_config.LogInvalidRemappings)
+            {
+                foreach (var kvp in _config._remappedNames)
+                {
+                    var name = kvp.Key;
+                    var remappedName = kvp.Value;
+
+                    if (TryLowerFixedSizeBufferRemapping(remappedName, out var loweredName))
+                    {
+                        AddDiagnostic(DiagnosticLevel.Info, $"Potential invalid remapping '{name}={remappedName}'. A fixed-size-buffer type is not directly expressible in an unmanaged signature; it was lowered to the pointer '{loweredName}'.");
+                    }
+                }
+            }
         }
         catch (Exception e)
         {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -311,6 +311,8 @@ public sealed class PInvokeGeneratorConfiguration
 
     public bool LogPotentialTypedefRemappings => (_options & PInvokeGeneratorConfigurationOptions.LogPotentialTypedefRemappings) != 0;
 
+    public bool LogInvalidRemappings => (_options & PInvokeGeneratorConfigurationOptions.LogInvalidRemappings) != 0;
+
     public bool LogVisitedFiles => (_options & PInvokeGeneratorConfigurationOptions.LogVisitedFiles) != 0;
 
     [AllowNull]

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -92,4 +92,6 @@ public enum PInvokeGeneratorConfigurationOptions : long
     DontUseUsingStaticsForGuidMember = 1L << 40,
 
     GenerateFixedBufferIndexerOverloads = 1L << 41,
+
+    LogInvalidRemappings = 1L << 42,
 }

--- a/sources/ClangSharpPInvokeGenerator/Program.Options.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.Options.cs
@@ -182,6 +182,7 @@ internal static partial class Program
         new TwoColumnHelpRow("", ""),
 
         new TwoColumnHelpRow("log-exclusions", "A list of excluded declaration types should be generated. This will also log if the exclusion was due to an exact or partial match."),
+        new TwoColumnHelpRow("log-invalid-remappings", "A diagnostic should be generated for each remapping whose value is not directly expressible in an unmanaged signature, such as a fixed-size-buffer shape that was lowered to a pointer."),
         new TwoColumnHelpRow("log-potential-typedef-remappings", "A list of potential typedef remappings should be generated. This can help identify missing remappings."),
         new TwoColumnHelpRow("log-visited-files", "A list of the visited files should be generated. This can help identify traversal issues."),
     ];

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -459,6 +459,12 @@ internal static partial class Program
                     break;
                 }
 
+                case "log-invalid-remappings":
+                {
+                    configOptions |= PInvokeGeneratorConfigurationOptions.LogInvalidRemappings;
+                    break;
+                }
+
                 case "log-potential-typedef-remappings":
                 {
                     configOptions |= PInvokeGeneratorConfigurationOptions.LogPotentialTypedefRemappings;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/LogInvalidRemappingsTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/LogInvalidRemappingsTest.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+public sealed class LogInvalidRemappingsTest : PInvokeGeneratorTest
+{
+    [Test]
+    public Task FixedSizeBufferRemappingIsLoggedAndLoweredToPointer()
+    {
+        var inputContents = @"typedef int MyBuffer;
+
+extern ""C"" void MyFunction(MyBuffer value);
+extern ""C"" MyBuffer MyOtherFunction();";
+
+        var expectedOutputContents = @"using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public static unsafe partial class Methods
+    {
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void MyFunction([NativeTypeName(""MyBuffer"")] sbyte* value);
+
+        [DllImport(""ClangSharpPInvokeGenerator"", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName(""MyBuffer"")]
+        public static extern sbyte* MyOtherFunction();
+    }
+}
+";
+
+        var remappedNames = new Dictionary<string, string> {
+            ["MyBuffer"] = "sbyte[8]"
+        };
+
+        var expectedDiagnostics = new[] {
+            new Diagnostic(DiagnosticLevel.Info, "Potential invalid remapping 'MyBuffer=sbyte[8]'. A fixed-size-buffer type is not directly expressible in an unmanaged signature; it was lowered to the pointer 'sbyte*'.")
+        };
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.LogInvalidRemappings, remappedNames: remappedNames, expectedDiagnostics: expectedDiagnostics);
+    }
+}


### PR DESCRIPTION
This adds a new opt-in `--log-invalid-remappings` config switch that emits a `DiagnosticLevel.Info` diagnostic for each configured remapping whose value is structurally not a legal unmanaged type name, scoped precisely to the array/fixed-buffer shape (a numeric subscript `[<digit>`, the same rule as the lowering, so a managed `int[]` with an empty subscript is left untouched).

The message names the remapping and states the applied lowering, e.g.:

> Potential invalid remapping 'MyBuffer=sbyte[8]'. A fixed-size-buffer type is not directly expressible in an unmanaged signature; it was lowered to the pointer 'sbyte*'.

The lowering used to compute the shown pointer is factored into a shared `TryLowerFixedSizeBufferRemapping` helper so the diagnostic and `GetRemappedTypeName` can't drift.

----------

This builds on #745 (the fixed-size-buffer-to-pointer lowering), which has since merged; the branch is based directly on that commit so the diff here is just the diagnostic feature.