### PR TITLE
Don't emit duplicate members for structs with multiple vtbl bases

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
@@ -532,7 +532,7 @@ public partial class PInvokeGenerator
 
                 if (hasVtbl || hasBaseVtbl)
                 {
-                    OutputDelegateSignatures(cxxRecordDecl, cxxRecordDecl);
+                    OutputDelegateSignatures(cxxRecordDecl, cxxRecordDecl, new HashSet<string>(StringComparer.Ordinal));
                 }
             }
 
@@ -565,7 +565,7 @@ public partial class PInvokeGenerator
                     _outputBuilder.EmitFnPtrSupport();
                 }
 
-                OutputVtblHelperMethods(cxxRecordDecl, cxxRecordDecl);
+                OutputVtblHelperMethods(cxxRecordDecl, cxxRecordDecl, new HashSet<string>(StringComparer.Ordinal));
 
                 if (_config.GenerateMarkerInterfaces)
                 {
@@ -587,7 +587,7 @@ public partial class PInvokeGenerator
                     }
 
                     _outputBuilder.BeginExplicitVtbl();
-                    OutputVtblEntries(cxxRecordDecl, cxxRecordDecl);
+                    OutputVtblEntries(cxxRecordDecl, cxxRecordDecl, new HashSet<string>(StringComparer.Ordinal));
                     _outputBuilder.EndExplicitVtbl();
                 }
             }
@@ -618,7 +618,7 @@ public partial class PInvokeGenerator
             return remappedName;
         }
 
-        void OutputDelegateSignatures(CXXRecordDecl rootCxxRecordDecl, CXXRecordDecl cxxRecordDecl)
+        void OutputDelegateSignatures(CXXRecordDecl rootCxxRecordDecl, CXXRecordDecl cxxRecordDecl, HashSet<string> emittedMemberNames)
         {
             if (!_config.ExcludeFnptrCodegen)
             {
@@ -628,7 +628,7 @@ public partial class PInvokeGenerator
             foreach (var cxxBaseSpecifier in cxxRecordDecl.Bases)
             {
                 var baseCxxRecordDecl = GetRecordDecl(cxxBaseSpecifier);
-                OutputDelegateSignatures(rootCxxRecordDecl, baseCxxRecordDecl);
+                OutputDelegateSignatures(rootCxxRecordDecl, baseCxxRecordDecl, emittedMemberNames);
             }
 
             var cxxMethodDecls = cxxRecordDecl.Methods;
@@ -647,9 +647,15 @@ public partial class PInvokeGenerator
                         continue;
                     }
 
+                    var remappedName = FixupNameForMultipleHits(cxxMethodDecl);
+
+                    if (!emittedMemberNames.Add(GetVtblMemberDeduplicationKey(remappedName, cxxMethodDecl)))
+                    {
+                        continue;
+                    }
+
                     _outputBuilder.WriteDivider();
 
-                    var remappedName = FixupNameForMultipleHits(cxxMethodDecl);
                     Debug.Assert(CurrentContext.Cursor == rootCxxRecordDecl);
                     Visit(cxxMethodDecl);
                 }
@@ -772,12 +778,12 @@ public partial class PInvokeGenerator
             }
         }
 
-        void OutputVtblEntries(CXXRecordDecl rootCxxRecordDecl, CXXRecordDecl cxxRecordDecl)
+        void OutputVtblEntries(CXXRecordDecl rootCxxRecordDecl, CXXRecordDecl cxxRecordDecl, HashSet<string> emittedMemberNames)
         {
             foreach (var cxxBaseSpecifier in cxxRecordDecl.Bases)
             {
                 var baseCxxRecordDecl = GetRecordDecl(cxxBaseSpecifier);
-                OutputVtblEntries(rootCxxRecordDecl, baseCxxRecordDecl);
+                OutputVtblEntries(rootCxxRecordDecl, baseCxxRecordDecl, emittedMemberNames);
             }
 
             var cxxMethodDecls = cxxRecordDecl.Methods;
@@ -786,12 +792,12 @@ public partial class PInvokeGenerator
             {
                 foreach (var cxxMethodDecl in cxxMethodDecls.OrderBy((cxxmd) => cxxmd.VtblIndex))
                 {
-                    OutputVtblEntry(rootCxxRecordDecl, cxxMethodDecl);
+                    OutputVtblEntry(rootCxxRecordDecl, cxxMethodDecl, emittedMemberNames);
                 }
             }
         }
 
-        void OutputVtblEntry(CXXRecordDecl cxxRecordDecl, CXXMethodDecl cxxMethodDecl)
+        void OutputVtblEntry(CXXRecordDecl cxxRecordDecl, CXXMethodDecl cxxMethodDecl, HashSet<string> emittedMemberNames)
         {
             if (!cxxMethodDecl.IsVirtual)
             {
@@ -813,6 +819,11 @@ public partial class PInvokeGenerator
 
             var remappedName = FixupNameForMultipleHits(cxxMethodDecl);
             var escapedName = EscapeAndStripMethodName(remappedName);
+
+            if (!emittedMemberNames.Add(GetVtblMemberDeduplicationKey(escapedName, cxxMethodDecl)))
+            {
+                return;
+            }
 
             var desc = new FieldDesc {
                 AccessSpecifier = AccessSpecifier.Public,
@@ -837,7 +848,7 @@ public partial class PInvokeGenerator
             _outputBuilder.WriteDivider();
         }
 
-        void OutputVtblHelperMethod(CXXRecordDecl cxxRecordDecl, CXXMethodDecl cxxMethodDecl)
+        void OutputVtblHelperMethod(CXXRecordDecl cxxRecordDecl, CXXMethodDecl cxxMethodDecl, HashSet<string> emittedMemberNames)
         {
             if (!cxxMethodDecl.IsVirtual)
             {
@@ -845,6 +856,11 @@ public partial class PInvokeGenerator
             }
 
             if (IsExcluded(cxxMethodDecl, out var isExcludedByConflictingDefinition))
+            {
+                return;
+            }
+
+            if (!emittedMemberNames.Add(GetVtblMemberDeduplicationKey(EscapeAndStripMethodName(GetRemappedCursorName(cxxMethodDecl)), cxxMethodDecl)))
             {
                 return;
             }
@@ -1092,12 +1108,12 @@ public partial class PInvokeGenerator
             _context.RemoveLast();
         }
 
-        void OutputVtblHelperMethods(CXXRecordDecl rootCxxRecordDecl, CXXRecordDecl cxxRecordDecl)
+        void OutputVtblHelperMethods(CXXRecordDecl rootCxxRecordDecl, CXXRecordDecl cxxRecordDecl, HashSet<string> emittedMemberNames)
         {
             foreach (var cxxBaseSpecifier in cxxRecordDecl.Bases)
             {
                 var baseCxxRecordDecl = GetRecordDecl(cxxBaseSpecifier);
-                OutputVtblHelperMethods(rootCxxRecordDecl, baseCxxRecordDecl);
+                OutputVtblHelperMethods(rootCxxRecordDecl, baseCxxRecordDecl, emittedMemberNames);
             }
 
             var cxxMethodDecls = cxxRecordDecl.Methods;
@@ -1107,7 +1123,7 @@ public partial class PInvokeGenerator
                 foreach (var cxxMethodDecl in cxxMethodDecls.OrderBy((cxxmd) => cxxmd.VtblIndex))
                 {
                     _outputBuilder.WriteDivider();
-                    OutputVtblHelperMethod(rootCxxRecordDecl, cxxMethodDecl);
+                    OutputVtblHelperMethod(rootCxxRecordDecl, cxxMethodDecl, emittedMemberNames);
                 }
             }
         }
@@ -2022,5 +2038,30 @@ public partial class PInvokeGenerator
                 testOutputStarted = true;
             }
         }
+    }
+
+    // Multiple base classes can each contribute a virtual member that maps to the same C# name and
+    // signature (most notably each base's virtual destructor becoming `Dispose`). The single `lpVtbl`
+    // model flattens every base into one vtable, so the same member would otherwise be emitted more
+    // than once, which is a compile error. This builds a key of the emitted name plus the canonical
+    // parameter types so that legitimate overloads remain distinct. See https://github.com/dotnet/ClangSharp/issues/592
+    private static string GetVtblMemberDeduplicationKey(string emittedName, CXXMethodDecl cxxMethodDecl)
+    {
+        var builder = new StringBuilder(emittedName);
+        _ = builder.Append('(');
+
+        var parameters = cxxMethodDecl.Parameters;
+
+        for (var index = 0; index < parameters.Count; index++)
+        {
+            if (index != 0)
+            {
+                _ = builder.Append(',');
+            }
+            _ = builder.Append(parameters[index].Type.CanonicalType.AsString);
+        }
+
+        _ = builder.Append(')');
+        return builder.ToString();
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1430,25 +1430,28 @@ public sealed partial class PInvokeGenerator : IDisposable
         var hasVtbl = cxxRecordDecl.Methods.Any((method) => method.IsVirtual && (method.OverriddenMethods.Count == 0));
         hasBaseVtbl = false;
 
+        var indirectVtblCount = 0;
+
+        foreach (var cxxBaseSpecifier in cxxRecordDecl.Bases)
+        {
+            var baseCxxRecordDecl = GetRecordDecl(cxxBaseSpecifier);
+
+            if ((HasVtbl(baseCxxRecordDecl, out var baseHasBaseVtbl) || baseHasBaseVtbl) && !HasField(baseCxxRecordDecl))
+            {
+                indirectVtblCount++;
+            }
+        }
+
+        // Multiple virtual bases require a distinct vtable pointer per base subobject, but the
+        // generated bindings only model a single, flattened `lpVtbl`. This is true even when the
+        // derived type introduces its own virtuals (`hasVtbl`), so the warning must fire regardless.
+        if (indirectVtblCount > 1)
+        {
+            AddDiagnostic(DiagnosticLevel.Warning, "Unsupported cxx record declaration: 'multiple virtual bases'. Generated bindings may be incomplete.", cxxRecordDecl);
+        }
+
         if (!hasVtbl)
         {
-            var indirectVtblCount = 0;
-
-            foreach (var cxxBaseSpecifier in cxxRecordDecl.Bases)
-            {
-                var baseCxxRecordDecl = GetRecordDecl(cxxBaseSpecifier);
-
-                if ((HasVtbl(baseCxxRecordDecl, out var baseHasBaseVtbl) || baseHasBaseVtbl) && !HasField(baseCxxRecordDecl))
-                {
-                    indirectVtblCount++;
-                }
-            }
-
-            if (indirectVtblCount > 1)
-            {
-                AddDiagnostic(DiagnosticLevel.Warning, "Unsupported cxx record declaration: 'multiple virtual bases'. Generated bindings may be incomplete.", cxxRecordDecl);
-            }
-
             hasBaseVtbl = indirectVtblCount != 0;
         }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/MultipleBaseVtblDuplicationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/MultipleBaseVtblDuplicationTest.cs
@@ -1,0 +1,226 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>
+/// Regression test for https://github.com/dotnet/ClangSharp/issues/592.
+/// A struct deriving from two or more bases that each carry a virtual table flattens every base into
+/// the single <c>lpVtbl</c>. Members from different bases that map to the same C# name and signature
+/// (most notably each base's virtual destructor becoming <c>Dispose</c>) were emitted more than once,
+/// producing a CS0111 compile error. The duplicated member is now emitted only once. The generated
+/// bindings remain incomplete for multiple virtual bases (a warning is still reported), because
+/// correctly modeling that requires a distinct vtable pointer per base subobject.
+/// </summary>
+[Platform("win")]
+public sealed class MultipleBaseVtblDuplicationTest : PInvokeGeneratorTest
+{
+    private const string InputContents = @"struct Foo
+{
+    virtual ~Foo() = default;
+};
+
+struct Bar
+{
+    virtual ~Bar() = default;
+};
+
+struct Baz : Foo, Bar
+{
+};
+";
+
+    [Test]
+    public Task DoesNotEmitDuplicateMembers()
+    {
+        var expectedOutputContents = @"using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct Foo
+    {
+        public void** lpVtbl;
+
+        public void Dispose()
+        {
+            ((delegate* unmanaged[Thiscall]<Foo*, void>)(lpVtbl[0]))((Foo*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    public unsafe partial struct Bar
+    {
+        public void** lpVtbl;
+
+        public void Dispose()
+        {
+            ((delegate* unmanaged[Thiscall]<Bar*, void>)(lpVtbl[0]))((Bar*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName(""struct Baz : Foo, Bar"")]
+    public unsafe partial struct Baz
+    {
+        public void** lpVtbl;
+
+        public void Dispose()
+        {
+            ((delegate* unmanaged[Thiscall]<Baz*, void>)(lpVtbl[0]))((Baz*)Unsafe.AsPointer(ref this));
+        }
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new Diagnostic(DiagnosticLevel.Warning, "Unsupported cxx record declaration: 'multiple virtual bases'. Generated bindings may be incomplete.", "Line 11, Column 8 in ClangUnsavedFile.h")
+        };
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(InputContents, expectedOutputContents, expectedDiagnostics: expectedDiagnostics);
+    }
+
+    [Test]
+    public Task DoesNotEmitDuplicateExplicitVtblEntries()
+    {
+        var expectedOutputContents = @"using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct Foo
+    {
+        public Vtbl* lpVtbl;
+
+        public void Dispose()
+        {
+            lpVtbl->Dispose((Foo*)Unsafe.AsPointer(ref this));
+        }
+
+        public partial struct Vtbl
+        {
+            [NativeTypeName(""void () noexcept"")]
+            public delegate* unmanaged[Thiscall]<Foo*, void> Dispose;
+        }
+    }
+
+    public unsafe partial struct Bar
+    {
+        public Vtbl* lpVtbl;
+
+        public void Dispose()
+        {
+            lpVtbl->Dispose((Bar*)Unsafe.AsPointer(ref this));
+        }
+
+        public partial struct Vtbl
+        {
+            [NativeTypeName(""void () noexcept"")]
+            public delegate* unmanaged[Thiscall]<Bar*, void> Dispose;
+        }
+    }
+
+    [NativeTypeName(""struct Baz : Foo, Bar"")]
+    public unsafe partial struct Baz
+    {
+        public Vtbl* lpVtbl;
+
+        public void Dispose()
+        {
+            lpVtbl->Dispose((Baz*)Unsafe.AsPointer(ref this));
+        }
+
+        public partial struct Vtbl
+        {
+            [NativeTypeName(""void () noexcept"")]
+            public delegate* unmanaged[Thiscall]<Baz*, void> Dispose;
+        }
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new Diagnostic(DiagnosticLevel.Warning, "Unsupported cxx record declaration: 'multiple virtual bases'. Generated bindings may be incomplete.", "Line 11, Column 8 in ClangUnsavedFile.h")
+        };
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(InputContents, expectedOutputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls, expectedDiagnostics: expectedDiagnostics);
+    }
+
+    // The non-unifying case: two bases contributing distinctly named virtual methods, plus a virtual
+    // method introduced by the derived type itself. There is no name collision here, so nothing is
+    // deduplicated, but the flattened single-vtable model is still wrong: the secondary base's
+    // `BarMethod` is dispatched through `lpVtbl[0]` (the primary vtable slot shared with `FooMethod`)
+    // rather than the Bar subobject's own vtable. Because the derived type introduces its own virtual
+    // (`BazMethod`), this case previously produced NO diagnostic at all; the warning must still fire so
+    // the incompleteness is never silent.
+    private const string NonUnifyingInputContents = @"struct Foo
+{
+    virtual void FooMethod();
+};
+
+struct Bar
+{
+    virtual void BarMethod();
+};
+
+struct Baz : Foo, Bar
+{
+    virtual void BazMethod();
+};
+";
+
+    [Test]
+    public Task WarnsForNonUnifyingMultipleBases()
+    {
+        var expectedOutputContents = @"using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct Foo
+    {
+        public void** lpVtbl;
+
+        public void FooMethod()
+        {
+            ((delegate* unmanaged[Thiscall]<Foo*, void>)(lpVtbl[0]))((Foo*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    public unsafe partial struct Bar
+    {
+        public void** lpVtbl;
+
+        public void BarMethod()
+        {
+            ((delegate* unmanaged[Thiscall]<Bar*, void>)(lpVtbl[0]))((Bar*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName(""struct Baz : Foo, Bar"")]
+    public unsafe partial struct Baz
+    {
+        public void** lpVtbl;
+
+        public void FooMethod()
+        {
+            ((delegate* unmanaged[Thiscall]<Baz*, void>)(lpVtbl[0]))((Baz*)Unsafe.AsPointer(ref this));
+        }
+
+        public void BarMethod()
+        {
+            ((delegate* unmanaged[Thiscall]<Baz*, void>)(lpVtbl[0]))((Baz*)Unsafe.AsPointer(ref this));
+        }
+
+        public void BazMethod()
+        {
+            ((delegate* unmanaged[Thiscall]<Baz*, void>)(lpVtbl[1]))((Baz*)Unsafe.AsPointer(ref this));
+        }
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new Diagnostic(DiagnosticLevel.Warning, "Unsupported cxx record declaration: 'multiple virtual bases'. Generated bindings may be incomplete.", "Line 11, Column 8 in ClangUnsavedFile.h")
+        };
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(NonUnifyingInputContents, expectedOutputContents, expectedDiagnostics: expectedDiagnostics);
+    }
+}


### PR DESCRIPTION
Fixes #592.

A struct deriving from two or more bases that each carry a virtual table flattens every base into the single `lpVtbl`. Members from different bases that map to the same C# name and signature -- most notably each base's virtual destructor becoming `Dispose` -- were emitted more than once, producing a `CS0111` compile error.

Deduplicate the flattened vtbl members by their emitted name and canonical parameter types so the output at least compiles. This is correct for the destructor-unifying case: `~Foo`/`~Bar` are both overridden by the implicit `Baz::~Baz`, and the primary vtable slot destroys the complete object, so a single `Dispose()` via `lpVtbl[0]` is right. Legitimate cross-base overloads with differing signatures are preserved; only true `CS0111`/`CS0102` collisions are dropped. The fix covers both the function-pointer helper path and the `explicit-vtbls` path.

----------

Also ensure the `'multiple virtual bases'` warning fires even when the derived type introduces its own virtual method. Previously `HasVtbl` only counted the indirect vtables inside the `!hasVtbl` branch, so the non-unifying case -- distinct secondary-base methods flattened onto the primary `lpVtbl` (e.g. `Bar::BarMethod` dispatched through `lpVtbl[0]`, colliding with `Foo::FooMethod`) -- was emitted with incorrect dispatch and *no* diagnostic at all. The count is now computed unconditionally; `hasBaseVtbl` assignment is unchanged, so generated code is byte-identical and only the diagnostic differs.

The bindings remain incomplete for multiple virtual bases (the warning still reports this), since correctly modeling secondary-base dispatch requires a distinct vtable pointer per base subobject. That redesign is deferred to a follow-up.

Adds three golden regression tests (fnptr dedupe, explicit-vtbl dedupe, and the non-unifying warned case).