### PR TITLE
Add opt-in generate-extern-variables for extern global bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Options:
   generate-cpp-attributes                  [CppAttributeList("")] should be generated to document the encountered C++ attributes.
   generate-disable-runtime-marshalling     [assembly: DisableRuntimeMarshalling] should be generated.
   generate-doc-includes                    <include> xml documentation tags should be generated for declarations.
+  generate-extern-variables                Top-level extern/extern const global variables should be surfaced as settable pointer fields on a <Class>ManualImports struct for the consumer to resolve (like --with-manual-import). Opt-in; pointer and primitive types only.
   generate-file-scoped-namespaces          Namespaces should be scoped to the file to reduce nesting.
   generate-fixed-buffer-indexer-overloads  Fixed sized buffer helper types should generate additional uint, nint, and nuint indexer overloads.
   generate-guid-member                     Types with an associated GUID should have a corresponding member generated.

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.ExternVariable.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.ExternVariable.cs
@@ -1,0 +1,108 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Diagnostics;
+using ClangSharp.CSharp;
+
+namespace ClangSharp;
+
+public partial class PInvokeGenerator
+{
+    // Attempts to bind a top-level `extern`/`extern const` global variable that has no initializer. The
+    // generator otherwise drops these (there is nothing to constant-fold), so surfacing them requires the
+    // consumer to resolve the export at runtime. Rather than have the generator own a `NativeLibrary`
+    // handle (which cannot be released safely -- e.g. under a collectible `AssemblyLoadContext`), this
+    // mirrors `--with-manual-import`: each global is emitted as a settable pointer field on a synthesized
+    // `<Class>ManualImports` struct that the consumer populates however it resolves the rest of its
+    // manual imports. The naming makes it explicit the pointers are unresolved until the caller wires
+    // them up.
+    //
+    // This is strictly opt-in via `generate-extern-variables` because it emits API surface and only ever
+    // supports pointer/primitive shapes -- a struct-by-value global would need real marshalling that isn't
+    // modeled here.
+    //
+    // Returns true when the variable was emitted; false leaves the caller's existing no-op behavior intact.
+    private bool TryVisitExternVariable(VarDecl varDecl, string nativeName)
+    {
+        if (!_config.GenerateExternVariables)
+        {
+            return false;
+        }
+
+        // Only the C# backend knows how to emit the manual-import struct.
+        if (_config.OutputMode != PInvokeGeneratorOutputMode.CSharp)
+        {
+            return false;
+        }
+
+        // Synthetic macro-definition records are handled separately and never represent a real export.
+        if (nativeName.StartsWith("ClangSharpMacro_", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var type = varDecl.Type;
+
+        // Only pointer and primitive/enum globals are supported. Anything else (record-by-value, arrays,
+        // references) would require marshalling that a raw pointer field can't model, so it is left
+        // untouched.
+        if (type.CanonicalType is not (BuiltinType or EnumType or PointerType))
+        {
+            AddDiagnostic(DiagnosticLevel.Warning, $"Extern variable '{nativeName}' has an unsupported type '{type.AsString}' for 'generate-extern-variables' and was skipped. Only pointer and primitive types are supported.", varDecl);
+            return false;
+        }
+
+        var accessSpecifier = GetAccessSpecifier(varDecl, matchStar: false);
+        var name = GetRemappedName(nativeName, varDecl, tryRemapOperatorName: false, out _, skipUsing: true);
+        var escapedName = EscapeName(name);
+        var typeName = GetRemappedTypeName(varDecl, context: null, type, out var nativeTypeName);
+
+        // The export lives on `<Class>ManualImports`, a struct sibling to the class the symbol would
+        // otherwise be routed into. Reusing the method-class wrapper (registered here) gives us the
+        // namespace, access specifier, `unsafe`, and `partial struct` header for free.
+        var structName = $"{GetClass(name)}ManualImports";
+        _ = _topLevelClassNames.Add(structName);
+        _ = _topLevelStructNames.Add(structName);
+
+        // The pointer fields make the struct unsafe.
+        _topLevelClassIsUnsafe[structName] = true;
+
+        StartUsingOutputBuilder(structName);
+        {
+            Debug.Assert(_outputBuilder is CSharpOutputBuilder);
+            var outputBuilder = (CSharpOutputBuilder)_outputBuilder;
+
+            OutputExternVariable(outputBuilder, accessSpecifier.AsString(), typeName, nativeTypeName, escapedName);
+        }
+        StopUsingOutputBuilder();
+
+        return true;
+    }
+
+    // Emits a single settable pointer field for an extern global on the manual-import struct, e.g.
+    // `public int* kMyConstInt;`. The consumer assigns the pointer (typically off their own export
+    // resolution); the generator owns no library handle. Const-ness is carried purely by `[NativeTypeName]`
+    // since the field is a raw pointer into native storage.
+    private static void OutputExternVariable(CSharpOutputBuilder outputBuilder, string accessSpecifier, string typeName, string nativeTypeName, string escapedName)
+    {
+        if (!string.IsNullOrEmpty(nativeTypeName) && (nativeTypeName != typeName))
+        {
+            outputBuilder.WriteIndented("[NativeTypeName(\"");
+            outputBuilder.Write(EscapeString(nativeTypeName));
+            outputBuilder.WriteLine("\")]");
+            outputBuilder.WriteIndentation();
+        }
+        else
+        {
+            outputBuilder.WriteIndentation();
+        }
+
+        outputBuilder.Write(accessSpecifier);
+        outputBuilder.Write(' ');
+        outputBuilder.Write(typeName);
+        outputBuilder.Write("* ");
+        outputBuilder.Write(escapedName);
+        outputBuilder.WriteLine(';');
+        outputBuilder.NeedsNewline = true;
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
@@ -33,6 +33,13 @@ public partial class PInvokeGenerator
         {
             if (!varDecl.HasInit)
             {
+                // A top level declaration without an initializer is normally dropped (there is nothing to
+                // constant-fold), but an opt-in extern binding can still resolve it at runtime.
+                if (TryVisitExternVariable(varDecl, GetCursorName(varDecl)))
+                {
+                    return;
+                }
+
                 // Nothing to do if a top level const declaration doesn't have an initializer
                 return;
             }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -81,6 +81,12 @@ public sealed partial class PInvokeGenerator : IDisposable
     private readonly Dictionary<CXFile, (nuint Address, nuint Length)> _fileContents;
     private readonly Dictionary<CXFile, (string Name, string FullName)> _fileNames;
     private readonly HashSet<string> _topLevelClassNames;
+
+    // Top-level method-class output builders that should be emitted as a `struct` rather than a `class`.
+    // Used by `generate-extern-variables` to render the synthesized `<Class>ManualImports` holder as a
+    // struct, reusing the method-class wrapper without mutating the immutable configuration.
+    private readonly HashSet<string> _topLevelStructNames;
+
     private readonly HashSet<string> _usedRemappings;
     private readonly HashSet<RecordDecl> _declashedRecordNames;
     private readonly Dictionary<EnumDecl, (EnumMemberStripKind Kind, string Text)> _enumMemberStrips;
@@ -194,6 +200,7 @@ public sealed partial class PInvokeGenerator : IDisposable
             _topLevelClassHasGuidMember = new Dictionary<string, bool>(StringComparer.Ordinal);
             _topLevelClassIsUnsafe = new Dictionary<string, bool>(StringComparer.Ordinal);
             _topLevelClassNames = new HashSet<string>(StringComparer.Ordinal);
+            _topLevelStructNames = new HashSet<string>(StringComparer.Ordinal);
             _topLevelClassAttributes = new Dictionary<string, List<string>>(StringComparer.Ordinal);
             _fileContents = [];
             _fileNames = [];
@@ -740,7 +747,7 @@ public sealed partial class PInvokeGenerator : IDisposable
 
             if (isMethodClass)
             {
-                var isTopLevelStruct = _config._withTypes.GetAlternateLookup<ReadOnlySpan<char>>().TryGetValue(nonTestName, out var withType) && withType.Equals("struct", StringComparison.Ordinal);
+                var isTopLevelStruct = _topLevelStructNames.GetAlternateLookup<ReadOnlySpan<char>>().Contains(nonTestName) || (_config._withTypes.GetAlternateLookup<ReadOnlySpan<char>>().TryGetValue(nonTestName, out var withType) && withType.Equals("struct", StringComparison.Ordinal));
 
                 if (outputBuilder.IsTestOutput)
                 {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -324,6 +324,8 @@ public sealed class PInvokeGeneratorConfiguration
 
     public bool GenerateGenericPointerWrapper => (_options & PInvokeGeneratorConfigurationOptions.GenerateGenericPointerWrapper) != 0;
 
+    public bool GenerateExternVariables => (_options & PInvokeGeneratorConfigurationOptions.GenerateExternVariables) != 0;
+
     public bool GenerateGuidMember => (_options & PInvokeGeneratorConfigurationOptions.GenerateGuidMember) != 0;
 
     public bool GenerateHelperTypes => (_options & PInvokeGeneratorConfigurationOptions.GenerateHelperTypes) != 0;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -96,4 +96,6 @@ public enum PInvokeGeneratorConfigurationOptions : long
     GenerateGeneratedCodeAttributeAsType = 1L << 42,
 
     ExcludeGeneratedCodeAttribute = 1L << 43,
+
+    GenerateExternVariables = 1L << 44,
 }

--- a/sources/ClangSharpPInvokeGenerator/Program.Options.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.Options.cs
@@ -217,6 +217,7 @@ internal static partial class Program
         new HelpRow("generate-cpp-attributes", "[CppAttributeList(\"\")] should be generated to document the encountered C++ attributes."),
         new HelpRow("generate-disable-runtime-marshalling", "[assembly: DisableRuntimeMarshalling] should be generated."),
         new HelpRow("generate-doc-includes", "<include> xml documentation tags should be generated for declarations."),
+        new HelpRow("generate-extern-variables", "Top-level extern/extern const global variables should be surfaced as settable pointer fields on a <Class>ManualImports struct for the consumer to resolve (like --with-manual-import). Opt-in; pointer and primitive types only."),
         new HelpRow("generate-file-scoped-namespaces", "Namespaces should be scoped to the file to reduce nesting."),
         new HelpRow("generate-fixed-buffer-indexer-overloads", "Fixed sized buffer helper types should generate additional uint, nint, and nuint indexer overloads."),
         new HelpRow("generate-generated-code=<mode>", "Controls the emission of the GeneratedCode attribute. 'assembly' (default) emits a single '[assembly: GeneratedCode]' when helper types are generated; 'type' instead annotates each generated top-level type; 'none' emits neither."),

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -430,6 +430,12 @@ internal static partial class Program
                     break;
                 }
 
+                case "generate-extern-variables":
+                {
+                    configOptions |= PInvokeGeneratorConfigurationOptions.GenerateExternVariables;
+                    break;
+                }
+
                 case "generate-helper-types":
                 {
                     configOptions |= PInvokeGeneratorConfigurationOptions.GenerateHelperTypes;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/ExternVariable/ExternGlobalsAreBound.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/ExternVariable/ExternGlobalsAreBound.CSharp.Latest.Windows.cs
@@ -1,0 +1,12 @@
+namespace ClangSharp.Test
+{
+    public unsafe partial struct MethodsManualImports
+    {
+        [NativeTypeName("const int")]
+        public int* kMyConstInt;
+
+        public int* MyMutableInt;
+
+        public void** MyMutablePointer;
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/ExternVariable/UnsupportedExternTypesAreSkipped.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/ExternVariable/UnsupportedExternTypesAreSkipped.CSharp.Latest.Windows.cs
@@ -1,0 +1,7 @@
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int X;
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/ExternVariableTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/ExternVariableTest.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using ClangSharp.UnitTests.Baseline;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>
+/// Regression tests for https://github.com/dotnet/ClangSharp/issues/504.
+/// The opt-in <c>generate-extern-variables</c> option surfaces top-level <c>extern</c> /
+/// <c>extern const</c> global variables (which the generator otherwise drops, since there is nothing to
+/// constant-fold). Mirroring <c>--with-manual-import</c>, each global is emitted as a settable instance
+/// pointer field on a synthesized <c>&lt;Class&gt;ManualImports</c> struct that the consumer populates
+/// itself, so the generator owns no <see cref="System.Runtime.InteropServices.NativeLibrary"/> handle.
+/// This is strictly opt-in because it emits API surface and only supports pointer and primitive shapes;
+/// const-ness is carried by <c>[NativeTypeName]</c>. Unsupported shapes (record-by-value, arrays) are
+/// skipped with a diagnostic, and the default output is unchanged when the option is off.
+/// </summary>
+[Platform("win")]
+public sealed class ExternVariableTest : StandaloneBaselineTest
+{
+    protected override string Area => "ExternVariable";
+
+    [Test]
+    public Task ExternGlobalsAreBound()
+    {
+        var inputContents = @"extern const int kMyConstInt;
+extern int MyMutableInt;
+extern void* MyMutablePointer;
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(inputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateExternVariables);
+    }
+
+    [Test]
+    public Task UnsupportedExternTypesAreSkipped()
+    {
+        var inputContents = @"struct MyStruct
+{
+    int X;
+};
+
+extern MyStruct MyGlobalStruct;
+";
+
+        var diagnostics = new[] {
+            new Diagnostic(DiagnosticLevel.Warning, "Extern variable 'MyGlobalStruct' has an unsupported type 'MyStruct' for 'generate-extern-variables' and was skipped. Only pointer and primitive types are supported.", "Line 6, Column 17 in ClangUnsavedFile.h")
+        };
+
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(inputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateExternVariables, expectedDiagnostics: diagnostics);
+    }
+
+    [Test]
+    public Task ExternGlobalsAreLeftUntouchedWhenNotOptedIn()
+    {
+        var inputContents = @"extern const int kMyConstInt;
+extern int MyMutableInt;
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(inputContents);
+    }
+}


### PR DESCRIPTION
Fixes #504

Top-level `extern` / `extern const` globals with no initializer are otherwise dropped, since there is nothing to constant-fold. The opt-in `generate-extern-variables` config flag now surfaces them.

Rather than have the generator own a `NativeLibrary` handle to resolve the exports (which cannot be released safely -- e.g. under a collectible `AssemblyLoadContext`, a hand-rolled static `NativeLibrary.Load` is untracked and the library stays mapped), this mirrors `--with-manual-import`: each global is emitted as a settable instance pointer field on a synthesized `<Class>ManualImports` struct that the consumer populates itself, however it resolves the rest of its manual imports. The generator owns no handle, so there is no lifetime story to get wrong.

For example, this input:

```c
extern const int kMyConstInt;
extern int MyMutableInt;
extern void* MyMutablePointer;
```

emits:

```csharp
public unsafe partial struct MethodsManualImports
{
    [NativeTypeName("const int")]
    public int* kMyConstInt;

    public int* MyMutableInt;

    public void** MyMutablePointer;
}
```

----------

Notes:

* Strictly opt-in -- it emits API surface and only ever supports pointer/primitive shapes. A record-by-value / array global would need real marshalling that a raw pointer field can''t model, so those are skipped with a diagnostic.
* Const-ness is carried by `[NativeTypeName]`; the field is a raw pointer into native storage.
* The holder is `<Class>ManualImports` where `<Class>` is the class the symbol would otherwise route into (default `Methods`), so `--with-class` remapping applies. The struct reuses the existing method-class wrapper (namespace / access / `unsafe` / `partial struct`) via a generator-side struct-name set, without mutating configuration.
* Default output is unchanged when the option is off.

> [!NOTE]
> This PR body was drafted by Copilot.
