### PR TITLE
Pass `this` as a pointer when a callee expects one

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -495,6 +495,40 @@ public partial class PInvokeGenerator
                         needsComma = true;
                         continue;
                     }
+                    else if (IsStmtAsWritten<CXXThisExpr>(arg, out _) && IsType<PointerType>(callExpr, functionProtoType.ParamTypes[i], out var thisPointerType))
+                    {
+                        // `this` inside a struct instance method is the value itself, but the callee expects a
+                        // pointer. Materialize its address the same way the reference-parameter path above does.
+                        var thisPointerTypeName = GetTypeName(callExpr, context: null, type: functionProtoType.ParamTypes[i], ignoreTransparentStructsWhereRequired: true, isTemplate: false, nativeTypeName: out _);
+
+                        outputBuilder.AddUsingDirective("System.Runtime.CompilerServices");
+                        outputBuilder.Write('(');
+                        outputBuilder.Write(thisPointerTypeName);
+                        outputBuilder.Write(")Unsafe.AsPointer(");
+
+                        if (thisPointerType.PointeeType.IsLocalConstQualified)
+                        {
+                            if (!_config.GenerateLatestCode)
+                            {
+                                outputBuilder.Write("ref Unsafe.AsRef(");
+                            }
+
+                            outputBuilder.Write("in this");
+
+                            if (!_config.GenerateLatestCode)
+                            {
+                                outputBuilder.Write(')');
+                            }
+                        }
+                        else
+                        {
+                            outputBuilder.Write("ref this");
+                        }
+                        outputBuilder.Write(')');
+
+                        needsComma = true;
+                        continue;
+                    }
                 }
 
                 Visit(arg);

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Compatible.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Compatible.Unix.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct TestInterface_
+    {
+        [NativeTypeName("int (*)(MyStruct *)")]
+        public IntPtr TestMethod;
+    }
+
+    public unsafe partial struct MyStruct_
+    {
+        [NativeTypeName("const struct TestInterface_ *")]
+        public TestInterface_* functions;
+
+        public int TestMethod()
+        {
+            return functions->TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Compatible.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Compatible.Windows.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct TestInterface_
+    {
+        [NativeTypeName("int (*)(MyStruct *)")]
+        public IntPtr TestMethod;
+    }
+
+    public unsafe partial struct MyStruct_
+    {
+        [NativeTypeName("const struct TestInterface_ *")]
+        public TestInterface_* functions;
+
+        public int TestMethod()
+        {
+            return functions->TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Default.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Default.Unix.cs
@@ -1,0 +1,21 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct TestInterface_
+    {
+        [NativeTypeName("int (*)(MyStruct *)")]
+        public delegate* unmanaged[Cdecl]<MyStruct_*, int> TestMethod;
+    }
+
+    public unsafe partial struct MyStruct_
+    {
+        [NativeTypeName("const struct TestInterface_ *")]
+        public TestInterface_* functions;
+
+        public int TestMethod()
+        {
+            return functions->TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Default.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Default.Windows.cs
@@ -1,0 +1,21 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct TestInterface_
+    {
+        [NativeTypeName("int (*)(MyStruct *)")]
+        public delegate* unmanaged[Cdecl]<MyStruct_*, int> TestMethod;
+    }
+
+    public unsafe partial struct MyStruct_
+    {
+        [NativeTypeName("const struct TestInterface_ *")]
+        public TestInterface_* functions;
+
+        public int TestMethod()
+        {
+            return functions->TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Latest.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Latest.Unix.cs
@@ -1,0 +1,21 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct TestInterface_
+    {
+        [NativeTypeName("int (*)(MyStruct *)")]
+        public delegate* unmanaged[Cdecl]<MyStruct_*, int> TestMethod;
+    }
+
+    public unsafe partial struct MyStruct_
+    {
+        [NativeTypeName("const struct TestInterface_ *")]
+        public TestInterface_* functions;
+
+        public int TestMethod()
+        {
+            return functions->TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Latest.Windows.cs
@@ -1,0 +1,21 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct TestInterface_
+    {
+        [NativeTypeName("int (*)(MyStruct *)")]
+        public delegate* unmanaged[Cdecl]<MyStruct_*, int> TestMethod;
+    }
+
+    public unsafe partial struct MyStruct_
+    {
+        [NativeTypeName("const struct TestInterface_ *")]
+        public TestInterface_* functions;
+
+        public int TestMethod()
+        {
+            return functions->TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Preview.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Preview.Unix.cs
@@ -1,0 +1,21 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct TestInterface_
+    {
+        [NativeTypeName("int (*)(MyStruct *)")]
+        public delegate* unmanaged[Cdecl]<MyStruct_*, int> TestMethod;
+    }
+
+    public unsafe partial struct MyStruct_
+    {
+        [NativeTypeName("const struct TestInterface_ *")]
+        public TestInterface_* functions;
+
+        public int TestMethod()
+        {
+            return functions->TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Preview.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.CSharp.Preview.Windows.cs
@@ -1,0 +1,21 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct TestInterface_
+    {
+        [NativeTypeName("int (*)(MyStruct *)")]
+        public delegate* unmanaged[Cdecl]<MyStruct_*, int> TestMethod;
+    }
+
+    public unsafe partial struct MyStruct_
+    {
+        [NativeTypeName("const struct TestInterface_ *")]
+        public TestInterface_* functions;
+
+        public int TestMethod()
+        {
+            return functions->TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Compatible.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Compatible.Unix.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="TestInterface_" access="public">
+      <field name="TestMethod" access="public">
+        <type native="int (*)(MyStruct *)">IntPtr</type>
+      </field>
+    </struct>
+    <struct name="MyStruct_" access="public" unsafe="true">
+      <field name="functions" access="public">
+        <type native="const struct TestInterface_ *">TestInterface_*</type>
+      </field>
+      <function name="TestMethod" access="public">
+        <type>int</type>
+        <code>return functions-&gt;TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));</code>
+      </function>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Compatible.Windows.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Compatible.Windows.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="TestInterface_" access="public">
+      <field name="TestMethod" access="public">
+        <type native="int (*)(MyStruct *)">IntPtr</type>
+      </field>
+    </struct>
+    <struct name="MyStruct_" access="public" unsafe="true">
+      <field name="functions" access="public">
+        <type native="const struct TestInterface_ *">TestInterface_*</type>
+      </field>
+      <function name="TestMethod" access="public">
+        <type>int</type>
+        <code>return functions-&gt;TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));</code>
+      </function>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Default.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Default.Unix.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="TestInterface_" access="public" unsafe="true">
+      <field name="TestMethod" access="public">
+        <type native="int (*)(MyStruct *)">delegate* unmanaged[Cdecl]&lt;MyStruct_*, int&gt;</type>
+      </field>
+    </struct>
+    <struct name="MyStruct_" access="public" unsafe="true">
+      <field name="functions" access="public">
+        <type native="const struct TestInterface_ *">TestInterface_*</type>
+      </field>
+      <function name="TestMethod" access="public">
+        <type>int</type>
+        <code>return functions-&gt;TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));</code>
+      </function>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Default.Windows.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Default.Windows.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="TestInterface_" access="public" unsafe="true">
+      <field name="TestMethod" access="public">
+        <type native="int (*)(MyStruct *)">delegate* unmanaged[Cdecl]&lt;MyStruct_*, int&gt;</type>
+      </field>
+    </struct>
+    <struct name="MyStruct_" access="public" unsafe="true">
+      <field name="functions" access="public">
+        <type native="const struct TestInterface_ *">TestInterface_*</type>
+      </field>
+      <function name="TestMethod" access="public">
+        <type>int</type>
+        <code>return functions-&gt;TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));</code>
+      </function>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Latest.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Latest.Unix.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="TestInterface_" access="public" unsafe="true">
+      <field name="TestMethod" access="public">
+        <type native="int (*)(MyStruct *)">delegate* unmanaged[Cdecl]&lt;MyStruct_*, int&gt;</type>
+      </field>
+    </struct>
+    <struct name="MyStruct_" access="public" unsafe="true">
+      <field name="functions" access="public">
+        <type native="const struct TestInterface_ *">TestInterface_*</type>
+      </field>
+      <function name="TestMethod" access="public">
+        <type>int</type>
+        <code>return functions-&gt;TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));</code>
+      </function>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Latest.Windows.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Latest.Windows.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="TestInterface_" access="public" unsafe="true">
+      <field name="TestMethod" access="public">
+        <type native="int (*)(MyStruct *)">delegate* unmanaged[Cdecl]&lt;MyStruct_*, int&gt;</type>
+      </field>
+    </struct>
+    <struct name="MyStruct_" access="public" unsafe="true">
+      <field name="functions" access="public">
+        <type native="const struct TestInterface_ *">TestInterface_*</type>
+      </field>
+      <function name="TestMethod" access="public">
+        <type>int</type>
+        <code>return functions-&gt;TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));</code>
+      </function>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Preview.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Preview.Unix.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="TestInterface_" access="public" unsafe="true">
+      <field name="TestMethod" access="public">
+        <type native="int (*)(MyStruct *)">delegate* unmanaged[Cdecl]&lt;MyStruct_*, int&gt;</type>
+      </field>
+    </struct>
+    <struct name="MyStruct_" access="public" unsafe="true">
+      <field name="functions" access="public">
+        <type native="const struct TestInterface_ *">TestInterface_*</type>
+      </field>
+      <function name="TestMethod" access="public">
+        <type>int</type>
+        <code>return functions-&gt;TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));</code>
+      </function>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Preview.Windows.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ThisAsPointerTest.Xml.Preview.Windows.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="TestInterface_" access="public" unsafe="true">
+      <field name="TestMethod" access="public">
+        <type native="int (*)(MyStruct *)">delegate* unmanaged[Cdecl]&lt;MyStruct_*, int&gt;</type>
+      </field>
+    </struct>
+    <struct name="MyStruct_" access="public" unsafe="true">
+      <field name="functions" access="public">
+        <type native="const struct TestInterface_ *">TestInterface_*</type>
+      </field>
+      <function name="TestMethod" access="public">
+        <type>int</type>
+        <code>return functions-&gt;TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));</code>
+      </function>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/FunctionDeclarationBodyImportTest.cs
@@ -876,6 +876,30 @@ MyStruct MyFunction()
     }
 
     [Test]
+    public Task ThisAsPointerTest()
+    {
+        var inputContents = @"struct TestInterface_;
+struct MyStruct_;
+
+typedef MyStruct_ MyStruct;
+
+struct TestInterface_ {
+    int (*TestMethod)(MyStruct *vm);
+};
+
+struct MyStruct_ {
+    const struct TestInterface_ *functions;
+
+    int TestMethod() {
+        return functions->TestMethod(this);
+    }
+};
+";
+
+        return ValidateAsync(nameof(ThisAsPointerTest), inputContents);
+    }
+
+    [Test]
     public Task WhileTest()
     {
         var inputContents = @"int MyFunction(int count)


### PR DESCRIPTION
Fixes #239.

When a struct instance method forwards `this` to a callee that expects a pointer -- e.g. `functions->TestMethod(this)` where `TestMethod` is a function-pointer field taking `MyStruct *` -- the argument flows through the general `VisitArgs` path. There the parameter is a `PointerType` rather than a `ReferenceType`, so the existing `this`-as-pointer handling (which already materializes `(T)Unsafe.AsPointer(ref this)` for reference parameters) was skipped and we emitted a bare `this`. In C# `this` inside a struct method is the value, not its address, so the generated call didn't compile.

This makes the pointer-parameter case materialize the address the same way the reference and `memcpy` paths already do:

```cs
return functions->TestMethod((MyStruct_*)Unsafe.AsPointer(ref this));
```

The const-pointee case reuses the existing `in this` / `ref Unsafe.AsRef(in this)` handling for the non-latest language levels, so all output modes are covered.

----------

A method-wide `fixed` is the more general answer for address-of-`this` lifetimes across a whole body, but reusing `Unsafe.AsPointer(ref this)` keeps this consistent with the reference and `memcpy` paths and is safe for the synchronous call. Left as a possible follow-up.

Added `ThisAsPointerTest` (the issue's minimal repro) across all baseline variants.