### PR TITLE
Degrade gracefully on C++ pointer-to-member types

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
@@ -347,6 +347,17 @@ public sealed partial class PInvokeGenerator
                     result.nativeTypeName = $"{nativePointeeTypeName} &";
                 }
             }
+            else if (type is MemberPointerType)
+            {
+                // C++ pointers-to-members have no C# equivalent. Their size and layout are ABI-specific
+                // (a data member pointer is pointer-sized on the Itanium ABI, where-as a member function
+                // pointer is generally larger), so we emit an opaque pointer-sized `void*` and preserve the
+                // original spelling via the NativeTypeName. The layout may be incorrect for member function
+                // pointers, which the diagnostic calls out so a consumer can remap the field if needed.
+
+                result.typeName = "void*";
+                AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported type: '{type.TypeClass}'. Emitting an opaque 'void*'; the size and layout may be incorrect for member function pointers.", cursor);
+            }
             else if (type is SubstTemplateTypeParmType substTemplateTypeParmType)
             {
                 result.typeName = GetTypeName(cursor, context, rootType, substTemplateTypeParmType.ReplacementType, ignoreTransparentStructsWhereRequired, isTemplate, out _);
@@ -900,7 +911,7 @@ public sealed partial class PInvokeGenerator
         {
             GetTypeSize(cursor, enumType.Decl.IntegerType, ref alignment32, ref alignment64, ref has8BytePrimitiveField, out size32, out size64);
         }
-        else if (type is FunctionType or PointerType or ReferenceType)
+        else if (type is FunctionType or PointerType or ReferenceType or MemberPointerType)
         {
             size32 = 4;
             size64 = 8;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MemberPointerDeclaration/DataMemberPointerTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MemberPointerDeclaration/DataMemberPointerTest.CSharp.cs
@@ -1,0 +1,12 @@
+namespace ClangSharp.Test
+{
+    public partial struct MyClass
+    {
+    }
+
+    public unsafe partial struct MyStruct
+    {
+        [NativeTypeName("int MyClass::*")]
+        public void* field;
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MemberPointerDeclaration/DataMemberPointerTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MemberPointerDeclaration/DataMemberPointerTest.Xml.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="MyClass" access="public"></struct>
+    <struct name="MyStruct" access="public" unsafe="true">
+      <field name="field" access="public">
+        <type native="int MyClass::*">void*</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MemberPointerDeclaration/FunctionMemberPointerTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MemberPointerDeclaration/FunctionMemberPointerTest.CSharp.cs
@@ -1,0 +1,12 @@
+namespace ClangSharp.Test
+{
+    public partial struct MyClass
+    {
+    }
+
+    public unsafe partial struct MyStruct
+    {
+        [NativeTypeName("void (MyClass::*)(int)")]
+        public void* callback;
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MemberPointerDeclaration/FunctionMemberPointerTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/MemberPointerDeclaration/FunctionMemberPointerTest.Xml.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="MyClass" access="public"></struct>
+    <struct name="MyStruct" access="public" unsafe="true">
+      <field name="callback" access="public">
+        <type native="void (MyClass::*)(int)">void*</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/MemberPointerDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/MemberPointerDeclarationTest.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests.Baseline;
+
+[TestFixtureSource(nameof(Variants))]
+public sealed class MemberPointerDeclarationTest : BaselineTest
+{
+    public MemberPointerDeclarationTest(BaselineVariant variant) : base(variant)
+    {
+    }
+
+    protected override string Area => "MemberPointerDeclaration";
+
+    // C++ pointers-to-members have no C# equivalent, so the generator degrades to an opaque `void*` and a
+    // warning rather than hard-erroring the whole run (see dotnet/ClangSharp#511). Windows targets use the
+    // MSVC ABI, which additionally attaches an MSInheritance attribute to the referenced class.
+    private IReadOnlyList<Diagnostic> ExpectedDiagnostics(int column)
+    {
+        var memberPointer = new Diagnostic(DiagnosticLevel.Warning, "Unsupported type: 'CX_TypeClass_MemberPointer'. Emitting an opaque 'void*'; the size and layout may be incorrect for member function pointers.", $"Line 5, Column {column} in ClangUnsavedFile.h");
+
+        if (Variant.Os == BaselineOs.Windows)
+        {
+            var msInheritance = new Diagnostic(DiagnosticLevel.Warning, "Unsupported attribute: 'MSInheritance'. Generated bindings may be incomplete.", "Line 1, Column 8 in ClangUnsavedFile.h");
+            return [msInheritance, memberPointer];
+        }
+
+        return [memberPointer];
+    }
+
+    [Test]
+    public Task DataMemberPointerTest()
+    {
+        var inputContents = @"struct MyClass;
+
+struct MyStruct
+{
+    int MyClass::* field;
+};
+";
+
+        return ValidateAsync(nameof(DataMemberPointerTest), inputContents, expectedDiagnostics: ExpectedDiagnostics(column: 20));
+    }
+
+    [Test]
+    public Task FunctionMemberPointerTest()
+    {
+        var inputContents = @"struct MyClass;
+
+struct MyStruct
+{
+    void (MyClass::* callback)(int);
+};
+";
+
+        return ValidateAsync(nameof(FunctionMemberPointerTest), inputContents, expectedDiagnostics: ExpectedDiagnostics(column: 22));
+    }
+}


### PR DESCRIPTION
C++ pointer-to-member types (`int MyClass::*`, `void (MyClass::*)()`) were unsupported: the type-class switch never mapped `CX_TypeClass_MemberPointer`, so `GetTypeName` fell through to the raw Clang spelling (`int MyClass::*`, which isn't valid C#) and `GetTypeSize` hard-errored with `Unsupported type: 'CX_TypeClass_MemberPointer'`. The containing struct then couldn't be laid out.

These have no direct C# equivalent, so this degrades gracefully rather than erroring: `GetTypeName` emits an opaque `void*` and preserves the original spelling via `[NativeTypeName(...)]` plus a single warning, and `GetTypeSize` treats member pointers as pointer-sized (added to the existing `FunctionType or PointerType or ReferenceType` branch).

```csharp
public unsafe partial struct MyStruct
{
    [NativeTypeName("int MyClass::*")]
    public void* field;
}
```

----------

Caveat, called out in the warning: a member-**function** pointer can be wider than a data pointer under both the Itanium and MSVC ABIs, so `void*` may under-size those. Getting the exact width right is ABI-specific and left as a separate follow-up; this change is about not hard-erroring and keeping the struct usable.

Adds a golden regression test (`MemberPointerDeclarationTest`) covering data- and function-member pointers, with per-OS expected diagnostics (MSVC additionally emits an `MSInheritance` attribute warning; Itanium does not).

Fixes #511