### PR TITLE
Model nested multiple inheritance of polymorphic bases as ABI-correct subobjects

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -725,13 +725,7 @@ public sealed partial class PInvokeGenerator
         if ((cursor is CXXBaseSpecifier cxxBaseSpecifier) && remappedName.StartsWith(AnonymousBasePrefix, StringComparison.Ordinal))
         {
             Debug.Assert(_cxxRecordDeclContext is not null);
-            remappedName = "Base";
-
-            if (_cxxRecordDeclContext.Bases.Count > 1)
-            {
-                var index = _cxxRecordDeclContext.Bases.IndexOf(cxxBaseSpecifier) + 1;
-                remappedName += index.ToString(CultureInfo.InvariantCulture);
-            }
+            remappedName = GetBaseSubobjectFieldName(_cxxRecordDeclContext, cxxBaseSpecifier);
 
             wasRemapped = true;
             return AddUsingDirectiveIfNeeded(_outputBuilder, remappedName, skipUsing);
@@ -739,6 +733,54 @@ public sealed partial class PInvokeGenerator
 
         wasRemapped = false;
         return AddUsingDirectiveIfNeeded(_outputBuilder, remappedName, skipUsingIfNotRemapped);
+    }
+
+    // Computes the field name for a base subobject emitted on `emittingRecordDecl`. The natural name is
+    // `Base` plus the base specifier's one-based index among its OWN owning record's bases (so a carried
+    // grand-base keeps the name it had on the base that declared it, e.g. `B` -> `Base2` whether emitted on
+    // `C` or carried onto `D`). For a direct base the owner is `emittingRecordDecl`, so this matches the
+    // historical numbering exactly. Because a direct secondary base and a carried secondary base can share a
+    // natural name, the names are assigned in native layout order with a deterministic `_N` disambiguator so
+    // the result is a pure function of `(emittingRecordDecl, cxxBaseSpecifier)` and therefore agrees between
+    // the field declaration and every member access that resolves through the subobject.
+    private string GetBaseSubobjectFieldName(CXXRecordDecl emittingRecordDecl, CXXBaseSpecifier cxxBaseSpecifier)
+    {
+        var usedNames = new HashSet<string>(StringComparer.Ordinal);
+        var result = (string?)null;
+
+        foreach (var (specifier, owner) in EnumerateBaseSubobjects(emittingRecordDecl))
+        {
+            var name = "Base";
+
+            if (owner.Bases.Count > 1)
+            {
+                var index = owner.Bases.IndexOf(specifier) + 1;
+                name += index.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (!usedNames.Add(name))
+            {
+                var suffix = 2;
+                var candidate = $"{name}_{suffix.ToString(CultureInfo.InvariantCulture)}";
+
+                while (!usedNames.Add(candidate))
+                {
+                    suffix++;
+                    candidate = $"{name}_{suffix.ToString(CultureInfo.InvariantCulture)}";
+                }
+
+                name = candidate;
+            }
+
+            if (specifier == cxxBaseSpecifier)
+            {
+                result = name;
+            }
+        }
+
+        // A base specifier that is not itself materialized as a subobject (for example a flattened primary
+        // vtbl base) has no field name; fall back to the un-numbered `Base` to preserve prior behavior.
+        return result ?? "Base";
     }
 
     private string AddUsingDirectiveIfNeeded(IOutputBuilder? outputBuilder, string remappedName, bool skipUsing)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -707,7 +707,7 @@ public partial class PInvokeGenerator
                 var parent = cxxMethodDecl.Parent;
                 Debug.Assert(parent is not null);
 
-                var cxxBaseSpecifier = _cxxRecordDeclContext.Bases.Where((baseSpecifier) => baseSpecifier.Referenced == parent).SingleOrDefault();
+                var cxxBaseSpecifier = GetBaseSubobjectSpecifier(_cxxRecordDeclContext, parent);
 
                 if (cxxBaseSpecifier is not null)
                 {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
@@ -46,6 +46,11 @@ public partial class PInvokeGenerator
             if (cxxRecordDecl is not null)
             {
                 hasVtbl = HasVtbl(cxxRecordDecl, out hasBaseVtbl);
+
+                if (HasVirtualBase(cxxRecordDecl))
+                {
+                    AddDiagnostic(DiagnosticLevel.Warning, "Virtual inheritance is not currently modeled. The generated layout and vtable dispatch for this type may be incorrect.", cxxRecordDecl);
+                }
             }
 
             var alignment = Math.Max(recordDecl.TypeForDecl.Handle.AlignOf, 1);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
@@ -35,8 +35,6 @@ public partial class PInvokeGenerator
         var name = GetRemappedCursorName(recordDecl);
         var escapedName = EscapeName(name);
 
-        var vtblFlatteningNeedsCarry = (recordDecl is CXXRecordDecl cxxRecordDeclForCarry) && VtblFlatteningNeedsCarry(cxxRecordDeclForCarry);
-
         StartUsingOutputBuilder(name, includeTestOutput: true);
         {
             var cxxRecordDecl = recordDecl as CXXRecordDecl;
@@ -48,16 +46,6 @@ public partial class PInvokeGenerator
             if (cxxRecordDecl is not null)
             {
                 hasVtbl = HasVtbl(cxxRecordDecl, out hasBaseVtbl);
-
-                if (vtblFlatteningNeedsCarry)
-                {
-                    // Nested multiple inheritance would require carrying a flattened base's own non-primary
-                    // polymorphic subobjects (each with its own vtable pointer at a distinct offset) onto the
-                    // derived type. That is not yet modeled, so we fall back to the legacy flattened `lpVtbl`
-                    // (which preserves reachability of every inherited method, though not their true offsets)
-                    // and flag the record as incomplete.
-                    AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported cxx record declaration: 'nested multiple virtual bases'. Generated bindings for {name} may be incomplete.", cxxRecordDecl);
-                }
             }
 
             var alignment = Math.Max(recordDecl.TypeForDecl.Handle.AlignOf, 1);
@@ -397,26 +385,11 @@ public partial class PInvokeGenerator
 
             if (cxxRecordDecl is not null)
             {
-                var seenPrimaryVtblBase = false;
-
-                foreach (var cxxBaseSpecifier in cxxRecordDecl.Bases)
+                foreach (var (cxxBaseSpecifier, _) in EnumerateBaseSubobjects(cxxRecordDecl))
                 {
                     var baseCxxRecordDecl = GetRecordDecl(cxxBaseSpecifier);
 
-                    var isPolymorphic = HasVtbl(baseCxxRecordDecl, out var baseHasBaseVtbl) || baseHasBaseVtbl;
-                    var isPrimaryVtblBase = isPolymorphic && !seenPrimaryVtblBase;
-                    seenPrimaryVtblBase |= isPolymorphic;
-
-                    // A base is emitted as a nested subobject when it carries its own fields or when it is a
-                    // non-primary polymorphic base (its distinct vtable pointer cannot be flattened into the
-                    // derived type's single `lpVtbl`). The vtbl-only primary polymorphic base is instead
-                    // flattened, so it is not repeated as a field here. Records whose primary base chain has
-                    // its own non-primary polymorphic base (nested multiple inheritance) cannot be modeled
-                    // this way and fall back to the legacy flattened layout, which only ever nested bases
-                    // that carry fields.
-                    var emitAsSubobject = HasField(baseCxxRecordDecl) || (!vtblFlatteningNeedsCarry && isPolymorphic && !isPrimaryVtblBase);
-
-                    if (emitAsSubobject && !IsBaseExcluded(cxxRecordDecl, baseCxxRecordDecl, cxxBaseSpecifier, out var baseFieldName))
+                    if (!IsBaseExcluded(cxxRecordDecl, baseCxxRecordDecl, cxxBaseSpecifier, out var baseFieldName))
                     {
                         var parent = GetRemappedCursorName(baseCxxRecordDecl);
 
@@ -656,26 +629,12 @@ public partial class PInvokeGenerator
             return remappedName;
         }
 
-        // The vtbl emission passes flatten a base's vtable into the derived type's `lpVtbl`. Normally only
-        // the primary polymorphic base is flattened (every other polymorphic base becomes a subobject with
-        // its own vtable pointer). For nested multiple inheritance we cannot model the carried subobjects, so
-        // we fall back to the legacy behavior of flattening every polymorphic base into a single run-on
-        // vtable -- this keeps all inherited methods reachable, at the cost of exact offsets.
+        // The vtbl emission passes flatten a base's vtable into the derived type's `lpVtbl`. Only the primary
+        // polymorphic base is flattened (it shares the derived type's vtable pointer); every other
+        // polymorphic base becomes a subobject with its own vtable pointer and is not flattened here.
         IEnumerable<CXXRecordDecl> EnumerateFlattenedVtblBases(CXXRecordDecl cxxRecordDecl)
         {
-            if (vtblFlatteningNeedsCarry)
-            {
-                foreach (var cxxBaseSpecifier in cxxRecordDecl.Bases)
-                {
-                    var baseCxxRecordDecl = GetRecordDecl(cxxBaseSpecifier);
-
-                    if (HasVtbl(baseCxxRecordDecl, out var baseHasBaseVtbl) || baseHasBaseVtbl)
-                    {
-                        yield return baseCxxRecordDecl;
-                    }
-                }
-            }
-            else if (GetPrimaryVtblBase(cxxRecordDecl) is CXXRecordDecl primaryVtblBase)
+            if (GetPrimaryVtblBase(cxxRecordDecl) is CXXRecordDecl primaryVtblBase)
             {
                 yield return primaryVtblBase;
             }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
@@ -353,7 +353,7 @@ public partial class PInvokeGenerator
                 _outputBuilder.EndValue(in valueDesc);
             }
 
-            if (hasVtbl || hasBaseVtbl)
+            if ((hasVtbl || hasBaseVtbl) && ((cxxRecordDecl is null) || (GetVtblPtrAccessPrefix(cxxRecordDecl).Length == 0)))
             {
                 var fieldDesc = new FieldDesc {
                     AccessSpecifier = AccessSpecifier.Public,
@@ -629,14 +629,23 @@ public partial class PInvokeGenerator
             return remappedName;
         }
 
-        // The vtbl emission passes flatten a base's vtable into the derived type's `lpVtbl`. Only the primary
-        // polymorphic base is flattened (it shares the derived type's vtable pointer); every other
-        // polymorphic base becomes a subobject with its own vtable pointer and is not flattened here.
+        // The vtbl emission passes flatten the primary polymorphic base's vtable into the derived type (it
+        // shares, and extends, the derived type's vtable pointer) so the derived type re-exposes every
+        // inherited virtual method at its native index. This holds whether the pointer lives in the derived
+        // type's own `lpVtbl` (vtbl-only primary base) or inside a field-bearing primary base subobject; only
+        // the physical location of the pointer differs (see `GetVtblPtrAccessPrefix`). Every other polymorphic
+        // base becomes a subobject with its own vtable pointer and is not flattened here.
         IEnumerable<CXXRecordDecl> EnumerateFlattenedVtblBases(CXXRecordDecl cxxRecordDecl)
         {
-            if (GetPrimaryVtblBase(cxxRecordDecl) is CXXRecordDecl primaryVtblBase)
+            foreach (var cxxBaseSpecifier in cxxRecordDecl.Bases)
             {
-                yield return primaryVtblBase;
+                var baseCxxRecordDecl = GetRecordDecl(cxxBaseSpecifier);
+
+                if (HasVtbl(baseCxxRecordDecl, out var baseHasBaseVtbl) || baseHasBaseVtbl)
+                {
+                    yield return baseCxxRecordDecl;
+                    yield break;
+                }
             }
         }
 
@@ -897,6 +906,7 @@ public partial class PInvokeGenerator
             var cxxRecordDeclName = GetRemappedCursorName(cxxRecordDecl);
             var parentName = cxxRecordDeclName;
             var isInherited = false;
+            var vtblPtrAccessPrefix = GetVtblPtrAccessPrefix(cxxRecordDecl);
 
             var parent = cxxMethodDecl.Parent;
             Debug.Assert(parent is not null);
@@ -1004,7 +1014,23 @@ public partial class PInvokeGenerator
 
             if (_config.GenerateExplicitVtbls)
             {
-                body.Write("lpVtbl->");
+                if (vtblPtrAccessPrefix.Length != 0)
+                {
+                    // The shared vtable pointer lives inside a field-bearing primary base subobject and is
+                    // typed as that base's `Vtbl`; reinterpret it as this type's fuller `Vtbl` so the entries
+                    // this type appends onto the shared vtable resolve at their native offsets.
+                    var vtblTypeName = (_config.GenerateMarkerInterfaces && !_config.GenerateCompatibleCode) ? $"Vtbl<{nativeName}>" : "Vtbl";
+                    body.Write("((");
+                    body.Write(vtblTypeName);
+                    body.Write("*)");
+                    body.Write(vtblPtrAccessPrefix);
+                    body.Write("lpVtbl)->");
+                }
+                else
+                {
+                    body.Write("lpVtbl->");
+                }
+
                 body.BeginMarker("vtbl", new KeyValuePair<string, object>("explicit", true));
                 body.Write(EscapeAndStripMethodName(remappedName));
                 body.EndMarker("vtbl");
@@ -1020,7 +1046,9 @@ public partial class PInvokeGenerator
 
                 body.Write('(');
                 body.Write(cxxMethodDeclTypeName);
-                body.Write(")(lpVtbl[");
+                body.Write(")(");
+                body.Write(vtblPtrAccessPrefix);
+                body.Write("lpVtbl[");
                 body.BeginMarker("vtbl", new KeyValuePair<string, object>("explicit", false));
                 body.Write(cxxMethodDecl.VtblIndex);
                 body.EndMarker("vtbl");

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -2129,7 +2129,7 @@ public partial class PInvokeGenerator
 
                 if ((_cxxRecordDeclContext is not null) && (_cxxRecordDeclContext != parent) && HasField(parent))
                 {
-                    var cxxBaseSpecifier = _cxxRecordDeclContext.Bases.Where((baseSpecifier) => baseSpecifier.Referenced == parent).SingleOrDefault();
+                    var cxxBaseSpecifier = GetBaseSubobjectSpecifier(_cxxRecordDeclContext, parent);
 
                     if ((cxxBaseSpecifier is not null) && IsBaseExcluded(_cxxRecordDeclContext, GetRecordDecl(cxxBaseSpecifier), cxxBaseSpecifier, out baseFieldName))
                     {
@@ -2144,7 +2144,7 @@ public partial class PInvokeGenerator
 
                 if ((_cxxRecordDeclContext is not null) && (_cxxRecordDeclContext != parent))
                 {
-                    var cxxBaseSpecifier = _cxxRecordDeclContext.Bases.Where((baseSpecifier) => baseSpecifier.Referenced == parent).SingleOrDefault();
+                    var cxxBaseSpecifier = GetBaseSubobjectSpecifier(_cxxRecordDeclContext, parent);
 
                     if ((cxxBaseSpecifier is not null) && IsBaseExcluded(_cxxRecordDeclContext, GetRecordDecl(cxxBaseSpecifier), cxxBaseSpecifier, out baseFieldName))
                     {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1502,6 +1502,33 @@ public sealed partial class PInvokeGenerator : IDisposable
             .Select((entry) => entry.Specifier)
             .SingleOrDefault();
 
+    // A record shares (and extends) the vtable pointer of its primary polymorphic base. When that base is
+    // vtbl-only it is flattened into the record's own `lpVtbl`; when it also carries data fields it cannot be
+    // flattened and is emitted as a subobject instead, so the shared vtable pointer physically lives inside
+    // that subobject. This returns the access prefix used to reach the shared pointer in the latter case (for
+    // example `Base.`, or `Base.Base.` for a deeper chain of field-bearing primary bases) and an empty string
+    // when the record declares its own `lpVtbl` (no polymorphic base, or a flattened vtbl-only primary base).
+    private string GetVtblPtrAccessPrefix(CXXRecordDecl cxxRecordDecl)
+    {
+        foreach (var cxxBaseSpecifier in cxxRecordDecl.Bases)
+        {
+            var baseCxxRecordDecl = GetRecordDecl(cxxBaseSpecifier);
+
+            if (HasVtbl(baseCxxRecordDecl, out var baseHasBaseVtbl) || baseHasBaseVtbl)
+            {
+                if (!HasField(baseCxxRecordDecl))
+                {
+                    return "";
+                }
+
+                var baseFieldName = GetBaseSubobjectFieldName(cxxRecordDecl, cxxBaseSpecifier);
+                return $"{baseFieldName}.{GetVtblPtrAccessPrefix(baseCxxRecordDecl)}";
+            }
+        }
+
+        return "";
+    }
+
     private bool NeedsReturnFixup(CXXMethodDecl cxxMethodDecl)
     {
         Debug.Assert(cxxMethodDecl != null);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1424,6 +1424,26 @@ public sealed partial class PInvokeGenerator : IDisposable
         return hasUnsafeMethod;
     }
 
+    // Virtual inheritance introduces a shared base subobject that is laid out once in the most-derived object.
+    // A class that carries a virtual base therefore has a different layout standalone than when it is itself
+    // embedded as a base (the shared base moves to the most-derived object), and the shared base must not be
+    // duplicated across the classes that inherit it. ClangSharp models every base as a by-value subobject of a
+    // single generated type, which cannot represent that context-dependent layout, so records that inherit a
+    // virtual base -- directly or indirectly -- cannot be laid out correctly. Detect them so the caller can
+    // surface a diagnostic rather than silently emit a wrong layout.
+    private bool HasVirtualBase(CXXRecordDecl cxxRecordDecl)
+    {
+        foreach (var cxxBaseSpecifier in cxxRecordDecl.Bases)
+        {
+            if (cxxBaseSpecifier.IsVirtual || HasVirtualBase(GetRecordDecl(cxxBaseSpecifier)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private bool HasVtbl(CXXRecordDecl cxxRecordDecl, out bool hasBaseVtbl)
     {
         var hasVtbl = cxxRecordDecl.Methods.Any((method) => method.IsVirtual && (method.OverriddenMethods.Count == 0));
@@ -1462,13 +1482,30 @@ public sealed partial class PInvokeGenerator : IDisposable
     // carries its own fields or when it is a non-primary polymorphic base (its distinct vtable pointer
     // cannot be flattened into the derived type's single `lpVtbl`). The vtbl-only primary polymorphic base
     // is instead flattened into `lpVtbl`; its own non-primary polymorphic subobjects are carried onto the
-    // derived type (nested multiple inheritance), so we recurse into it in declaration order -- this keeps
-    // every carried subobject at the correct position relative to the derived type's later direct bases.
+    // derived type (nested multiple inheritance), so we recurse into it to collect them. The collected
+    // subobjects are then ordered by clang's authoritative per-target offset so the emitted layout matches
+    // the native one even when the ABI reorders bases (see below).
     private IEnumerable<(CXXBaseSpecifier Specifier, CXXRecordDecl Owner)> EnumerateBaseSubobjects(CXXRecordDecl cxxRecordDecl)
+    {
+        var entries = new List<(CXXBaseSpecifier Specifier, CXXRecordDecl Owner, long Offset)>();
+        CollectBaseSubobjects(cxxRecordDecl, 0, entries);
+
+        // Emit subobjects in native layout order rather than declaration order. The MSVC ABI promotes the
+        // first polymorphic direct base to offset 0 (so it can share its vtable pointer), which can reorder a
+        // non-polymorphic base declared before it. Ordering by clang's authoritative per-target base offset
+        // keeps the generated sequential layout byte-compatible. OrderBy is stable, so bases at the same
+        // offset (none, in practice) keep declaration order.
+        foreach (var (specifier, owner, _) in entries.OrderBy((entry) => entry.Offset))
+        {
+            yield return (specifier, owner);
+        }
+    }
+
+    private void CollectBaseSubobjects(CXXRecordDecl owningRecordDecl, long baseOffsetBits, List<(CXXBaseSpecifier Specifier, CXXRecordDecl Owner, long Offset)> entries)
     {
         var seenPrimaryVtblBase = false;
 
-        foreach (var cxxBaseSpecifier in cxxRecordDecl.Bases)
+        foreach (var cxxBaseSpecifier in owningRecordDecl.Bases)
         {
             var baseCxxRecordDecl = GetRecordDecl(cxxBaseSpecifier);
 
@@ -1478,16 +1515,16 @@ public sealed partial class PInvokeGenerator : IDisposable
 
             var hasField = HasField(baseCxxRecordDecl);
 
+            var relativeOffset = clang.getOffsetOfBase(owningRecordDecl.Handle, cxxBaseSpecifier.Handle);
+            var offset = (relativeOffset < 0) ? baseOffsetBits : (baseOffsetBits + relativeOffset);
+
             if (isPrimaryVtblBase && !hasField)
             {
-                foreach (var carried in EnumerateBaseSubobjects(baseCxxRecordDecl))
-                {
-                    yield return carried;
-                }
+                CollectBaseSubobjects(baseCxxRecordDecl, offset, entries);
             }
             else if (hasField || (isPolymorphic && !isPrimaryVtblBase))
             {
-                yield return (cxxBaseSpecifier, cxxRecordDecl);
+                entries.Add((cxxBaseSpecifier, owningRecordDecl, offset));
             }
         }
     }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1457,45 +1457,50 @@ public sealed partial class PInvokeGenerator : IDisposable
         return null;
     }
 
-    // Flattening a vtbl-only primary base inlines its vtable into the derived type's `lpVtbl`. That is only
-    // loss-free when nothing has to be carried alongside it. A base along the flattened primary chain that
-    // itself has a non-primary polymorphic base (nested multiple inheritance) introduces a second vtable
-    // pointer at a distinct offset that would have to be carried onto the derived type as a subobject; that
-    // is not yet modeled, so such records fall back to the legacy run-on `lpVtbl`.
-    private bool VtblFlatteningNeedsCarry(CXXRecordDecl cxxRecordDecl)
+    // Enumerates the base subobjects a record materializes as fields, in native layout order, together with
+    // the record that directly declares each base specifier (its owner). A base is a subobject when it
+    // carries its own fields or when it is a non-primary polymorphic base (its distinct vtable pointer
+    // cannot be flattened into the derived type's single `lpVtbl`). The vtbl-only primary polymorphic base
+    // is instead flattened into `lpVtbl`; its own non-primary polymorphic subobjects are carried onto the
+    // derived type (nested multiple inheritance), so we recurse into it in declaration order -- this keeps
+    // every carried subobject at the correct position relative to the derived type's later direct bases.
+    private IEnumerable<(CXXBaseSpecifier Specifier, CXXRecordDecl Owner)> EnumerateBaseSubobjects(CXXRecordDecl cxxRecordDecl)
     {
-        for (var primaryVtblBase = GetPrimaryVtblBase(cxxRecordDecl); primaryVtblBase is not null; primaryVtblBase = GetPrimaryVtblBase(primaryVtblBase))
-        {
-            if (HasNonPrimaryVtblBase(primaryVtblBase))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private bool HasNonPrimaryVtblBase(CXXRecordDecl cxxRecordDecl)
-    {
-        var seenVtblBase = false;
+        var seenPrimaryVtblBase = false;
 
         foreach (var cxxBaseSpecifier in cxxRecordDecl.Bases)
         {
             var baseCxxRecordDecl = GetRecordDecl(cxxBaseSpecifier);
 
-            if (HasVtbl(baseCxxRecordDecl, out var baseHasBaseVtbl) || baseHasBaseVtbl)
-            {
-                if (seenVtblBase)
-                {
-                    return true;
-                }
+            var isPolymorphic = HasVtbl(baseCxxRecordDecl, out var baseHasBaseVtbl) || baseHasBaseVtbl;
+            var isPrimaryVtblBase = isPolymorphic && !seenPrimaryVtblBase;
+            seenPrimaryVtblBase |= isPolymorphic;
 
-                seenVtblBase = true;
+            var hasField = HasField(baseCxxRecordDecl);
+
+            if (isPrimaryVtblBase && !hasField)
+            {
+                foreach (var carried in EnumerateBaseSubobjects(baseCxxRecordDecl))
+                {
+                    yield return carried;
+                }
+            }
+            else if (hasField || (isPolymorphic && !isPrimaryVtblBase))
+            {
+                yield return (cxxBaseSpecifier, cxxRecordDecl);
             }
         }
-
-        return false;
     }
+
+    // Resolves the base subobject specifier through which a member declared on `parentRecordDecl` is reached
+    // from `emittingRecordDecl`, considering carried subobjects (nested multiple inheritance) and not just
+    // direct bases. Returns null when the member is reached through the flattened primary chain (i.e. not
+    // through a distinct subobject field).
+    private CXXBaseSpecifier? GetBaseSubobjectSpecifier(CXXRecordDecl emittingRecordDecl, RecordDecl parentRecordDecl)
+        => EnumerateBaseSubobjects(emittingRecordDecl)
+            .Where((entry) => entry.Specifier.Referenced == parentRecordDecl)
+            .Select((entry) => entry.Specifier)
+            .SingleOrDefault();
 
     private bool NeedsReturnFixup(CXXMethodDecl cxxMethodDecl)
     {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/CarriesMultipleNestedNonPrimaryBasesWithStableNames.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/CarriesMultipleNestedNonPrimaryBasesWithStableNames.CSharp.Latest.Windows.cs
@@ -1,0 +1,64 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct A
+    {
+        public void** lpVtbl;
+
+        public void AMethod()
+        {
+            ((delegate* unmanaged[Thiscall]<A*, void>)(lpVtbl[0]))((A*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    public unsafe partial struct B
+    {
+        public void** lpVtbl;
+
+        public void BMethod()
+        {
+            ((delegate* unmanaged[Thiscall]<B*, void>)(lpVtbl[0]))((B*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    public unsafe partial struct E
+    {
+        public void** lpVtbl;
+
+        public void EMethod()
+        {
+            ((delegate* unmanaged[Thiscall]<E*, void>)(lpVtbl[0]))((E*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName("struct C : A, B, E")]
+    public unsafe partial struct C
+    {
+        public void** lpVtbl;
+
+        public B Base2;
+
+        public E Base3;
+
+        public void AMethod()
+        {
+            ((delegate* unmanaged[Thiscall]<C*, void>)(lpVtbl[0]))((C*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName("struct D : C")]
+    public unsafe partial struct D
+    {
+        public void** lpVtbl;
+
+        public B Base2;
+
+        public E Base3;
+
+        public void AMethod()
+        {
+            ((delegate* unmanaged[Thiscall]<D*, void>)(lpVtbl[0]))((D*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/CarriesNestedNonPrimaryBaseAsSubobject.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/CarriesNestedNonPrimaryBaseAsSubobject.CSharp.Latest.Windows.cs
@@ -1,0 +1,65 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct A
+    {
+        public void** lpVtbl;
+
+        public void a()
+        {
+            ((delegate* unmanaged[Thiscall]<A*, void>)(lpVtbl[0]))((A*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    public unsafe partial struct B
+    {
+        public void** lpVtbl;
+
+        public void b()
+        {
+            ((delegate* unmanaged[Thiscall]<B*, void>)(lpVtbl[0]))((B*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName("struct C : A, B")]
+    public unsafe partial struct C
+    {
+        public void** lpVtbl;
+
+        public B Base2;
+
+        public void a()
+        {
+            ((delegate* unmanaged[Thiscall]<C*, void>)(lpVtbl[0]))((C*)Unsafe.AsPointer(ref this));
+        }
+
+        public void c()
+        {
+            ((delegate* unmanaged[Thiscall]<C*, void>)(lpVtbl[1]))((C*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName("struct D : C")]
+    public unsafe partial struct D
+    {
+        public void** lpVtbl;
+
+        public B Base2;
+
+        public void a()
+        {
+            ((delegate* unmanaged[Thiscall]<D*, void>)(lpVtbl[0]))((D*)Unsafe.AsPointer(ref this));
+        }
+
+        public void c()
+        {
+            ((delegate* unmanaged[Thiscall]<D*, void>)(lpVtbl[1]))((D*)Unsafe.AsPointer(ref this));
+        }
+
+        public void d()
+        {
+            ((delegate* unmanaged[Thiscall]<D*, void>)(lpVtbl[2]))((D*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/CarriesNestedNonPrimaryBaseThroughDeepChain.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/CarriesNestedNonPrimaryBaseThroughDeepChain.CSharp.Latest.Windows.cs
@@ -45,12 +45,9 @@ namespace ClangSharp.Test
     {
         public void** lpVtbl;
 
-        public void a()
-        {
-            ((delegate* unmanaged[Thiscall]<D*, void>)(lpVtbl[0]))((D*)Unsafe.AsPointer(ref this));
-        }
+        public B Base2;
 
-        public void b()
+        public void a()
         {
             ((delegate* unmanaged[Thiscall]<D*, void>)(lpVtbl[0]))((D*)Unsafe.AsPointer(ref this));
         }
@@ -63,6 +60,34 @@ namespace ClangSharp.Test
         public void d()
         {
             ((delegate* unmanaged[Thiscall]<D*, void>)(lpVtbl[2]))((D*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName("struct F : D")]
+    public unsafe partial struct F
+    {
+        public void** lpVtbl;
+
+        public B Base2;
+
+        public void a()
+        {
+            ((delegate* unmanaged[Thiscall]<F*, void>)(lpVtbl[0]))((F*)Unsafe.AsPointer(ref this));
+        }
+
+        public void c()
+        {
+            ((delegate* unmanaged[Thiscall]<F*, void>)(lpVtbl[1]))((F*)Unsafe.AsPointer(ref this));
+        }
+
+        public void d()
+        {
+            ((delegate* unmanaged[Thiscall]<F*, void>)(lpVtbl[2]))((F*)Unsafe.AsPointer(ref this));
+        }
+
+        public void f()
+        {
+            ((delegate* unmanaged[Thiscall]<F*, void>)(lpVtbl[3]))((F*)Unsafe.AsPointer(ref this));
         }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/EmitsReorderedPolymorphicPrimaryBaseInLayoutOrder.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/EmitsReorderedPolymorphicPrimaryBaseInLayoutOrder.CSharp.Latest.Windows.cs
@@ -1,0 +1,41 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct Data
+    {
+        public int dx;
+    }
+
+    public unsafe partial struct P
+    {
+        public void** lpVtbl;
+
+        public int pp;
+
+        public void v()
+        {
+            ((delegate* unmanaged[Thiscall]<P*, void>)(lpVtbl[0]))((P*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName("struct C : Data, P")]
+    public unsafe partial struct C
+    {
+        public P Base2;
+
+        public Data Base1;
+
+        public int cx;
+
+        public void v()
+        {
+            ((delegate* unmanaged[Thiscall]<C*, void>)(Base2.lpVtbl[0]))((C*)Unsafe.AsPointer(ref this));
+        }
+
+        public void c()
+        {
+            ((delegate* unmanaged[Thiscall]<C*, void>)(Base2.lpVtbl[1]))((C*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/SharesFieldBearingPrimaryBaseVtblPointer.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/SharesFieldBearingPrimaryBaseVtblPointer.CSharp.Latest.Windows.cs
@@ -1,0 +1,32 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct Foo
+    {
+        public void** lpVtbl;
+
+        public int x;
+
+        public void A()
+        {
+            ((delegate* unmanaged[Thiscall]<Foo*, void>)(lpVtbl[0]))((Foo*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName("struct C : Foo")]
+    public unsafe partial struct C
+    {
+        public Foo Base;
+
+        public void A()
+        {
+            ((delegate* unmanaged[Thiscall]<C*, void>)(Base.lpVtbl[0]))((C*)Unsafe.AsPointer(ref this));
+        }
+
+        public void c()
+        {
+            ((delegate* unmanaged[Thiscall]<C*, void>)(Base.lpVtbl[1]))((C*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/SharesFieldBearingPrimaryBaseVtblPointerThroughDeepChain.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/SharesFieldBearingPrimaryBaseVtblPointerThroughDeepChain.CSharp.Latest.Windows.cs
@@ -1,0 +1,53 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct Foo
+    {
+        public void** lpVtbl;
+
+        public int x;
+
+        public void A()
+        {
+            ((delegate* unmanaged[Thiscall]<Foo*, void>)(lpVtbl[0]))((Foo*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName("struct C : Foo")]
+    public unsafe partial struct C
+    {
+        public Foo Base;
+
+        public void A()
+        {
+            ((delegate* unmanaged[Thiscall]<C*, void>)(Base.lpVtbl[0]))((C*)Unsafe.AsPointer(ref this));
+        }
+
+        public void c()
+        {
+            ((delegate* unmanaged[Thiscall]<C*, void>)(Base.lpVtbl[1]))((C*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName("struct D : C")]
+    public unsafe partial struct D
+    {
+        public C Base;
+
+        public void A()
+        {
+            ((delegate* unmanaged[Thiscall]<D*, void>)(Base.Base.lpVtbl[0]))((D*)Unsafe.AsPointer(ref this));
+        }
+
+        public void c()
+        {
+            ((delegate* unmanaged[Thiscall]<D*, void>)(Base.Base.lpVtbl[1]))((D*)Unsafe.AsPointer(ref this));
+        }
+
+        public void d()
+        {
+            ((delegate* unmanaged[Thiscall]<D*, void>)(Base.Base.lpVtbl[2]))((D*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/SharesFieldBearingPrimaryBaseVtblPointerWithExplicitVtbls.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/SharesFieldBearingPrimaryBaseVtblPointerWithExplicitVtbls.CSharp.Latest.Windows.cs
@@ -1,0 +1,47 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct Foo
+    {
+        public Vtbl* lpVtbl;
+
+        public int x;
+
+        public void A()
+        {
+            lpVtbl->A((Foo*)Unsafe.AsPointer(ref this));
+        }
+
+        public partial struct Vtbl
+        {
+            [NativeTypeName("void ()")]
+            public delegate* unmanaged[Thiscall]<Foo*, void> A;
+        }
+    }
+
+    [NativeTypeName("struct C : Foo")]
+    public unsafe partial struct C
+    {
+        public Foo Base;
+
+        public void A()
+        {
+            ((Vtbl*)Base.lpVtbl)->A((C*)Unsafe.AsPointer(ref this));
+        }
+
+        public void c()
+        {
+            ((Vtbl*)Base.lpVtbl)->c((C*)Unsafe.AsPointer(ref this));
+        }
+
+        public partial struct Vtbl
+        {
+            [NativeTypeName("void ()")]
+            public delegate* unmanaged[Thiscall]<C*, void> A;
+
+            [NativeTypeName("void ()")]
+            public delegate* unmanaged[Thiscall]<C*, void> c;
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/WarnsThatVirtualInheritanceIsNotModeled.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MultipleBaseVtblSubobject/WarnsThatVirtualInheritanceIsNotModeled.CSharp.Latest.Windows.cs
@@ -1,0 +1,34 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct A
+    {
+        public void** lpVtbl;
+
+        public int ax;
+
+        public void a()
+        {
+            ((delegate* unmanaged[Thiscall]<A*, void>)(lpVtbl[0]))((A*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName("struct C : A")]
+    public unsafe partial struct C
+    {
+        public A Base;
+
+        public int cx;
+
+        public void a()
+        {
+            ((delegate* unmanaged[Thiscall]<C*, void>)(Base.lpVtbl[0]))((C*)Unsafe.AsPointer(ref this));
+        }
+
+        public void c()
+        {
+            ((delegate* unmanaged[Thiscall]<C*, void>)(Base.lpVtbl[0]))((C*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/MultipleBaseVtblSubobjectTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/MultipleBaseVtblSubobjectTest.cs
@@ -261,4 +261,59 @@ struct D : C
     {
         return ValidateGeneratedCSharpLatestWindowsBaselineAsync(FieldBearingPrimaryDeepChainInputContents);
     }
+
+    // MSVC promotes the first polymorphic base to offset 0 so the object can share its vtable pointer,
+    // reordering any non-polymorphic base that was declared before it. The subobject fields must be emitted
+    // in native layout order (`P` first, then `Data`) rather than declaration order, or the struct layout
+    // would not match the native ABI.
+    private const string ReorderedPolymorphicBaseInputContents = @"struct Data
+{
+    int dx;
+};
+
+struct P
+{
+    int pp;
+    virtual void v();
+};
+
+struct C : Data, P
+{
+    int cx;
+    virtual void c();
+};
+";
+
+    [Test]
+    public Task EmitsReorderedPolymorphicPrimaryBaseInLayoutOrder()
+    {
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(ReorderedPolymorphicBaseInputContents);
+    }
+
+    // Virtual inheritance is not representable in the by-value subobject model: a virtually-inherited base
+    // is laid out once for the most-derived object, so its offset within a given subobject is
+    // context-dependent. The generator emits a diagnostic and falls back to a best-effort layout rather
+    // than silently emitting an ABI-incorrect one.
+    private const string VirtualInheritanceInputContents = @"struct A
+{
+    int ax;
+    virtual void a();
+};
+
+struct C : virtual A
+{
+    int cx;
+    virtual void c();
+};
+";
+
+    [Test]
+    public Task WarnsThatVirtualInheritanceIsNotModeled()
+    {
+        var expectedDiagnostics = new[] {
+            new Diagnostic(DiagnosticLevel.Warning, "Virtual inheritance is not currently modeled. The generated layout and vtable dispatch for this type may be incorrect.", "Line 7, Column 8 in ClangUnsavedFile.h")
+        };
+
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(VirtualInheritanceInputContents, expectedDiagnostics: expectedDiagnostics);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/MultipleBaseVtblSubobjectTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/MultipleBaseVtblSubobjectTest.cs
@@ -108,10 +108,9 @@ struct Baz : Foo, Bar
 
     // Nested multiple inheritance: `C` derives from two polymorphic bases and `D` derives from `C`.
     // `C` is a single level of multiple inheritance and is modeled exactly (`A` flattened, `B` a subobject).
-    // Flattening `C` into `D`, however, would require carrying `C`'s own non-primary polymorphic base (`B`,
-    // at its own vtable pointer offset) onto `D`, which is not yet modeled. `D` therefore falls back to the
-    // legacy run-on `lpVtbl` -- every inherited method stays reachable (so the bindings still compile), but
-    // a secondary base's methods dispatch through the primary vtable, so the record is flagged incomplete.
+    // `D` flattens `C`'s primary chain (`A`, plus `C`'s and `D`'s own methods) into its single `lpVtbl` and
+    // carries `C`'s non-primary polymorphic base `B` onto itself as a subobject, exactly mirroring the
+    // single-level layout. `b()` is reached through the `B` subobject and is not re-exposed on `D`.
     private const string NestedMultipleInheritanceInputContents = @"struct A
 {
     virtual void a();
@@ -134,12 +133,76 @@ struct D : C
 ";
 
     [Test]
-    public Task FallsBackToFlattenedVtblForNestedMultipleInheritance()
+    public Task CarriesNestedNonPrimaryBaseAsSubobject()
     {
-        var expectedDiagnostics = new[] {
-            new Diagnostic(DiagnosticLevel.Warning, "Unsupported cxx record declaration: 'nested multiple virtual bases'. Generated bindings for D may be incomplete.", "Line 16, Column 8 in ClangUnsavedFile.h")
-        };
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(NestedMultipleInheritanceInputContents);
+    }
 
-        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(NestedMultipleInheritanceInputContents, expectedDiagnostics: expectedDiagnostics);
+    // Double carry: `C` derives from three polymorphic bases, so it flattens `A` and carries both `B` and
+    // `E` as subobjects. `D : C` must carry both onto itself with the same, non-colliding names (`Base2`,
+    // `Base3`) it uses on `C` -- numbering the carried bases by their owning record (`C`) rather than by
+    // `D`'s direct bases is what keeps them distinct.
+    private const string DoubleCarryInputContents = @"struct A
+{
+    virtual void AMethod();
+};
+
+struct B
+{
+    virtual void BMethod();
+};
+
+struct E
+{
+    virtual void EMethod();
+};
+
+struct C : A, B, E
+{
+};
+
+struct D : C
+{
+};
+";
+
+    [Test]
+    public Task CarriesMultipleNestedNonPrimaryBasesWithStableNames()
+    {
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(DoubleCarryInputContents);
+    }
+
+    // The carried subobject propagates through an arbitrary depth of single-inheritance chaining: `F : D`
+    // flattens the whole primary chain (`a`, `c`, `d`, `f`) into its `lpVtbl` and still carries `B`.
+    private const string DeeplyNestedInputContents = @"struct A
+{
+    virtual void a();
+};
+
+struct B
+{
+    virtual void b();
+};
+
+struct C : A, B
+{
+    virtual void c();
+};
+
+struct D : C
+{
+    virtual void d();
+};
+
+struct F : D
+{
+    virtual void f();
+};
+";
+
+    [Test]
+    public Task CarriesNestedNonPrimaryBaseThroughDeepChain()
+    {
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(DeeplyNestedInputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/MultipleBaseVtblSubobjectTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/MultipleBaseVtblSubobjectTest.cs
@@ -205,4 +205,60 @@ struct F : D
     {
         return ValidateGeneratedCSharpLatestWindowsBaselineAsync(DeeplyNestedInputContents);
     }
+
+    // A field-bearing polymorphic primary base shares (and physically holds) the derived type's vtable
+    // pointer, so the derived type must NOT declare a second `lpVtbl` -- that would corrupt its layout and
+    // dispatch through an uninitialized pointer. Instead the base is emitted as a subobject and every
+    // virtual method dispatches through the pointer that lives inside it (`Base.lpVtbl`), keeping native
+    // vtable indices (`A` at `0`, `c` at `1`).
+    private const string FieldBearingPrimaryWithMethodsInputContents = @"struct Foo
+{
+    int x;
+
+    virtual void A();
+};
+
+struct C : Foo
+{
+    virtual void c();
+};
+";
+
+    [Test]
+    public Task SharesFieldBearingPrimaryBaseVtblPointer()
+    {
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(FieldBearingPrimaryWithMethodsInputContents);
+    }
+
+    [Test]
+    public Task SharesFieldBearingPrimaryBaseVtblPointerWithExplicitVtbls()
+    {
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(FieldBearingPrimaryWithMethodsInputContents, PInvokeGeneratorConfigurationOptions.GenerateExplicitVtbls);
+    }
+
+    // The shared pointer is reached through as many field-bearing primary subobjects as the chain is deep:
+    // `D : C : Foo` dispatches through `Base.Base.lpVtbl`, still at native indices.
+    private const string FieldBearingPrimaryDeepChainInputContents = @"struct Foo
+{
+    int x;
+
+    virtual void A();
+};
+
+struct C : Foo
+{
+    virtual void c();
+};
+
+struct D : C
+{
+    virtual void d();
+};
+";
+
+    [Test]
+    public Task SharesFieldBearingPrimaryBaseVtblPointerThroughDeepChain()
+    {
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(FieldBearingPrimaryDeepChainInputContents);
+    }
 }


### PR DESCRIPTION
Follow-up to #750 (now merged), which modeled single-level multiple inheritance of polymorphic bases
as ABI-correct subobjects but fell back to a legacy run-on `lpVtbl` (plus a warning) for nested MI.
This makes nested MI truly ABI-correct, removes that fallback, and fixes two adjacent vtbl-layout bugs
surfaced while verifying the ABI edges. Each fix is a separate commit.

----------

**Carry nested non-primary vtbl bases as ABI-correct subobjects.** `D : C` where `C : A, B` previously
fell back to a run-on `lpVtbl` and a `'nested multiple virtual bases'` warning. `D` now flattens `C`'s
primary chain (`A`, plus `C`'s and `D`'s own methods) into its single `lpVtbl` and carries `C`'s
non-primary polymorphic base `B` onto itself as a subobject, exactly mirroring the single-level layout:
`D { void** lpVtbl; B Base2; a()->[0]; c()->[1]; d()->[2]; }`. `b()` is reached through the `B`
subobject and is not re-exposed on `D`. The blocker was subobject naming: base fields were numbered by
the emitting record's direct bases, so a carried grand-base collapsed to `Base` and collided (CS0102).
Base fields are now numbered by the specifier's owning record, so a carried base keeps the stable,
non-colliding name it had on the base that declared it (`B->Base2`, `E->Base3`) whether emitted on `C`
or carried onto `D`. Direct bases are unchanged (zero churn). The warning machinery is removed.

----------

**Share the vtbl pointer of a field-bearing polymorphic primary base.** A pre-existing bug (present on
#750's base): a record whose polymorphic primary base also has instance fields could not be flattened,
so the base became a subobject but the derived still emitted its own `void** lpVtbl` and dispatched new
methods through that uninitialized second pointer -- a bogus vtable pointer and wrong-index dispatch.
Reproduces with plain single inheritance (`struct Foo { int x; virtual void A(); }; struct C : Foo {
virtual void c(); }` emitted a 24-byte `C` with two vtable pointers instead of the 16-byte native
layout). The primary base's vtable pointer is now shared and physically lives inside the subobject;
the derived declares no `lpVtbl` and dispatches every virtual method through the pointer inside the
subobject (`Base.lpVtbl`, or `Base.Base.lpVtbl` for a deeper chain), keeping native vtable indices.

----------

**Order multiple-inheritance base subobjects by native layout offset.** MSVC promotes the first
polymorphic base to offset 0 (to share its vfptr), reordering any non-polymorphic base declared before
it. The generator emitted bases in declaration order, so `struct C : Data, P` (with `P` polymorphic)
laid `Data` first and mismatched the native ABI. Base subobjects are now ordered by their
`clang.getOffsetOfBase` offset (stable sort, so declaration order is preserved among equal offsets ->
zero churn on existing bindings), matching the native layout.

----------

Virtual inheritance is explicitly out of scope: a virtually-inherited base is laid out once for the
most-derived object, so its offset within a given subobject is context-dependent and is not
representable in the by-value subobject model without a new type-identity model. Rather than silently
emit an ABI-incorrect layout, the generator now emits a diagnostic; full support is deferred to its
own change.

The self-hosted bindings contain no multi-base polymorphic structs, so no regeneration of
`sources/ClangSharp[.Interop]` is required. Full generator test suite: `Failed: 0`.

Fixes #592