### PR TITLE
Don't emit unnecessary unchecked scope for native-int literals

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Predicates.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Predicates.cs
@@ -946,6 +946,19 @@ public sealed partial class PInvokeGenerator
                 targetTypeName = transparentStruct.Name;
             }
         }
+        else
+        {
+            // The platform-dependent narrowing that could overflow on a 32-bit target only happens
+            // when the generator emits the explicit `(nint)`/`(nuint)` cast, which it only does for
+            // `VarDecl` initializers (see `UncheckStmt`). Outside of that context an expression keeps
+            // its natural C# type and never needs an `unchecked` scope, so evaluate native-sized
+            // integer targets against their widest equivalent.
+            targetTypeName = targetTypeName switch {
+                "nint" or "IntPtr" => "long",
+                "nuint" or "UIntPtr" => "ulong",
+                _ => targetTypeName,
+            };
+        }
 
         switch (stmt.StmtClass)
         {
@@ -1159,23 +1172,6 @@ public sealed partial class PInvokeGenerator
             {
                 var integerLiteral = (IntegerLiteral)stmt;
                 var signedValue = integerLiteral.Value;
-
-                // A bare integer literal is emitted with its natural C# type (e.g. a value that only
-                // fits `ulong` gets a `U` suffix and is a `ulong` constant). For the native-sized
-                // integer targets (`nint`/`nuint`), the platform-dependent narrowing that could
-                // overflow on a 32-bit target only happens when the generator emits the explicit
-                // `(nint)`/`(nuint)` cast, which it only does for `VarDecl` initializers (see
-                // `UncheckStmt`). Outside of that context the literal keeps its natural type and
-                // never needs an `unchecked` scope, so evaluate against the widest equivalent.
-                if (!IsPrevContextDecl<VarDecl>(out _, out _))
-                {
-                    targetTypeName = targetTypeName switch {
-                        "nint" or "IntPtr" => "long",
-                        "nuint" or "UIntPtr" => "ulong",
-                        _ => targetTypeName,
-                    };
-                }
-
                 return IsUnchecked(targetTypeName, signedValue, integerLiteral.IsNegative, isHex: integerLiteral.ValueString.StartsWith("0x", StringComparison.Ordinal));
             }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Predicates.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Predicates.cs
@@ -1159,6 +1159,23 @@ public sealed partial class PInvokeGenerator
             {
                 var integerLiteral = (IntegerLiteral)stmt;
                 var signedValue = integerLiteral.Value;
+
+                // A bare integer literal is emitted with its natural C# type (e.g. a value that only
+                // fits `ulong` gets a `U` suffix and is a `ulong` constant). For the native-sized
+                // integer targets (`nint`/`nuint`), the platform-dependent narrowing that could
+                // overflow on a 32-bit target only happens when the generator emits the explicit
+                // `(nint)`/`(nuint)` cast, which it only does for `VarDecl` initializers (see
+                // `UncheckStmt`). Outside of that context the literal keeps its natural type and
+                // never needs an `unchecked` scope, so evaluate against the widest equivalent.
+                if (!IsPrevContextDecl<VarDecl>(out _, out _))
+                {
+                    targetTypeName = targetTypeName switch {
+                        "nint" or "IntPtr" => "long",
+                        "nuint" or "UIntPtr" => "ulong",
+                        _ => targetTypeName,
+                    };
+                }
+
                 return IsUnchecked(targetTypeName, signedValue, integerLiteral.IsNegative, isHex: integerLiteral.ValueString.StartsWith("0x", StringComparison.Ordinal));
             }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/C/CLongDefinesRegressionTestUnix.CSharp.Latest.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/C/CLongDefinesRegressionTestUnix.CSharp.Latest.Unix.cs
@@ -5,7 +5,7 @@ namespace ClangSharp.Test
         [return: NativeTypeName("_Bool")]
         public static bool SDL_size_add_check_overflow([NativeTypeName("size_t")] nuint a, [NativeTypeName("size_t")] nuint b, [NativeTypeName("size_t *")] nuint* ret)
         {
-            if (b > unchecked(18446744073709551615U) - a)
+            if (b > (18446744073709551615U) - a)
             {
                 return (0) != 0;
             }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/CTest.cs
@@ -382,7 +382,7 @@ typedef struct Bitfield {
     public Task CLongDefinesRegressionTestUnix()
     {
         // This test is to catch a potential regression when changing how native integers are handled
-        // Specifically, (18446744073709551615U) became unchecked(18446744073709551615U)
+        // Specifically, (18446744073709551615U) must not be wrapped in an unnecessary unchecked scope
 
         // Macro values are taken from the Linux headers when using Clang
         // Some values are substituted for simplicity
@@ -406,9 +406,8 @@ bool SDL_size_add_check_overflow(size_t a, size_t b, size_t *ret)
 }
 ";
 
-        // The expected below currently does not represent the ideal behavior.
-        // Ideally, the unchecked keywork is removed as it is unnecessary.
-        // This issue is tracked here: https://github.com/dotnet/ClangSharp/issues/709
+        // The unnecessary unchecked scope around the `ulong` literal is now elided; see
+        // https://github.com/dotnet/ClangSharp/issues/709
         return ValidateGeneratedCSharpLatestUnixBaselineAsync(inputContents, commandLineArgs: DefaultCClangCommandLineArgs, language: "c", languageStandard: DefaultCStandard);
     }
 


### PR DESCRIPTION
Fixes #709.

A bare integer literal whose target type resolves to a native-sized integer (`nint`/`nuint`) was wrapped in an `unchecked` scope whenever its value fell outside the 32-bit range, even in expression contexts where the literal keeps its natural C# type and is never narrowed.

The root cause is that on an LP64 target `unsigned long` maps to `nuint`, so the `18446744073709551615UL` literal in `SDL_size_add_check_overflow` is treated as `nuint` and `IsUnchecked` applies the `nuint` 32-bit-range check (`> uint.MaxValue`) to it. But the narrowing `(nuint)`/`(nint)` cast -- the only thing that would actually overflow on a 32-bit target -- is only emitted for `VarDecl` initializers (see the `IsPrevContextDecl<VarDecl>` gate in `UncheckStmt`). In a plain expression the literal just keeps its natural `ulong` type, so no `unchecked` is needed.

This restricts the native-int range check in the `IntegerLiteral` path of `IsUnchecked` to the `VarDecl` context, which is symmetric with the existing cast-emission gate:

- `SDL_size_add_check_overflow` (expression) now emits `if (b > (18446744073709551615U) - a)`.
- `SIZE_MAX` and friends (`VarDecl` init) still emit `unchecked((nuint)(18446744073709551615U))`.

----------

The existing `CLongDefinesRegressionTestUnix` baseline test (added in #699 to track this) is reused as the regression; its expected output is updated to the ideal (`unchecked` removed) and the now-stale "not ideal yet" comments are refreshed. The case is inherently Unix-only -- it requires the `unsigned long` to `nuint` mapping -- so it keeps its `[Platform("unix")]` gate.

Verified with `dotnet build -c Release` (0 warnings) and `dotnet test -c Release` (generator suite: 3770 passed, 0 failed). The Unix-gated regression was also confirmed by temporarily un-gating it and running against the Unix-typed baseline harness on a Windows host.
