### PR TITLE
Remove nightly package publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,32 +163,3 @@ jobs:
         path: |
           ./artifacts/pkg/**/*
         if-no-files-found: error
-  publish-nightlies-azure:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }}
-    needs: [ sign-nuget ]
-    steps:
-    - uses: actions/download-artifact@v4
-      with:
-        name: sign_nuget
-        path: ./artifacts/pkg
-    - uses: actions/setup-dotnet@v4
-      with:
-        global-json-file: ./global.json
-        source-url: https://pkgs.clangsharp.dev/index.json
-      env:
-        NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_PAT }}
-    - run: dotnet nuget push "./artifacts/pkg/Release/*.nupkg" --api-key AzureDevOps --skip-duplicate
-  publish-nightlies-github:
-    runs-on: ubuntu-latest
-    if: false
-    needs: [ sign-nuget ]
-    steps:
-    - uses: actions/download-artifact@v4
-      with:
-        name: sign_nuget
-        path: ./artifacts/pkg
-    - uses: actions/setup-dotnet@v4
-      with:
-        global-json-file: ./global.json
-    - run: dotnet nuget push "./artifacts/pkg/Release/*.nupkg" --source https://nuget.pkg.github.com/dotnet/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ A helper package which exposes many Clang APIs missing from libClang is provided
 
 **NOTE:** libclang and libClangSharp are meta-packages which point to the platform-specific runtime packages ([e.g.](https://www.nuget.org/packages/libClangSharp.runtime.win-x64/21.1.8); see others owned by [tannergooding](https://www.nuget.org/profiles/tannergooding)). Several manual steps may be required to use them, see discussion in [#46](https://github.com/dotnet/ClangSharp/issues/46) and [#118](https://github.com/dotnet/ClangSharp/issues/118).
 
-Nightly packages are available via the NuGet Feed URL: https://pkgs.clangsharp.dev/index.json
-
 Source browsing is available via: https://source.clangsharp.dev/
 
 ## Table of Contents

--- a/sources/ClangSharpPInvokeGenerator/README.md
+++ b/sources/ClangSharpPInvokeGenerator/README.md
@@ -35,7 +35,6 @@ You can see the full set of available switches by passing `--help`, and the avai
 * Best practices for driving the generator: https://github.com/dotnet/ClangSharp/blob/main/docs/generating-bindings-best-practices.md
 * Full documentation and the list of options: https://github.com/dotnet/ClangSharp#generating-bindings
 * Source repository: https://github.com/dotnet/ClangSharp
-* Nightly packages: https://pkgs.clangsharp.dev/index.json
 
 ## License
 


### PR DESCRIPTION
Drops nightly package publishing. The Azure DevOps feed (pkgs.clangsharp.dev) constantly runs out of storage even with very tight retention policies, so it's been of little benefit lately.

This removes the publish-nightlies-azure job along with the already-disabled publish-nightlies-github job, and drops the nightly feed references from the READMEs.

`sign-nuget` is untouched -- its `azure/login`/`azure-key-vault` usage is for signing, not nightly publishing.

----------

Out of scope: the `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`KEY_VAULT_*` secrets remain in use for signing; the `AZURE_DEVOPS_PAT` secret is now unused and can be cleaned up separately.