### PR TITLE
Give a clear diagnostic when the output location conflicts with the file mode

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -127,6 +127,20 @@ public sealed class PInvokeGeneratorConfiguration
         {
             throw new ArgumentOutOfRangeException(nameof(options));
         }
+        else if ((options & PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles) == 0 && Directory.Exists(_outputLocation))
+        {
+            // In single-file mode the output location is treated as a file path; pointing it at an
+            // existing directory otherwise surfaces as a confusing UnauthorizedAccessException (or a
+            // DirectoryNotFoundException with a trailing separator) when the stream is opened.
+            throw new ArgumentException($"The output location '{_outputLocation}' is an existing directory, but single-file output was requested. Specify a file path for the output location, or pass '--config multi-file' to generate multiple files into the directory.", nameof(outputLocation));
+        }
+        else if ((options & PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles) != 0 && File.Exists(_outputLocation))
+        {
+            // In multi-file mode the output location is treated as a directory that each file is
+            // written into; pointing it at an existing file otherwise fails when that directory is
+            // created.
+            throw new ArgumentException($"The output location '{_outputLocation}' is an existing file, but multi-file output was requested. Specify a directory path for the output location, or remove '--config multi-file' to generate a single file.", nameof(outputLocation));
+        }
 
         if ((options & PInvokeGeneratorConfigurationOptions.GeneratePreviewCode) != 0)
         {

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -537,35 +537,46 @@ internal static partial class Program
         translationFlags |= CXTranslationUnit_IncludeAttributedTypes;               // Include attributed types in CXType
         translationFlags |= CXTranslationUnit_VisitImplicitAttributes;              // Implicit attributes should be visited
 
-        var config = new PInvokeGeneratorConfiguration(language, std, namespaceName, outputLocation, headerFile, outputMode, configOptions) {
-            DefaultClass = methodClassName,
-            ExcludedNames = excludedNames,
-            IncludedNames = includedNames,
-            LibraryPath = libraryPath,
-            MethodPrefixToStrip = methodPrefixToStrip,
-            NativeTypeNamesToStrip = nativeTypeNamesToStrip,
-            RemappedNames = remappedNames,
-            RemappedTypeNames = remappedTypeNames,
-            RemappedFieldNames = remappedFieldNames,
-            TraversalNames = traversalNames,
-            TestOutputLocation = testOutputLocation,
-            WithAccessSpecifiers = withAccessSpecifiers,
-            WithAttributes = withAttributes,
-            WithCallConvs = withCallConvs,
-            WithClasses = withClasses,
-            WithGuids = withGuids,
-            WithLengths = withLengths,
-            WithLibraryPaths = withLibraryPaths,
-            WithManualImports = withManualImports,
-            WithNamespaces = withNamespaces,
-            WithReadonlys = withReadonlys,
-            WithSetLastErrors = withSetLastErrors,
-            WithSuppressGCTransitions = withSuppressGCTransitions,
-            WithTransparentStructs = withTransparentStructs,
-            WithTypes = withTypes,
-            WithUsings = withUsings,
-            WithPackings = withPackings,
-        };
+        PInvokeGeneratorConfiguration config;
+
+        try
+        {
+            config = new PInvokeGeneratorConfiguration(language, std, namespaceName, outputLocation, headerFile, outputMode, configOptions) {
+                DefaultClass = methodClassName,
+                ExcludedNames = excludedNames,
+                IncludedNames = includedNames,
+                LibraryPath = libraryPath,
+                MethodPrefixToStrip = methodPrefixToStrip,
+                NativeTypeNamesToStrip = nativeTypeNamesToStrip,
+                RemappedNames = remappedNames,
+                RemappedTypeNames = remappedTypeNames,
+                RemappedFieldNames = remappedFieldNames,
+                TraversalNames = traversalNames,
+                TestOutputLocation = testOutputLocation,
+                WithAccessSpecifiers = withAccessSpecifiers,
+                WithAttributes = withAttributes,
+                WithCallConvs = withCallConvs,
+                WithClasses = withClasses,
+                WithGuids = withGuids,
+                WithLengths = withLengths,
+                WithLibraryPaths = withLibraryPaths,
+                WithManualImports = withManualImports,
+                WithNamespaces = withNamespaces,
+                WithReadonlys = withReadonlys,
+                WithSetLastErrors = withSetLastErrors,
+                WithSuppressGCTransitions = withSuppressGCTransitions,
+                WithTransparentStructs = withTransparentStructs,
+                WithTypes = withTypes,
+                WithUsings = withUsings,
+                WithPackings = withPackings,
+            };
+        }
+        catch (ArgumentException e)
+        {
+            Console.Error.Write($"Error: {e.Message}");
+            Console.Error.Write(Environment.NewLine);
+            return -1;
+        }
 
         if (config.GenerateMacroBindings)
         {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/ConfigurationOutputLocationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/ConfigurationOutputLocationTest.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.IO;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+public sealed class ConfigurationOutputLocationTest
+{
+    private static PInvokeGeneratorConfiguration CreateConfiguration(string outputLocation, PInvokeGeneratorConfigurationOptions options)
+    {
+        return new PInvokeGeneratorConfiguration("c++", "c++17", "ClangSharp.Test", outputLocation, headerFile: null, PInvokeGeneratorOutputMode.CSharp, options);
+    }
+
+    [Test]
+    public void SingleFileModeRejectsExistingDirectory()
+    {
+        var directory = Directory.CreateTempSubdirectory("ClangSharpTest");
+
+        try
+        {
+            var exception = Assert.Throws<System.ArgumentException>(() => CreateConfiguration(directory.FullName, PInvokeGeneratorConfigurationOptions.None))!;
+            Assert.That(exception.Message, Does.Contain("existing directory"));
+            Assert.That(exception.Message, Does.Contain("--config multi-file"));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public void MultiFileModeRejectsExistingFile()
+    {
+        var file = Path.GetTempFileName();
+
+        try
+        {
+            var exception = Assert.Throws<System.ArgumentException>(() => CreateConfiguration(file, PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles))!;
+            Assert.That(exception.Message, Does.Contain("existing file"));
+            Assert.That(exception.Message, Does.Contain("--config multi-file"));
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Test]
+    public void SingleFileModeAllowsExistingFile()
+    {
+        var file = Path.GetTempFileName();
+
+        try
+        {
+            Assert.DoesNotThrow(() => CreateConfiguration(file, PInvokeGeneratorConfigurationOptions.None));
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Test]
+    public void MultiFileModeAllowsExistingDirectory()
+    {
+        var directory = Directory.CreateTempSubdirectory("ClangSharpTest");
+
+        try
+        {
+            Assert.DoesNotThrow(() => CreateConfiguration(directory.FullName, PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public void NonExistentOutputLocationIsAllowedInEitherMode()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        Assert.DoesNotThrow(() => CreateConfiguration(path, PInvokeGeneratorConfigurationOptions.None));
+        Assert.DoesNotThrow(() => CreateConfiguration(path, PInvokeGeneratorConfigurationOptions.GenerateMultipleFiles));
+    }
+}


### PR DESCRIPTION
Fixes #544.

The tool defaults to single-file output, which treats `-o`/`--output` as a *file* path. Pointing it at an existing directory (e.g. `-o libs/bindings/Miniaudio`) opened that directory as a `FileStream` and surfaced as a confusing `System.UnauthorizedAccessException: Access to the path is denied` -- or a `System.IO.DirectoryNotFoundException` with a trailing separator, even though the directory clearly exists.

This validates the output location against the selected file mode in the `PInvokeGeneratorConfiguration` constructor:
- single-file mode + existing directory -> actionable error pointing at `--config multi-file`
- multi-file mode + existing file -> actionable error pointing at a directory path

Non-existent paths remain valid in either mode (they're created during generation), so normal usage is unaffected.

----------

The CLI wraps configuration construction so the message prints as a single `Error: ...` line and returns `-1`, rather than dumping the raw exception. The library throw benefits all consumers, keeping the check a single source of truth.

Example, running single-file mode against an existing directory:

```
Error: The output location '...' is an existing directory, but single-file output was requested. Specify a file path for the output location, or pass '--config multi-file' to generate multiple files into the directory. (Parameter 'outputLocation')
```

Adds `ConfigurationOutputLocationTest` covering both rejections and the valid cases (existing file single-file, existing dir multi-file, non-existent path either mode). Full generator suite passes (3761 passed on Windows; Unix-gated variants skipped locally).
