### PR TITLE
Annotate generated bindings with GeneratedCodeAttribute

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.Visit.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.Visit.cs
@@ -36,6 +36,10 @@ internal partial class CSharpOutputBuilder
         {
             AddUsingDirective("System.Runtime.Versioning");
         }
+        else if (attribute.StartsWith("GeneratedCode(", StringComparison.Ordinal))
+        {
+            AddUsingDirective("System.CodeDom.Compiler");
+        }
 
         if (!_customAttrIsForParameter)
         {

--- a/sources/ClangSharp.PInvokeGenerator/GeneratedCodeAttributeMode.cs
+++ b/sources/ClangSharp.PInvokeGenerator/GeneratedCodeAttributeMode.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+namespace ClangSharp;
+
+public enum GeneratedCodeAttributeMode
+{
+    Assembly,
+    Type,
+    None
+}

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Close.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Close.cs
@@ -87,6 +87,14 @@ public partial class PInvokeGenerator
                         _ = staticUsingDirectives.Add(staticUsingDirective);
                     }
 
+                    // The method class emits its [GeneratedCode] attribute directly rather than through
+                    // WriteCustomAttribute, so its System.CodeDom.Compiler using is not tracked on the
+                    // builder and must be hoisted here for single-file output.
+                    if (!csharpOutputBuilder.IsTestOutput && _config.GeneratedCodeAttributeMode == GeneratedCodeAttributeMode.Type && csharpOutputBuilder.Contents.Any() && _topLevelClassNames.Contains(csharpOutputBuilder.Name))
+                    {
+                        _ = usingDirectives.Add("System.CodeDom.Compiler");
+                    }
+
                     if (csharpOutputBuilder.IsTestOutput)
                     {
                         testHasAnyContents |= csharpOutputBuilder.Contents.Any();
@@ -118,6 +126,11 @@ public partial class PInvokeGenerator
 
                 _ = usingDirectives.Add("System");
                 _ = usingDirectives.Add("System.Diagnostics");
+
+                if (_config.GeneratedCodeAttributeMode == GeneratedCodeAttributeMode.Assembly)
+                {
+                    _ = usingDirectives.Add("System.CodeDom.Compiler");
+                }
 
                 if (_config.GenerateSetsLastSystemErrorAttribute)
                 {
@@ -167,14 +180,36 @@ public partial class PInvokeGenerator
                         sw.WriteLine();
                     }
 
-                    if (generateHelperTypes && _config.GenerateDisableRuntimeMarshalling)
+                    if (generateHelperTypes)
                     {
-                        // Assembly attributes must precede the namespace declaration, so the
-                        // [assembly: DisableRuntimeMarshalling] attribute is emitted here rather
-                        // than alongside the other helper types.
+                        var emittedAssemblyAttribute = false;
 
-                        sw.WriteLine("[assembly: DisableRuntimeMarshalling]");
-                        sw.WriteLine();
+                        if (_config.GeneratedCodeAttributeMode == GeneratedCodeAttributeMode.Assembly)
+                        {
+                            // Assembly attributes must precede the namespace declaration. The generated
+                            // helper types identify the assembly as containing generated code, so the
+                            // [assembly: GeneratedCode] marker is emitted here rather than per type.
+
+                            sw.Write("[assembly: ");
+                            sw.Write(GeneratedCodeAttribute);
+                            sw.WriteLine(']');
+                            emittedAssemblyAttribute = true;
+                        }
+
+                        if (_config.GenerateDisableRuntimeMarshalling)
+                        {
+                            // Assembly attributes must precede the namespace declaration, so the
+                            // [assembly: DisableRuntimeMarshalling] attribute is emitted here rather
+                            // than alongside the other helper types.
+
+                            sw.WriteLine("[assembly: DisableRuntimeMarshalling]");
+                            emittedAssemblyAttribute = true;
+                        }
+
+                        if (emittedAssemblyAttribute)
+                        {
+                            sw.WriteLine();
+                        }
                     }
                 }
                 else if (_config.OutputMode == PInvokeGeneratorOutputMode.Xml)
@@ -362,6 +397,7 @@ public partial class PInvokeGenerator
                 }
             }
 
+            GenerateGeneratedCodeAssemblyAttribute(this, stream, leaveStreamOpen);
             GenerateDisableRuntimeMarshallingAttribute(this, stream, leaveStreamOpen);
             hasNamespaceContent = GenerateNativeBitfieldAttribute(this, stream, leaveStreamOpen, hasNamespaceContent);
             hasNamespaceContent = GenerateNativeInheritanceAttribute(this, stream, leaveStreamOpen, hasNamespaceContent);
@@ -411,6 +447,49 @@ public partial class PInvokeGenerator
         _outputBuilderFactory.Clear();
         _uuidsToGenerate.Clear();
         _visitedFiles.Clear();
+
+        static void GenerateGeneratedCodeAssemblyAttribute(PInvokeGenerator generator, Stream? stream, bool leaveStreamOpen)
+        {
+            var config = generator.Config;
+
+            if (config.GeneratedCodeAttributeMode != GeneratedCodeAttributeMode.Assembly)
+            {
+                return;
+            }
+
+            if (!config.GenerateMultipleFiles)
+            {
+                // In single-file mode the [assembly: GeneratedCode] attribute is emitted at the top
+                // of the file, before the namespace declaration, since assembly attributes cannot
+                // appear after a namespace.
+                return;
+            }
+
+            if (stream is null)
+            {
+                var outputPath = Path.Combine(config.OutputLocation, "GeneratedCode.cs");
+                stream = generator._outputStreamFactory(outputPath);
+            }
+
+            using var sw = new StreamWriter(stream, s_defaultStreamWriterEncoding, DefaultStreamWriterBufferSize, leaveStreamOpen);
+            sw.NewLine = "\n";
+
+            if (!string.IsNullOrEmpty(config.HeaderText))
+            {
+                sw.WriteLine(config.HeaderText);
+            }
+
+            sw.WriteLine("using System.CodeDom.Compiler;");
+            sw.WriteLine();
+            sw.Write("[assembly: ");
+            sw.Write(GeneratedCodeAttribute);
+            sw.WriteLine(']');
+
+            if (!leaveStreamOpen)
+            {
+                stream = null;
+            }
+        }
 
         static void GenerateDisableRuntimeMarshallingAttribute(PInvokeGenerator generator, Stream? stream, bool leaveStreamOpen)
         {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -399,7 +399,7 @@ public partial class PInvokeGenerator
                     WriteCustomAttrs = static context => {
                         (var enumDecl, var generator) = ((EnumDecl, PInvokeGenerator))context;
 
-                        generator.WithAttributes(enumDecl);
+                        generator.WithAttributes(enumDecl, emitGeneratedCodeAttribute: true);
                         generator.WithUsings(enumDecl);
                     },
                     CustomAttrGeneratorData = (enumDecl, this),
@@ -1401,7 +1401,7 @@ public partial class PInvokeGenerator
                     WriteCustomAttrs = static context => {
                         (var typedefDecl, var generator) = ((TypedefDecl, PInvokeGenerator))context;
 
-                        generator.WithAttributes(typedefDecl);
+                        generator.WithAttributes(typedefDecl, emitGeneratedCodeAttribute: true);
                         generator.WithUsings(typedefDecl);
                     },
                     CustomAttrGeneratorData = (typedefDecl, this),

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
@@ -217,7 +217,7 @@ public partial class PInvokeGenerator
                 WriteCustomAttrs = static context => {
                     (var recordDecl, var generator) = ((RecordDecl, PInvokeGenerator))context;
 
-                    generator.WithAttributes(recordDecl);
+                    generator.WithAttributes(recordDecl, emitGeneratedCodeAttribute: true);
                     generator.WithUsings(recordDecl);
                 },
                 CustomAttrGeneratorData = (recordDecl, this),

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -42,6 +42,13 @@ public sealed partial class PInvokeGenerator : IDisposable
     private const string AnonymousRecordPrefix = $"{AnonymousNamePrefix}Record_";
     private const string AnonymousTypeKindTag = "_e__";
 
+    // The [GeneratedCode] annotation emitted to mark output as generated. By default it rides on the
+    // assembly (via [assembly: GeneratedCode]) when helper types are generated; --config
+    // generate-generated-code=type instead annotates each generated top-level type, and =none emits
+    // neither. The version is the ClangSharp assembly version (without any prerelease/build metadata) so
+    // it is deterministic within a release and only churns the assembly/helper-type baselines on bump.
+    private static readonly string GeneratedCodeAttribute = $"GeneratedCode(\"ClangSharp\", \"{typeof(PInvokeGenerator).Assembly.GetName().Version?.ToString() ?? ""}\")";
+
     private static readonly Encoding s_defaultStreamWriterEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
     private static readonly string[] s_doubleColonSeparator = ["::"];
     private static readonly char[] s_doubleQuoteSeparator = ['"'];
@@ -630,6 +637,11 @@ public sealed partial class PInvokeGenerator : IDisposable
                             csharpOutputBuilder.AddUsingDirective(withUsing);
                         }
                     }
+
+                    if (!outputBuilder.IsTestOutput && _config.GeneratedCodeAttributeMode == GeneratedCodeAttributeMode.Type)
+                    {
+                        csharpOutputBuilder.AddUsingDirective("System.CodeDom.Compiler");
+                    }
                 }
 
                 var usingDirectives = new SortedSet<string>(csharpOutputBuilder.UsingDirectives, StringComparer.Ordinal);
@@ -738,6 +750,14 @@ public sealed partial class PInvokeGenerator : IDisposable
                     }
 
                     sw.WriteLine(".</summary>");
+                }
+
+                if (!outputBuilder.IsTestOutput && _config.GeneratedCodeAttributeMode == GeneratedCodeAttributeMode.Type)
+                {
+                    sw.Write(indentationString);
+                    sw.Write('[');
+                    sw.Write(GeneratedCodeAttribute);
+                    sw.WriteLine(']');
                 }
 
                 if (_topLevelClassAttributes.GetAlternateLookup<ReadOnlySpan<char>>().TryGetValue(nonTestName, out var withAttributes))
@@ -2151,10 +2171,15 @@ public sealed partial class PInvokeGenerator : IDisposable
         return declAttrs;
     }
 
-    private void WithAttributes(NamedDecl namedDecl, bool onlySupportedOSPlatform = false, bool isTestOutput = false)
+    private void WithAttributes(NamedDecl namedDecl, bool onlySupportedOSPlatform = false, bool isTestOutput = false, bool emitGeneratedCodeAttribute = false)
     {
         var outputBuilder = isTestOutput ? _testOutputBuilder : _outputBuilder;
         Debug.Assert(outputBuilder is not null);
+
+        if (emitGeneratedCodeAttribute && !isTestOutput && !onlySupportedOSPlatform && _config.GeneratedCodeAttributeMode == GeneratedCodeAttributeMode.Type)
+        {
+            outputBuilder.WriteCustomAttribute(GeneratedCodeAttribute);
+        }
 
         if (TryGetRemappedValue(namedDecl, _config._withAttributes, out var attributes, matchStar: true))
         {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -295,6 +295,24 @@ public sealed class PInvokeGeneratorConfiguration
 
     public bool GenerateFixedBufferIndexerOverloads => (_options & PInvokeGeneratorConfigurationOptions.GenerateFixedBufferIndexerOverloads) != 0;
 
+    public GeneratedCodeAttributeMode GeneratedCodeAttributeMode
+    {
+        get
+        {
+            if ((_options & PInvokeGeneratorConfigurationOptions.ExcludeGeneratedCodeAttribute) != 0)
+            {
+                return GeneratedCodeAttributeMode.None;
+            }
+
+            if ((_options & PInvokeGeneratorConfigurationOptions.GenerateGeneratedCodeAttributeAsType) != 0)
+            {
+                return GeneratedCodeAttributeMode.Type;
+            }
+
+            return GeneratedCodeAttributeMode.Assembly;
+        }
+    }
+
     public bool GenerateGenericPointerWrapper => (_options & PInvokeGeneratorConfigurationOptions.GenerateGenericPointerWrapper) != 0;
 
     public bool GenerateGuidMember => (_options & PInvokeGeneratorConfigurationOptions.GenerateGuidMember) != 0;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -92,4 +92,8 @@ public enum PInvokeGeneratorConfigurationOptions : long
     DontUseUsingStaticsForGuidMember = 1L << 40,
 
     GenerateFixedBufferIndexerOverloads = 1L << 41,
+
+    GenerateGeneratedCodeAttributeAsType = 1L << 42,
+
+    ExcludeGeneratedCodeAttribute = 1L << 43,
 }

--- a/sources/ClangSharpPInvokeGenerator/Program.Options.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.Options.cs
@@ -201,6 +201,7 @@ internal static partial class Program
         new HelpRow("generate-doc-includes", "<include> xml documentation tags should be generated for declarations."),
         new HelpRow("generate-file-scoped-namespaces", "Namespaces should be scoped to the file to reduce nesting."),
         new HelpRow("generate-fixed-buffer-indexer-overloads", "Fixed sized buffer helper types should generate additional uint, nint, and nuint indexer overloads."),
+        new HelpRow("generate-generated-code=<mode>", "Controls the emission of the GeneratedCode attribute. 'assembly' (default) emits a single '[assembly: GeneratedCode]' when helper types are generated; 'type' instead annotates each generated top-level type; 'none' emits neither."),
         new HelpRow("generate-guid-member", "Types with an associated GUID should have a corresponding member generated."),
         new HelpRow("generate-helper-types", "Code files should be generated for various helper attributes and declared transparent structs."),
         new HelpRow("generate-macro-bindings", "Bindings for macro-definitions should be generated. This currently only works with value like macros and not function-like ones."),

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -143,8 +143,12 @@ internal static partial class Program
         var configOptions = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? PInvokeGeneratorConfigurationOptions.None : PInvokeGeneratorConfigurationOptions.GenerateUnixTypes;
         var printConfigHelp = false;
 
-        foreach (var configSwitch in configSwitches)
+        foreach (var configSwitchRaw in configSwitches)
         {
+            var separatorIndex = configSwitchRaw.IndexOf('=', StringComparison.Ordinal);
+            var configSwitch = separatorIndex >= 0 ? configSwitchRaw[..separatorIndex] : configSwitchRaw;
+            var configSwitchValue = separatorIndex >= 0 ? configSwitchRaw[(separatorIndex + 1)..] : "";
+
             switch (configSwitch)
             {
                 case "?":
@@ -378,6 +382,40 @@ internal static partial class Program
                 case "generate-fixed-buffer-indexer-overloads":
                 {
                     configOptions |= PInvokeGeneratorConfigurationOptions.GenerateFixedBufferIndexerOverloads;
+                    break;
+                }
+
+                case "generate-generated-code":
+                {
+                    switch (configSwitchValue)
+                    {
+                        case "" or "assembly":
+                        {
+                            configOptions &= ~PInvokeGeneratorConfigurationOptions.GenerateGeneratedCodeAttributeAsType;
+                            configOptions &= ~PInvokeGeneratorConfigurationOptions.ExcludeGeneratedCodeAttribute;
+                            break;
+                        }
+
+                        case "type":
+                        {
+                            configOptions |= PInvokeGeneratorConfigurationOptions.GenerateGeneratedCodeAttributeAsType;
+                            configOptions &= ~PInvokeGeneratorConfigurationOptions.ExcludeGeneratedCodeAttribute;
+                            break;
+                        }
+
+                        case "none":
+                        {
+                            configOptions |= PInvokeGeneratorConfigurationOptions.ExcludeGeneratedCodeAttribute;
+                            configOptions &= ~PInvokeGeneratorConfigurationOptions.GenerateGeneratedCodeAttributeAsType;
+                            break;
+                        }
+
+                        default:
+                        {
+                            errorList.Add($"Error: Unrecognized generate-generated-code value: {configSwitchValue}. Expected 'assembly', 'type', or 'none'.");
+                            break;
+                        }
+                    }
                     break;
                 }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsAssemblyAttributeWithHelperTypes.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsAssemblyAttributeWithHelperTypes.CSharp.Latest.Windows.cs
@@ -1,18 +1,26 @@
 using System;
 using System.CodeDom.Compiler;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 [assembly: GeneratedCode("ClangSharp", "21.1.8.3")]
 
 namespace ClangSharp.Test
 {
-    public unsafe partial struct SRC_DATA
+    public enum MyEnum
     {
-        [NativeTypeName("const float *")]
-        public float* data_in;
+        MyEnum_Value,
+    }
 
-        [NativeTypeName("long")]
-        public int input_frames;
+    public partial struct MyStruct
+    {
+        public int value;
+    }
+
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?MyFunction@@YAXP6AXH@Z@Z", ExactSpelling = true)]
+        public static extern void MyFunction([NativeTypeName("MyCallback")] delegate* unmanaged[Cdecl]<int, void> callback);
     }
 
     /// <summary>Defines the type of a member as it was used in the native signature.</summary>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsPerTypeAttributeInTypeMode.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsPerTypeAttributeInTypeMode.CSharp.Latest.Windows.cs
@@ -1,0 +1,24 @@
+using System.CodeDom.Compiler;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    public enum MyEnum
+    {
+        MyEnum_Value,
+    }
+
+    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    public partial struct MyStruct
+    {
+        public int value;
+    }
+
+    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?MyFunction@@YAXP6AXH@Z@Z", ExactSpelling = true)]
+        public static extern void MyFunction([NativeTypeName("MyCallback")] delegate* unmanaged[Cdecl]<int, void> callback);
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsPerTypeAttributeOnDelegateInTypeMode.CSharp.Compatible.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsPerTypeAttributeOnDelegateInTypeMode.CSharp.Compatible.Windows.cs
@@ -1,0 +1,29 @@
+using System;
+using System.CodeDom.Compiler;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    public enum MyEnum
+    {
+        MyEnum_Value,
+    }
+
+    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    public partial struct MyStruct
+    {
+        public int value;
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    public delegate void MyCallback(int value);
+
+    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    public static partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?MyFunction@@YAXP6AXH@Z@Z", ExactSpelling = true)]
+        public static extern void MyFunction([NativeTypeName("MyCallback")] IntPtr callback);
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsPerTypeInsteadOfAssemblyWithHelperTypes.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsPerTypeInsteadOfAssemblyWithHelperTypes.CSharp.Latest.Windows.cs
@@ -1,18 +1,27 @@
 using System;
 using System.CodeDom.Compiler;
 using System.Diagnostics;
-
-[assembly: GeneratedCode("ClangSharp", "21.1.8.3")]
+using System.Runtime.InteropServices;
 
 namespace ClangSharp.Test
 {
-    public unsafe partial struct SRC_DATA
+    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    public enum MyEnum
     {
-        [NativeTypeName("const float *")]
-        public float* data_in;
+        MyEnum_Value,
+    }
 
-        [NativeTypeName("long")]
-        public int input_frames;
+    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    public partial struct MyStruct
+    {
+        public int value;
+    }
+
+    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?MyFunction@@YAXP6AXH@Z@Z", ExactSpelling = true)]
+        public static extern void MyFunction([NativeTypeName("MyCallback")] delegate* unmanaged[Cdecl]<int, void> callback);
     }
 
     /// <summary>Defines the type of a member as it was used in the native signature.</summary>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/OmitsAllAttributesInNoneModeWithHelperTypes.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/OmitsAllAttributesInNoneModeWithHelperTypes.CSharp.Latest.Windows.cs
@@ -1,18 +1,23 @@
 using System;
-using System.CodeDom.Compiler;
 using System.Diagnostics;
-
-[assembly: GeneratedCode("ClangSharp", "21.1.8.3")]
+using System.Runtime.InteropServices;
 
 namespace ClangSharp.Test
 {
-    public unsafe partial struct SRC_DATA
+    public enum MyEnum
     {
-        [NativeTypeName("const float *")]
-        public float* data_in;
+        MyEnum_Value,
+    }
 
-        [NativeTypeName("long")]
-        public int input_frames;
+    public partial struct MyStruct
+    {
+        public int value;
+    }
+
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?MyFunction@@YAXP6AXH@Z@Z", ExactSpelling = true)]
+        public static extern void MyFunction([NativeTypeName("MyCallback")] delegate* unmanaged[Cdecl]<int, void> callback);
     }
 
     /// <summary>Defines the type of a member as it was used in the native signature.</summary>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/OmitsAssemblyAttributeWithoutHelperTypes.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/OmitsAssemblyAttributeWithoutHelperTypes.CSharp.Latest.Windows.cs
@@ -1,0 +1,20 @@
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public enum MyEnum
+    {
+        MyEnum_Value,
+    }
+
+    public partial struct MyStruct
+    {
+        public int value;
+    }
+
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?MyFunction@@YAXP6AXH@Z@Z", ExactSpelling = true)]
+        public static extern void MyFunction([NativeTypeName("MyCallback")] delegate* unmanaged[Cdecl]<int, void> callback);
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedAfterMethodClass.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedAfterMethodClass.CSharp.Latest.Windows.cs
@@ -1,6 +1,9 @@
 using System;
+using System.CodeDom.Compiler;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+
+[assembly: GeneratedCode("ClangSharp", "21.1.8.3")]
 
 namespace ClangSharp.Test
 {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedAfterMethodClassFileScoped.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedAfterMethodClassFileScoped.CSharp.Latest.Windows.cs
@@ -1,6 +1,9 @@
 using System;
+using System.CodeDom.Compiler;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+
+[assembly: GeneratedCode("ClangSharp", "21.1.8.3")]
 
 namespace ClangSharp.Test;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedInSharedFileScopedNamespace.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedInSharedFileScopedNamespace.CSharp.Latest.Windows.cs
@@ -1,5 +1,8 @@
 using System;
+using System.CodeDom.Compiler;
 using System.Diagnostics;
+
+[assembly: GeneratedCode("ClangSharp", "21.1.8.3")]
 
 namespace ClangSharp.Test;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/TransparentStruct/BooleanKindGeneratesValidHelper.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/TransparentStruct/BooleanKindGeneratesValidHelper.CSharp.Latest.Windows.cs
@@ -1,5 +1,8 @@
 using System;
+using System.CodeDom.Compiler;
 using System.Diagnostics;
+
+[assembly: GeneratedCode("ClangSharp", "21.1.8.3")]
 
 namespace ClangSharp.Test
 {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/GeneratedCodeAttributeTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/GeneratedCodeAttributeTest.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using ClangSharp.UnitTests.Baseline;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>
+/// Tests for https://github.com/dotnet/ClangSharp/issues/631.
+/// The GeneratedCode attribute has three modes. In the default 'assembly' mode a single
+/// <c>[assembly: GeneratedCode("ClangSharp", version)]</c> marker is emitted when helper types are
+/// generated. In 'type' mode (<c>generate-generated-code=type</c>) each generated top-level type is
+/// annotated with <c>[GeneratedCode("ClangSharp", version)]</c> instead, and no assembly marker is
+/// emitted. In 'none' mode (<c>generate-generated-code=none</c>) neither is emitted. The version is the
+/// ClangSharp assembly version.
+/// </summary>
+[Platform("win")]
+public sealed class GeneratedCodeAttributeTest : StandaloneBaselineTest
+{
+    protected override string Area => "GeneratedCodeAttribute";
+
+    private const string InputContents = @"enum MyEnum
+{
+    MyEnum_Value,
+};
+
+struct MyStruct
+{
+    int value;
+};
+
+typedef void (*MyCallback)(int value);
+
+void MyFunction(MyCallback callback);
+";
+
+    [Test]
+    public Task OmitsAssemblyAttributeWithoutHelperTypes()
+        => ValidateGeneratedCSharpLatestWindowsBaselineAsync(InputContents);
+
+    [Test]
+    public Task EmitsAssemblyAttributeWithHelperTypes()
+        => ValidateGeneratedCSharpLatestWindowsBaselineAsync(InputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateHelperTypes);
+
+    [Test]
+    public Task EmitsPerTypeAttributeInTypeMode()
+        => ValidateGeneratedCSharpLatestWindowsBaselineAsync(InputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateGeneratedCodeAttributeAsType);
+
+    [Test]
+    public Task EmitsPerTypeAttributeOnDelegateInTypeMode()
+        => ValidateGeneratedCSharpCompatibleWindowsBaselineAsync(InputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateGeneratedCodeAttributeAsType);
+
+    [Test]
+    public Task EmitsPerTypeInsteadOfAssemblyWithHelperTypes()
+        => ValidateGeneratedCSharpLatestWindowsBaselineAsync(InputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateHelperTypes | PInvokeGeneratorConfigurationOptions.GenerateGeneratedCodeAttributeAsType);
+
+    [Test]
+    public Task OmitsAllAttributesInNoneModeWithHelperTypes()
+        => ValidateGeneratedCSharpLatestWindowsBaselineAsync(InputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateHelperTypes | PInvokeGeneratorConfigurationOptions.ExcludeGeneratedCodeAttribute);
+}


### PR DESCRIPTION
Fixes #631.

Adds a `--config generate-generated-code=[assembly|type|none]` option controlling how `System.CodeDom.Compiler.GeneratedCodeAttribute` is emitted on generated bindings. The tri-state is modelled by a new public `GeneratedCodeAttributeMode` enum so a future `member`-level mode can be added later without another flag.

----------

**Modes**

1. `assembly` (default) -- when `generate-helper-types` is used (C# output), emit a single `[assembly: GeneratedCode(""ClangSharp"", version)]` alongside the generated helper types, mirroring the existing `[assembly: DisableRuntimeMarshalling]`. Nothing is emitted without helper types.
2. `type` (opt-in) -- instead of the assembly marker, annotate each generated top-level type (structs/records, COM/vtbl interfaces, enums, delegate typedefs, and the P/Invoke method class) with `[GeneratedCode(""ClangSharp"", version)]`, suppressing the assembly marker.
3. `none` -- emit neither.

The `version` is the ClangSharp assembly version (without prerelease or build metadata) so it stays deterministic within a release and only churns on a `VersionPrefix` bump.

----------

**Notes**

- The self-hosted `sources/ClangSharp` and `sources/ClangSharp.Interop` bindings are **not** regenerated here (no LLVM/libClangSharp env in this environment). Expected diff at regen: each helper-type-generating multi-file output dir gains a `GeneratedCode.cs` carrying `[assembly: GeneratedCode(""ClangSharp"", ""<version>"")]`. Happy to regenerate before merge.
- Adds `GeneratedCodeAttributeTest` covering the default/opt-in/off behavior across the assembly and per-type paths.

Validated with `dotnet build -c Release` (0 warnings) and `dotnet test -c Release` (all passing).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>