### PR TITLE
Ensure unsigned enum initializers cast to the signed underlying type

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -2089,10 +2089,56 @@ public sealed partial class PInvokeGenerator : IDisposable
 
             _outputBuilder.EndUnchecked();
         }
+        else if (EnumConstantInitNeedsCast(targetTypeName, stmt))
+        {
+            _outputBuilder.BeginInnerValue();
+            _outputBuilder.BeginInnerCast();
+            _outputBuilder.WriteCastType(targetTypeName);
+            _outputBuilder.EndInnerCast();
+
+            ParenthesizeStmt(stmt);
+
+            _outputBuilder.EndInnerValue();
+        }
         else
         {
             VisitStmt(stmt);
         }
+    }
+
+    private bool EnumConstantInitNeedsCast(string targetTypeName, Stmt stmt)
+    {
+        // A C# enum member initializer must be implicitly convertible to the enum's underlying
+        // type. The generator forces most enums to `int`, so an unsigned initializer expression
+        // (e.g. `1U << 22`) is not implicitly convertible and needs an explicit cast to the
+        // underlying type to compile. Out-of-range values are handled by the unchecked path.
+
+        if (stmt.DeclContext is not EnumDecl)
+        {
+            return false;
+        }
+
+        // Only cast the top-level initializer, not each nested subexpression, to avoid
+        // recursing back into this path while visiting the parenthesized initializer.
+        if (PreviousContext.Cursor is not EnumConstantDecl)
+        {
+            return false;
+        }
+
+        var expr = stmt as Expr;
+
+        if (expr is ImplicitCastExpr implicitCastExpr)
+        {
+            expr = implicitCastExpr.SubExprAsWritten;
+        }
+
+        if (expr is null)
+        {
+            return false;
+        }
+
+        var sourceTypeName = GetRemappedTypeName(expr, context: null, expr.Type, out _);
+        return IsUnsigned(sourceTypeName) && !IsUnsigned(targetTypeName);
     }
 
     private void Visit(Cursor cursor)

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.CSharp.Compatible.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.CSharp.Compatible.Unix.cs
@@ -4,7 +4,7 @@ namespace ClangSharp.Test
 {
     public enum MyEnum2
     {
-        MyEnum2_Value1 = MyEnum1_Value1,
+        MyEnum2_Value1 = ((int)(MyEnum1_Value1)),
     }
 
     public static partial class Methods

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.CSharp.Default.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.CSharp.Default.Unix.cs
@@ -4,7 +4,7 @@ namespace ClangSharp.Test
 {
     public enum MyEnum2
     {
-        MyEnum2_Value1 = MyEnum1_Value1,
+        MyEnum2_Value1 = ((int)(MyEnum1_Value1)),
     }
 
     public static partial class Methods

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.CSharp.Latest.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.CSharp.Latest.Unix.cs
@@ -4,7 +4,7 @@ namespace ClangSharp.Test
 {
     public enum MyEnum2
     {
-        MyEnum2_Value1 = MyEnum1_Value1,
+        MyEnum2_Value1 = ((int)(MyEnum1_Value1)),
     }
 
     public static partial class Methods

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.CSharp.Preview.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.CSharp.Preview.Unix.cs
@@ -4,7 +4,7 @@ namespace ClangSharp.Test
 {
     public enum MyEnum2
     {
-        MyEnum2_Value1 = MyEnum1_Value1,
+        MyEnum2_Value1 = ((int)(MyEnum1_Value1)),
     }
 
     public static partial class Methods

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.Xml.Compatible.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.Xml.Compatible.Unix.xml
@@ -6,7 +6,12 @@
       <enumerator name="MyEnum2_Value1" access="public">
         <type primitive="False">int</type>
         <value>
-          <code>MyEnum1_Value1</code>
+          <value>
+            <cast>int</cast>
+            <value>
+              <code>MyEnum1_Value1</code>
+            </value>
+          </value>
         </value>
       </enumerator>
     </enumeration>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.Xml.Default.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.Xml.Default.Unix.xml
@@ -6,7 +6,12 @@
       <enumerator name="MyEnum2_Value1" access="public">
         <type primitive="False">int</type>
         <value>
-          <code>MyEnum1_Value1</code>
+          <value>
+            <cast>int</cast>
+            <value>
+              <code>MyEnum1_Value1</code>
+            </value>
+          </value>
         </value>
       </enumerator>
     </enumeration>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.Xml.Latest.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.Xml.Latest.Unix.xml
@@ -6,7 +6,12 @@
       <enumerator name="MyEnum2_Value1" access="public">
         <type primitive="False">int</type>
         <value>
-          <code>MyEnum1_Value1</code>
+          <value>
+            <cast>int</cast>
+            <value>
+              <code>MyEnum1_Value1</code>
+            </value>
+          </value>
         </value>
       </enumerator>
     </enumeration>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.Xml.Preview.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithAnonymousEnumTest.Xml.Preview.Unix.xml
@@ -6,7 +6,12 @@
       <enumerator name="MyEnum2_Value1" access="public">
         <type primitive="False">int</type>
         <value>
-          <code>MyEnum1_Value1</code>
+          <value>
+            <cast>int</cast>
+            <value>
+              <code>MyEnum1_Value1</code>
+            </value>
+          </value>
         </value>
       </enumerator>
     </enumeration>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithUnsignedInitConversionTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithUnsignedInitConversionTest.CSharp.cs
@@ -1,0 +1,10 @@
+namespace ClangSharp.Test
+{
+    public enum MyEnum
+    {
+        MyEnum_Value0,
+        MyEnum_Value1 = ((int)(1U << 22)),
+        MyEnum_Value2 = ((int)((1U << 22) | (1 << 12))),
+        MyEnum_Value3 = unchecked((int)(0x80000000)),
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithUnsignedInitConversionTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/EnumDeclaration/WithUnsignedInitConversionTest.Xml.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <enumeration name="MyEnum" access="public">
+      <type>int</type>
+      <enumerator name="MyEnum_Value0" access="public">
+        <type primitive="False">int</type>
+      </enumerator>
+      <enumerator name="MyEnum_Value1" access="public">
+        <type primitive="False">int</type>
+        <value>
+          <value>
+            <cast>int</cast>
+            <code>(1U &lt;&lt; 22)</code>
+          </value>
+        </value>
+      </enumerator>
+      <enumerator name="MyEnum_Value2" access="public">
+        <type primitive="False">int</type>
+        <value>
+          <value>
+            <cast>int</cast>
+            <value>
+              <code>(1U &lt;&lt; 22) | (1 &lt;&lt; 12)</code>
+            </value>
+          </value>
+        </value>
+      </enumerator>
+      <enumerator name="MyEnum_Value3" access="public">
+        <type primitive="False">int</type>
+        <value>
+          <unchecked>
+            <value>
+              <cast>int</cast>
+              <value>
+                <code>0x80000000</code>
+              </value>
+            </value>
+          </unchecked>
+        </value>
+      </enumerator>
+    </enumeration>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/EnumDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/EnumDeclarationTest.cs
@@ -234,6 +234,17 @@ enum MyEnum2 : int
 ");
 
     [Test]
+    public Task WithUnsignedInitConversionTest()
+        => ValidateAsync(nameof(WithUnsignedInitConversionTest), @"enum MyEnum : int
+{
+    MyEnum_Value0,
+    MyEnum_Value1 = (1U << 22),
+    MyEnum_Value2 = (1U << 22) | (1 << 12),
+    MyEnum_Value3 = 0x80000000,
+};
+");
+
+    [Test]
     public Task WithTypeTest()
     {
         var inputContents = @"enum MyEnum : int


### PR DESCRIPTION
An in-range unsigned enum initializer on an enum with a signed underlying type (e.g. shaderc's `1U << 22` on the default `int`) was emitted without a cast, producing a `uint` assigned to an `int` member which fails to compile (CS0266).

`UncheckStmt` now emits an explicit `(int)` cast for that case. Since the value is in-range, no `unchecked` is needed, matching the existing out-of-range `unchecked((int)...)` behavior. The new `EnumConstantInitNeedsCast` helper drives this and is guarded on `PreviousContext.Cursor is EnumConstantDecl` so only the top-level initializer is cast, preventing recursion into nested sub-expressions.

Out-of-range and signed initializers are unchanged.

----------

Adds `WithUnsignedInitConversionTest` plus the 16 baseline variants (CSharp/Xml x Default/Latest/Preview/Compatible x Windows/Unix) covering the regression.

Fixes #519