### PR TITLE
Expose Type.UnqualifiedType

### DIFF
--- a/sources/ClangSharp/Types/Type.cs
+++ b/sources/ClangSharp/Types/Type.cs
@@ -17,6 +17,7 @@ public unsafe class Type : IEquatable<Type>
     private ValueLazy<Type, string> _kindSpelling;
     private ValueLazy<Type, Type> _pointeeType;
     private ValueLazy<Type, TranslationUnit> _translationUnit;
+    private ValueLazy<Type, Type> _unqualifiedType;
 
     protected Type(CXType handle, CXTypeKind expectedKind, CX_TypeClass expectedTypeClass, params ReadOnlySpan<CXTypeKind> additionalExpectedKinds)
     {
@@ -51,6 +52,7 @@ public unsafe class Type : IEquatable<Type>
         _kindSpelling = new ValueLazy<Type, string>(&KindSpellingFactory);
         _pointeeType = new ValueLazy<Type, Type>(&PointeeTypeFactory);
         _translationUnit = new ValueLazy<Type, TranslationUnit>(&TranslationUnitFactory);
+        _unqualifiedType = new ValueLazy<Type, Type>(&UnqualifiedTypeFactory);
     }
 
 #if !NET10_0_OR_GREATER
@@ -141,6 +143,8 @@ public unsafe class Type : IEquatable<Type>
             }
         }
     }
+
+    public Type UnqualifiedType => _unqualifiedType.GetValue(this);
 
     public static bool operator ==(Type? left, Type? right) => (left is not null) ? ((right is not null) && (left.Handle == right.Handle)) : (right is null);
 
@@ -243,6 +247,8 @@ public unsafe class Type : IEquatable<Type>
     private static unsafe TranslationUnit TranslationUnitFactory(Type self) => TranslationUnit.GetOrCreate((CXTranslationUnit)self.Handle.data[1]);
 
     private static unsafe Type PointeeTypeFactory(Type self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.PointeeType);
+
+    private static unsafe Type UnqualifiedTypeFactory(Type self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.UnqualifiedType);
 
     private static unsafe string KindSpellingFactory(Type self) => self.Handle.KindSpelling.ToString();
 

--- a/tests/ClangSharp.UnitTests/TypeTest.cs
+++ b/tests/ClangSharp.UnitTests/TypeTest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+public sealed class TypeTest : TranslationUnitTest
+{
+    [Test]
+    public void UnqualifiedTypeTest()
+    {
+        // Regression test for dotnet/ClangSharp#562. A `Type` mirrors a Clang `QualType`, so the
+        // local `const` cannot be stripped via sugar removal (`UnqualifiedDesugaredType` keeps it).
+        // `UnqualifiedType` exposes `clang_getUnqualifiedType` to drop the local qualifiers.
+        var inputContents = """
+typedef int const* pcint;
+pcint g();
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var functionDecl = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>().Single((functionDecl) => functionDecl.Name.Equals("g", StringComparison.Ordinal));
+        var pointeeType = functionDecl.ReturnType.CanonicalType.PointeeType;
+
+        Assert.That(pointeeType.IsLocalConstQualified, Is.True, "pointee should be const-qualified");
+        Assert.That(pointeeType.UnqualifiedDesugaredType.IsLocalConstQualified, Is.True, "UnqualifiedDesugaredType keeps the local const");
+
+        var unqualifiedType = pointeeType.UnqualifiedType;
+
+        Assert.That(unqualifiedType.IsLocalConstQualified, Is.False, "UnqualifiedType should drop the local const");
+        Assert.That(unqualifiedType.AsString, Is.EqualTo("int"));
+    }
+}


### PR DESCRIPTION
Adds a public `Type.UnqualifiedType` that wraps `clang_getUnqualifiedType`, giving a way to get a high-level `Type` with its local qualifiers stripped.

A ClangSharp `Type` mirrors a Clang `QualType` (the `CXType` handle carries the local qualifier bits), but it only exposes the `Type*`-shaped API. `UnqualifiedDesugaredType` mirrors `Type::getUnqualifiedDesugaredType()`, which strips *sugar*, not *qualifiers*, and `isSugared()` is `false` for a qualified builtin -- so e.g. the pointee of `int const*` comes back as `const int`. The interop layer already has `CXType.UnqualifiedType`, but `TranslationUnit.GetOrCreate<Type>` is `internal`, so there was no public way to wrap that handle back into a `Type`.

`Type.UnqualifiedType` closes that gap, mirroring the existing `PointeeType` factory. Added a regression test using the reporter's exact snippet.

----------

This is a public API addition, so it should go through API review before merge.

Fixes #562