### PR TITLE
Support struct field type remapping via --with-type

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -793,6 +793,14 @@ public sealed partial class PInvokeGenerator
 
                     WithType(enumDecl, ref remappedName, ref nativeTypeName);
                 }
+                else if (cursor is FieldDecl fieldDecl)
+                {
+                    // A field can have its emitted type overridden via `--with-type Struct.field=Type`.
+                    // The `*` catch-all is intentionally not honored here, as rewriting every field to
+                    // a single type is meaningless; the qualified `Struct.field` key must be explicit.
+
+                    WithType(fieldDecl, ref remappedName, ref nativeTypeName, matchStar: false);
+                }
             }
         }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -2399,9 +2399,9 @@ public sealed partial class PInvokeGenerator : IDisposable
         }
     }
 
-    private void WithType(NamedDecl namedDecl, ref string integerTypeName, ref string nativeTypeName)
+    private void WithType(NamedDecl namedDecl, ref string integerTypeName, ref string nativeTypeName, bool matchStar = true)
     {
-        if (TryGetRemappedValue(namedDecl, _config._withTypes, out var type, matchStar: true))
+        if (TryGetRemappedValue(namedDecl, _config._withTypes, out var type, matchStar))
         {
             if (string.IsNullOrWhiteSpace(nativeTypeName))
             {

--- a/sources/ClangSharpPInvokeGenerator/Program.Options.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.Options.cs
@@ -84,7 +84,7 @@ internal static partial class Program
     private static readonly CommandLineOption s_withSetLastErrors = Multi(s_withSetLastErrorOptionAliases, "Add the SetLastError=true modifier or SetsSystemLastError attribute to a given DllImport or UnmanagedFunctionPointer. Supports wildcards.");
     private static readonly CommandLineOption s_withSuppressGCTransitions = Multi(s_withSuppressGCTransitionOptionAliases, "Add the SuppressGCTransition calling convention to a given DllImport or UnmanagedFunctionPointer. Supports wildcards.");
     private static readonly CommandLineOption s_withTransparentStructNameValuePairs = Multi(s_withTransparentStructOptionAliases, "A remapped type name to be treated as a transparent wrapper during binding generation. Supports wildcards.");
-    private static readonly CommandLineOption s_withTypeNameValuePairs = Multi(s_withTypeOptionAliases, "A type to be used for the given enum declaration during binding generation. Supports wildcards.");
+    private static readonly CommandLineOption s_withTypeNameValuePairs = Multi(s_withTypeOptionAliases, "A type to be used for the given enum declaration, macro constant, or struct field (using the qualified `Type.field`) during binding generation. Supports wildcards.");
     private static readonly CommandLineOption s_withUsingNameValuePairs = Multi(s_withUsingOptionAliases, "A using directive to be included for the given remapped declaration name during binding generation. Supports wildcards.");
     private static readonly CommandLineOption s_helpOption = Flag(s_helpOptionAliases, "Show help and usage information");
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/WithTypeFieldTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/WithTypeFieldTest.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>
+/// Regression tests for https://github.com/dotnet/ClangSharp/issues/559.
+/// The <c>--with-type</c> option is extended to accept a field-qualified key (<c>Struct.field=Type</c>)
+/// so the emitted type of an individual struct field can be overridden. The original Clang type is
+/// preserved as a <c>[NativeTypeName]</c> attribute and unrelated fields are left untouched.
+/// </summary>
+[Platform("win")]
+public sealed class WithTypeFieldTest : PInvokeGeneratorTest
+{
+    [Test]
+    public Task OverridesFieldType()
+    {
+        var inputContents = @"struct Something
+{
+    int type;
+    int other;
+};
+";
+
+        var expectedOutputContents = @"namespace ClangSharp.Test
+{
+    public partial struct Something
+    {
+        [NativeTypeName(""int"")]
+        public SomethingType type;
+
+        public int other;
+    }
+}
+";
+
+        var withTypes = new Dictionary<string, string>
+        {
+            ["Something.type"] = "SomethingType",
+        };
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, withTypes: withTypes);
+    }
+}


### PR DESCRIPTION
Extends `--with-type` (`-wt`) to accept a field-qualified key (`Struct.field=Type`) so the emitted type of an individual struct field can be overridden.

`#559` originally proposed `--remap-type Something.type=SomethingType`, but `--remap-type`/`--remap-field` shipped in #736 with a different meaning (name disambiguation). Instead this reuses `--with-type`, whose semantics are already "use this type for the given declaration," so `int Something.type;` can be emitted as `SomethingType Something.type;`.

----------

Implementation reuses the existing `WithType` helper, which already performs the override and preserves the original Clang type as a `[NativeTypeName]` attribute — it was previously wired only for enum backing types. Field type emission already flows through the same `GetRemappedTypeName(fieldDecl, …)` path, so the hook is a `FieldDecl` sibling branch alongside the existing `EnumDecl` one.

- `WithType` gains an optional `matchStar = true` parameter; the enum call site is byte-for-byte unchanged.
- The `*` catch-all is intentionally **not** honored for fields — rewriting every struct field to a single type is meaningless, so the qualified `Struct.field` key must be explicit.
- Behavior is full-type replacement (the value is the complete desired C# type); the original type is preserved as `[NativeTypeName]` unless equivalent; unrelated fields are unaffected. This composes with the existing macro/enum-backing/struct-marker uses of `--with-type`, which use distinct qualified names.

----------

Added a focused root-level regression fixture (`WithTypeFieldTest`) using `ValidateGeneratedCSharpLatestWindowsBindingsAsync`, rather than adding to the 16-way matrix, to avoid golden churn. It asserts `int type` → `public SomethingType type;` with `[NativeTypeName("int")]` and that a sibling `int other;` field is untouched. No existing goldens change.

Validation: `dotnet build -c Release` produces 0 warnings; `dotnet test -c Release` is green (3746 generator + 56 interop/3 skipped + 11 CLI-parser tests).

Fixes #559
