### PR TITLE
Add a workflow to regenerate the native libclang and libClangSharp packages

### DIFF
--- a/.github/workflows/regenerate-native.yml
+++ b/.github/workflows/regenerate-native.yml
@@ -1,0 +1,270 @@
+name: regenerate-native
+
+# Regenerates the native runtime packages:
+#   * libclang.runtime.*        (the prebuilt libclang lifted from the matching LLVM release)
+#   * libClangSharp.runtime.*   (our helper library, compiled against that same LLVM release)
+#
+# libclang regenerates when the tracked LLVM major.minor version changes (the version in the
+# top-level CMakeLists.txt, which maps to the llvmorg-<version> release tag). libClangSharp
+# regenerates for that same reason or whenever sources/libClangSharp changes. Both can also be
+# forced via workflow_dispatch. See the "Regenerating native binaries" section in README.md.
+#
+# The jobs upload the resulting .nupkg files as build artifacts and sign them via the
+# separate sign-nuget leg; publishing to NuGet is manual.
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      libclang:
+        description: "Force regenerating the libclang runtime packages"
+        type: boolean
+        default: false
+      libclangsharp:
+        description: "Force regenerating the libClangSharp runtime packages"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: regenerate-native-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      llvm-version: ${{ steps.detect.outputs.llvm-version }}
+      libclang: ${{ steps.detect.outputs.libclang }}
+      libclangsharp: ${{ steps.detect.outputs.libclangsharp }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - id: detect
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        parse_version() { sed -n 's/^project(ClangSharp VERSION \([0-9.]*\)).*/\1/p' "$1"; }
+
+        # The top-level CMakeLists.txt is the source of truth for the tracked LLVM version.
+        version="$(parse_version CMakeLists.txt)"
+        if [ -z "${version}" ]; then echo "could not parse LLVM version from CMakeLists.txt" >&2; exit 1; fi
+        major_minor="${version%.*}"
+        echo "llvm-version=${version}" >> "$GITHUB_OUTPUT"
+
+        libclang=false
+        libclangsharp=false
+
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ inputs.libclang }}" = "true" ]; then libclang=true; fi
+          if [ "${{ inputs.libclangsharp }}" = "true" ]; then libclangsharp=true; fi
+        else
+          before="${{ github.event.before }}"
+          if [ -z "${before}" ] || [ "${before}" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "${before}^{commit}" 2>/dev/null; then
+            # No usable baseline to diff against (new/recreated branch, force-push,
+            # unfetched history); regenerate everything conservatively.
+            libclang=true
+            libclangsharp=true
+          else
+            # libclang regenerates when the tracked LLVM major.minor changes.
+            prev_version="$(git show "${before}:CMakeLists.txt" 2>/dev/null | sed -n 's/^project(ClangSharp VERSION \([0-9.]*\)).*/\1/p')"
+            prev_major_minor="${prev_version%.*}"
+            if [ "${major_minor}" != "${prev_major_minor}" ]; then
+              libclang=true
+            fi
+
+            # libClangSharp regenerates for the same reason or when its sources change.
+            if [ "${libclang}" = "true" ] || ! git diff --quiet "${before}" HEAD -- sources/libClangSharp/; then
+              libclangsharp=true
+            fi
+          fi
+        fi
+
+        echo "libclang=${libclang}" >> "$GITHUB_OUTPUT"
+        echo "libclangsharp=${libclangsharp}" >> "$GITHUB_OUTPUT"
+        echo "Resolved: llvm=${version} (major.minor=${major_minor}) libclang=${libclang} libclangsharp=${libclangsharp}"
+    - name: Verify package versions match the tracked LLVM version
+      # Guards against bumping CMakeLists.txt without updating the nuspec/runtime.json
+      # versions. libclang versions must equal the LLVM version exactly; libClangSharp
+      # versions must be that version plus an independent build revision (e.g. 21.1.8.2).
+      shell: bash
+      run: |
+        set -euo pipefail
+        version="${{ steps.detect.outputs.llvm-version }}"
+        rc=0
+
+        nuspec_version() { sed -n 's:.*<version>\([^<]*\)</version>.*:\1:p' "$1" | head -n1; }
+        nuspec_branch()  { sed -n 's:.*<repository[^>]*branch="\([^"]*\)".*:\1:p' "$1" | head -n1; }
+        json_versions()  { grep -oE '"[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?"' "$1" | tr -d '"'; }
+
+        fail() { echo "::error file=$1::$2"; rc=1; }
+
+        if [ "${{ steps.detect.outputs.libclang }}" = "true" ]; then
+          for f in packages/libclang/libclang/libclang.nuspec packages/libclang/libclang.runtime.*/*.nuspec; do
+            v="$(nuspec_version "$f")"
+            [ "${v}" = "${version}" ] || fail "$f" "version '${v}' does not match LLVM version '${version}'"
+            b="$(nuspec_branch "$f")"
+            if [ -n "${b}" ] && [ "${b}" != "llvmorg-${version}" ]; then
+              fail "$f" "repository branch '${b}' does not match 'llvmorg-${version}'"
+            fi
+          done
+          for v in $(json_versions packages/libclang/libclang/runtime.json); do
+            [ "${v}" = "${version}" ] || fail "packages/libclang/libclang/runtime.json" "mapped version '${v}' does not match LLVM version '${version}'"
+          done
+        fi
+
+        if [ "${{ steps.detect.outputs.libclangsharp }}" = "true" ]; then
+          for f in packages/libClangSharp/libClangSharp/libClangSharp.nuspec packages/libClangSharp/libClangSharp.runtime.*/*.nuspec; do
+            v="$(nuspec_version "$f")"
+            case "${v}" in
+              "${version}".*) : ;;
+              *) fail "$f" "version '${v}' is not 'llvm-version.<revision>' (expected '${version}.<n>')" ;;
+            esac
+          done
+          for v in $(json_versions packages/libClangSharp/libClangSharp/runtime.json); do
+            case "${v}" in
+              "${version}".*) : ;;
+              *) fail "packages/libClangSharp/libClangSharp/runtime.json" "mapped version '${v}' is not '${version}.<revision>'" ;;
+            esac
+          done
+        fi
+
+        if [ "${rc}" -ne 0 ]; then
+          echo "Update the package versions to match the tracked LLVM version (${version}) before regenerating." >&2
+          exit 1
+        fi
+        echo "Package versions verified against LLVM ${version}"
+
+  # -------- libclang: lift the prebuilt libclang out of the matching LLVM release --------
+
+  libclang:
+    needs: detect
+    if: ${{ needs.detect.outputs.libclang == 'true' }}
+    # Extraction just unpacks prebuilt binaries, so a single Windows runner (its
+    # bundled bsdtar handles .tar.xz) can produce every runtime's package.
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: NuGet/setup-nuget@v2
+    - name: Extract libclang and pack packages
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        New-Item -ItemType Directory -Force -Path out | Out-Null
+        foreach ($rid in @("win-x64", "win-arm64", "linux-x64", "linux-arm64", "osx-arm64")) {
+          ./scripts/build.ps1 -regeneratenative -target libclang -rid $rid
+          Copy-Item "artifacts/native/$rid/*" "packages/libclang/libclang.runtime.$rid/"
+          nuget pack "packages/libclang/libclang.runtime.$rid/libclang.runtime.$rid.nuspec" -OutputDirectory out
+          if ($LASTEXITCODE -ne 0) { throw "nuget pack failed for $rid" }
+        }
+        nuget pack "packages/libclang/libclang/libclang.nuspec" -OutputDirectory out
+        if ($LASTEXITCODE -ne 0) { throw "nuget pack failed for the libclang meta package" }
+    - uses: actions/upload-artifact@v4
+      with:
+        name: libclang-packages
+        path: out/*.nupkg
+        if-no-files-found: error
+
+  # -------- libClangSharp: compile our helper against that same LLVM release --------
+
+  libclangsharp-build:
+    needs: detect
+    if: ${{ needs.detect.outputs.libclangsharp == 'true' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { rid: win-x64,     os: windows-latest }
+        - { rid: win-arm64,   os: windows-11-arm }
+        - { rid: linux-x64,   os: ubuntu-latest }
+        - { rid: linux-arm64, os: ubuntu-24.04-arm }
+        - { rid: osx-arm64,   os: macos-latest }
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build libClangSharp (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: ./scripts/build.ps1 -regeneratenative -target libClangSharp -rid ${{ matrix.rid }}
+    - name: Build libClangSharp (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: ./scripts/build.sh --regeneratenative --target libClangSharp --rid ${{ matrix.rid }}
+    - uses: actions/upload-artifact@v4
+      with:
+        name: libclangsharp-native-${{ matrix.rid }}
+        path: artifacts/native/${{ matrix.rid }}/*
+        if-no-files-found: error
+
+  libclangsharp-pack:
+    needs: [ detect, libclangsharp-build ]
+    if: ${{ needs.detect.outputs.libclangsharp == 'true' }}
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: NuGet/setup-nuget@v2
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: libclangsharp-native-*
+        path: staging
+    - name: Pack libClangSharp packages
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p out
+        for rid in win-x64 win-arm64 linux-x64 linux-arm64 osx-arm64; do
+          cp staging/"libclangsharp-native-${rid}"/* "packages/libClangSharp/libClangSharp.runtime.${rid}/"
+          nuget pack "packages/libClangSharp/libClangSharp.runtime.${rid}/libClangSharp.runtime.${rid}.nuspec" -OutputDirectory out
+        done
+        nuget pack "packages/libClangSharp/libClangSharp/libClangSharp.nuspec" -OutputDirectory out
+    - uses: actions/upload-artifact@v4
+      with:
+        name: libClangSharp-packages
+        path: out/*.nupkg
+        if-no-files-found: error
+
+  # -------- sign the native packages (separate leg, native-specific file list) --------
+
+  sign-nuget:
+    needs: [ libclang, libclangsharp-pack ]
+    # Sign on pushes to main whenever the legs that actually ran succeeded. A leg that
+    # was version-gated out is 'skipped' (not a failure), so a libClangSharp-only
+    # regeneration still gets signed; a real failure or cancellation blocks signing.
+    if: >-
+      ${{ github.event_name == 'push'
+          && !cancelled()
+          && needs.libclang.result != 'failure'
+          && needs.libclangsharp-pack.result != 'failure'
+          && (needs.libclang.result == 'success' || needs.libclangsharp-pack.result == 'success') }}
+    runs-on: windows-latest
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true
+        path: ./artifacts/pkg
+        pattern: "lib*-packages"
+    - uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: ./global.json
+    - run: dotnet tool install --tool-path ./artifacts/tools --prerelease sign
+    - uses: azure/login@v2
+      with:
+        allow-no-subscriptions: true
+        client-id: "${{ secrets.AZURE_CLIENT_ID }}"
+        tenant-id: "${{ secrets.AZURE_TENANT_ID }}"
+    - run: ./artifacts/tools/sign code azure-key-vault "**/*.nupkg" --base-directory "${{ github.workspace }}/artifacts/pkg" --file-list "${{ github.workspace }}/scripts/SignClientFileListNative.txt" --publisher-name ".NET Foundation" --description "ClangSharp" --description-url "https://github.com/dotnet/clangsharp" --azure-credential-type "azure-cli" --azure-key-vault-url "${{ secrets.KEY_VAULT_URL }}" --azure-key-vault-certificate "${{ secrets.KEY_VAULT_CERTIFICATE_ID }}"
+      shell: pwsh
+    - uses: actions/upload-artifact@v4
+      with:
+        name: sign_nuget_native
+        path: |
+          ./artifacts/pkg/**/*
+        if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(ClangSharp VERSION 21.1.8)
+project(ClangSharp VERSION 22.1.8)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Source browsing is available via: https://source.clangsharp.dev/
 * [Features](#features)
 * [Building Managed](#building-managed)
 * [Building Native](#building-native)
+* [Regenerating native binaries](#regenerating-native-binaries)
 * [Generating Bindings](#generating-bindings)
   * [Best practices](docs/generating-bindings-best-practices.md)
   * [XML binding format](docs/xml-binding-format.md)
@@ -78,7 +79,7 @@ To successfully build `libClangSharp` you must first build Clang (https://clang.
 
 The process done on Windows is roughly:
 ```cmd
-git clone --single-branch --branch llvmorg-21.1.8 https://github.com/llvm/llvm-project
+git clone --single-branch --branch llvmorg-22.1.8 https://github.com/llvm/llvm-project
 cd llvm-project
 mkdir artifacts/bin
 cd artifacts/bin
@@ -102,7 +103,7 @@ You can then open `libClangSharp.slnx` in Visual Studio, change the configuratio
 
 The process done on Linux is roughly:
 ```bash
-git clone --single-branch --branch llvmorg-21.1.8 https://github.com/llvm/llvm-project
+git clone --single-branch --branch llvmorg-22.1.8 https://github.com/llvm/llvm-project
 cd llvm-project
 mkdir -p artifacts/bin
 cd artifacts/bin
@@ -127,6 +128,32 @@ cd artifacts/bin/native
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DPATH_TO_LLVM=../../../../llvm-project/artifacts/install ../../../
 make install
 ```
+
+### Regenerating native binaries
+
+The native runtime packages are produced by CI (`.github/workflows/regenerate-native.yml`) rather than by hand:
+
+* `libclang.runtime.*` (and the `libclang` meta-package) — the prebuilt `libclang` shared library, lifted directly from the matching official LLVM release.
+* `libClangSharp.runtime.*` (and the `libClangSharp` meta-package) — the `libClangSharp` helper, compiled from `sources/libClangSharp` against that same LLVM release.
+
+The tracked LLVM version is the `project(ClangSharp VERSION X.Y.Z)` value in the top-level `CMakeLists.txt`, which maps to the `llvmorg-X.Y.Z` release tag. For each runtime (`win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-arm64`) the download-and-stage step is handled by `scripts/build.ps1`/`scripts/build.sh`:
+
+```
+# lift the prebuilt libclang out of the matching LLVM release
+./scripts/build.sh --regeneratenative --target libclang --rid linux-x64
+
+# compile libClangSharp against that same LLVM release
+./scripts/build.sh --regeneratenative --target libClangSharp --rid linux-x64
+```
+
+The staged binary is written to `artifacts/native/<rid>/`. The LLVM release distribution bundles both the prebuilt `libclang` and the `lib/cmake/{llvm,clang}` config, headers, and import libraries used as `PATH_TO_LLVM` when building `libClangSharp`, so no from-source LLVM build is required (the manual [Building Native](#building-native) steps remain the way to reproduce a build locally). Because lifting `libclang` is just unpacking prebuilt binaries, the workflow does all five runtimes on a single Windows runner (its bundled `bsdtar` handles `.tar.xz`); `libClangSharp` is compiled per-runtime on native runners.
+
+The jobs run when:
+
+* **libclang** — the tracked LLVM major/minor version changes, or the workflow is dispatched manually with the `libclang` input set.
+* **libClangSharp** — the same LLVM version change, or anything under `sources/libClangSharp/` changes, or the workflow is dispatched manually with the `libclangsharp` input set.
+
+Before anything is downloaded, the workflow verifies the `packages/**/*.nuspec` and `packages/**/runtime.json` versions match the tracked LLVM version (libclang exactly; libClangSharp as `<llvm-version>.<revision>`), so a version bump that forgot to update a package fails fast. Each job uploads the resulting `.nupkg` files as build artifacts and signs them; publishing them to NuGet.org is a manual step. To move to a new LLVM release, bump the version in `CMakeLists.txt` alongside the `<version>` in the affected `packages/**/*.nuspec` files (and the versions in `packages/**/runtime.json` and this README); pushing that change regenerates the packages.
 
 ### Generating Bindings
 

--- a/packages/libClangSharp/libClangSharp.runtime.linux-arm64/libClangSharp.runtime.linux-arm64.nuspec
+++ b/packages/libClangSharp/libClangSharp.runtime.linux-arm64/libClangSharp.runtime.linux-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libClangSharp.runtime.linux-arm64</id>
-    <version>21.1.8.2</version>
+    <version>22.1.8.1</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libClangSharp/libClangSharp.runtime.linux-x64/libClangSharp.runtime.linux-x64.nuspec
+++ b/packages/libClangSharp/libClangSharp.runtime.linux-x64/libClangSharp.runtime.linux-x64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libClangSharp.runtime.linux-x64</id>
-    <version>21.1.8.2</version>
+    <version>22.1.8.1</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libClangSharp/libClangSharp.runtime.osx-arm64/libClangSharp.runtime.osx-arm64.nuspec
+++ b/packages/libClangSharp/libClangSharp.runtime.osx-arm64/libClangSharp.runtime.osx-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libClangSharp.runtime.osx-arm64</id>
-    <version>21.1.8.2</version>
+    <version>22.1.8.1</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libClangSharp/libClangSharp.runtime.win-arm64/libClangSharp.runtime.win-arm64.nuspec
+++ b/packages/libClangSharp/libClangSharp.runtime.win-arm64/libClangSharp.runtime.win-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libClangSharp.runtime.win-arm64</id>
-    <version>21.1.8.2</version>
+    <version>22.1.8.1</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libClangSharp/libClangSharp.runtime.win-x64/libClangSharp.runtime.win-x64.nuspec
+++ b/packages/libClangSharp/libClangSharp.runtime.win-x64/libClangSharp.runtime.win-x64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libClangSharp.runtime.win-x64</id>
-    <version>21.1.8.2</version>
+    <version>22.1.8.1</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libClangSharp/libClangSharp/libClangSharp.nuspec
+++ b/packages/libClangSharp/libClangSharp/libClangSharp.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libClangSharp</id>
-    <version>21.1.8.2</version>
+    <version>22.1.8.1</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libClangSharp/libClangSharp/runtime.json
+++ b/packages/libClangSharp/libClangSharp/runtime.json
@@ -2,27 +2,27 @@
   "runtimes": {
     "linux-arm64": {
       "libClangSharp": {
-        "libClangSharp.runtime.linux-arm64": "21.1.8.2"
+        "libClangSharp.runtime.linux-arm64": "22.1.8.1"
       }
     },
     "linux-x64": {
       "libClangSharp": {
-        "libClangSharp.runtime.linux-x64": "21.1.8.2"
+        "libClangSharp.runtime.linux-x64": "22.1.8.1"
       }
     },
     "osx-arm64": {
       "libClangSharp": {
-        "libClangSharp.runtime.osx-arm64": "21.1.8.2"
+        "libClangSharp.runtime.osx-arm64": "22.1.8.1"
       }
     },
     "win-arm64": {
       "libClangSharp": {
-        "libClangSharp.runtime.win-arm64": "21.1.8.2"
+        "libClangSharp.runtime.win-arm64": "22.1.8.1"
       }
     },
     "win-x64": {
       "libClangSharp": {
-        "libClangSharp.runtime.win-x64": "21.1.8.2"
+        "libClangSharp.runtime.win-x64": "22.1.8.1"
       }
     }
   }

--- a/packages/libclang/libclang.runtime.linux-arm64/libclang.runtime.linux-arm64.nuspec
+++ b/packages/libclang/libclang.runtime.linux-arm64/libclang.runtime.linux-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libclang.runtime.linux-arm64</id>
-    <version>21.1.8</version>
+    <version>22.1.8</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/dotnet/clangsharp</projectUrl>
     <description>linux arm64 native library for libclang.</description>
     <copyright>Copyright © LLVM Project</copyright>
-    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-21.1.8" />
+    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-22.1.8" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />

--- a/packages/libclang/libclang.runtime.linux-x64/libclang.runtime.linux-x64.nuspec
+++ b/packages/libclang/libclang.runtime.linux-x64/libclang.runtime.linux-x64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libclang.runtime.linux-x64</id>
-    <version>21.1.8</version>
+    <version>22.1.8</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/dotnet/clangsharp</projectUrl>
     <description>linux x64 native library for libclang.</description>
     <copyright>Copyright © LLVM Project</copyright>
-    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-21.1.8" />
+    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-22.1.8" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />

--- a/packages/libclang/libclang.runtime.osx-arm64/libclang.runtime.osx-arm64.nuspec
+++ b/packages/libclang/libclang.runtime.osx-arm64/libclang.runtime.osx-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libclang.runtime.osx-arm64</id>
-    <version>21.1.8</version>
+    <version>22.1.8</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/dotnet/clangsharp</projectUrl>
     <description>osx arm64 native library for libclang.</description>
     <copyright>Copyright © LLVM Project</copyright>
-    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-21.1.8" />
+    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-22.1.8" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />

--- a/packages/libclang/libclang.runtime.win-arm64/libclang.runtime.win-arm64.nuspec
+++ b/packages/libclang/libclang.runtime.win-arm64/libclang.runtime.win-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libclang.runtime.win-arm64</id>
-    <version>21.1.8</version>
+    <version>22.1.8</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/dotnet/clangsharp</projectUrl>
     <description>win arm64 native library for libclang.</description>
     <copyright>Copyright © LLVM Project</copyright>
-    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-21.1.8" />
+    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-22.1.8" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />

--- a/packages/libclang/libclang.runtime.win-x64/libclang.runtime.win-x64.nuspec
+++ b/packages/libclang/libclang.runtime.win-x64/libclang.runtime.win-x64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libclang.runtime.win-x64</id>
-    <version>21.1.8</version>
+    <version>22.1.8</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/dotnet/clangsharp</projectUrl>
     <description>win x64 native library for libclang.</description>
     <copyright>Copyright © LLVM Project</copyright>
-    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-21.1.8" />
+    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-22.1.8" />
   </metadata>
   <files>
     <file src="..\libclang\LICENSE.TXT" target="LICENSE.TXT" />

--- a/packages/libclang/libclang/libclang.nuspec
+++ b/packages/libclang/libclang/libclang.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libclang</id>
-    <version>21.1.8</version>
+    <version>22.1.8</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/dotnet/clangsharp</projectUrl>
     <description>Multi-platform native library for libclang.</description>
     <copyright>Copyright © LLVM Project</copyright>
-    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-21.1.8" />
+    <repository type="git" url="https://github.com/llvm/llvm-project" branch="llvmorg-22.1.8" />
     <dependencies>
       <group targetFramework=".NETStandard2.0" />
     </dependencies>

--- a/packages/libclang/libclang/runtime.json
+++ b/packages/libclang/libclang/runtime.json
@@ -2,27 +2,27 @@
   "runtimes": {
     "linux-arm64": {
       "libclang": {
-        "libclang.runtime.linux-arm64": "21.1.8"
+        "libclang.runtime.linux-arm64": "22.1.8"
       }
     },
     "linux-x64": {
       "libclang": {
-        "libclang.runtime.linux-x64": "21.1.8"
+        "libclang.runtime.linux-x64": "22.1.8"
       }
     },
     "osx-arm64": {
       "libclang": {
-        "libclang.runtime.osx-arm64": "21.1.8"
+        "libclang.runtime.osx-arm64": "22.1.8"
       }
     },
     "win-arm64": {
       "libclang": {
-        "libclang.runtime.win-arm64": "21.1.8"
+        "libclang.runtime.win-arm64": "22.1.8"
       }
     },
     "win-x64": {
       "libclang": {
-        "libclang.runtime.win-x64": "21.1.8"
+        "libclang.runtime.win-x64": "22.1.8"
       }
     }
   }

--- a/scripts/SignClientFileListNative.txt
+++ b/scripts/SignClientFileListNative.txt
@@ -1,0 +1,2 @@
+**/libclang.dll
+**/libClangSharp.dll

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -5,9 +5,13 @@ Param(
   [switch] $ci,
   [ValidateSet("Debug", "Release")][string] $configuration = "Debug",
   [switch] $help,
+  [string] $llvm = "",
   [switch] $pack,
+  [switch] $regeneratenative,
   [switch] $restore,
+  [ValidateSet("", "win-x64", "win-arm64", "linux-x64", "linux-arm64", "osx-arm64")][string] $rid = "",
   [string] $solution = "",
+  [ValidateSet("", "libclang", "libClangSharp")][string] $target = "",
   [switch] $test,
   [switch] $testwin32metadata,
   [ValidateSet("quiet", "minimal", "normal", "detailed", "diagnostic")][string] $verbosity = "minimal",
@@ -44,6 +48,8 @@ function Help() {
     Write-Host -Object "  -build                  Build solution"
     Write-Host -Object "  -test                   Run all tests in the solution"
     Write-Host -Object "  -pack                   Package build artifacts"
+    Write-Host -Object "  -regeneratenative       Download the matching LLVM release and stage a native binary"
+    Write-Host -Object "                          (use with -target and -rid)"
     Write-Host -Object ""
     Write-Host -Object "Advanced settings:"
     Write-Host -Object "  -solution <value>       Path to solution to build"
@@ -80,6 +86,132 @@ function Restore() {
 
   if ($LastExitCode -ne 0) {
     throw "'Restore' failed for '$solution'"
+  }
+}
+
+function Get-LlvmVersion() {
+  if ($llvm -ne "") {
+    return $llvm
+  }
+
+  $cmakeLists = Join-Path -Path $RepoRoot -ChildPath "CMakeLists.txt"
+  $match = Select-String -Path $cmakeLists -Pattern 'project\(ClangSharp VERSION ([0-9.]+)\)' | Select-Object -First 1
+
+  if (-not $match) {
+    throw "Could not parse the LLVM version from '$cmakeLists'"
+  }
+
+  return $match.Matches[0].Groups[1].Value
+}
+
+function Download-Llvm([string] $version, [string] $runtime, [string] $destination) {
+  $asset = switch ($runtime) {
+    "win-x64"     { "clang+llvm-$version-x86_64-pc-windows-msvc.tar.xz" }
+    "win-arm64"   { "clang+llvm-$version-aarch64-pc-windows-msvc.tar.xz" }
+    "linux-x64"   { "LLVM-$version-Linux-X64.tar.xz" }
+    "linux-arm64" { "LLVM-$version-Linux-ARM64.tar.xz" }
+    "osx-arm64"   { "LLVM-$version-macOS-ARM64.tar.xz" }
+    default       { throw "Unsupported runtime identifier '$runtime'" }
+  }
+
+  $url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-$version/$asset"
+  $archive = Join-Path -Path $ArtifactsDir -ChildPath "llvm-$runtime.tar.xz"
+
+  Create-Directory -Path $destination
+
+  # Windows ships bsdtar (libarchive) as tar.exe, which handles .tar.xz.
+  & curl.exe -fSL $url -o $archive
+
+  if ($LastExitCode -ne 0) {
+    throw "'curl' failed to download '$url'"
+  }
+
+  & tar -xf $archive -C $destination --strip-components=1
+
+  if ($LastExitCode -ne 0) {
+    throw "'tar' failed to extract '$archive'"
+  }
+}
+
+function Extract-Libclang([string] $runtime, [string] $source, [string] $destination) {
+  $pattern = switch -Wildcard ($runtime) {
+    "win-*"   { "libclang.dll" }
+    "linux-*" { "libclang.so*" }
+    "osx-*"   { "libclang.dylib" }
+  }
+
+  $name = switch -Wildcard ($runtime) {
+    "win-*"   { "libclang.dll" }
+    "linux-*" { "libclang.so" }
+    "osx-*"   { "libclang.dylib" }
+  }
+
+  # The Linux release ships a versioned real .so alongside symlinks, so pick the real
+  # file (largest) to get actual contents, matching the 'find -type f' in build.sh.
+  $lib = Get-ChildItem -Recurse -Path $source -Filter $pattern -File | Sort-Object -Property "Length" -Descending | Select-Object -First 1
+
+  if (-not $lib) {
+    throw "'$name' was not found in the LLVM release for '$runtime'"
+  }
+
+  Copy-Item -Path $lib.FullName -Destination (Join-Path -Path $destination -ChildPath $name)
+}
+
+function Build-Libclangsharp([string] $runtime, [string] $source, [string] $destination) {
+  $arch = switch ($runtime) {
+    "win-x64"   { "x64" }
+    "win-arm64" { "ARM64" }
+    default     { throw "'$runtime' cannot build libClangSharp on Windows; use build.sh on the matching runner" }
+  }
+
+  $nativeBuildDir = Join-Path -Path $ArtifactsDir -ChildPath "bin\native\$runtime"
+  $pathToLlvm = (Resolve-Path -Path $source).Path
+
+  & cmake -B "$nativeBuildDir" -S "$RepoRoot" -G "Visual Studio 17 2022" -A "$arch" "-Thost=$arch" "-DPATH_TO_LLVM=$pathToLlvm"
+
+  if ($LastExitCode -ne 0) {
+    throw "'cmake' configure failed for '$runtime'"
+  }
+
+  & cmake --build "$nativeBuildDir" --config Release --target ClangSharp
+
+  if ($LastExitCode -ne 0) {
+    throw "'cmake' build failed for '$runtime'"
+  }
+
+  $lib = Get-ChildItem -Recurse -Path $nativeBuildDir -Filter "libClangSharp.dll" -File | Select-Object -First 1
+
+  if (-not $lib) {
+    throw "'libClangSharp.dll' was not produced for '$runtime'"
+  }
+
+  Copy-Item -Path $lib.FullName -Destination (Join-Path -Path $destination -ChildPath "libClangSharp.dll")
+}
+
+function Regenerate-Native() {
+  if ($rid -eq "") {
+    throw "-rid is required with -regeneratenative"
+  }
+
+  if ($target -eq "") {
+    throw "-target is required with -regeneratenative"
+  }
+
+  $version = Get-LlvmVersion
+  $llvmDir = Join-Path -Path $ArtifactsDir -ChildPath "llvm\$rid"
+  $stagingDir = Join-Path -Path $ArtifactsDir -ChildPath "native\$rid"
+
+  Download-Llvm -version "$version" -runtime "$rid" -destination "$llvmDir"
+  Create-Directory -Path $stagingDir
+
+  if ($target -eq "libclang") {
+    Extract-Libclang -runtime "$rid" -source "$llvmDir" -destination "$stagingDir"
+  }
+  elseif ($target -eq "libClangSharp") {
+    Build-Libclangsharp -runtime "$rid" -source "$llvmDir" -destination "$stagingDir"
+  }
+  else {
+    throw "Unsupported target '$target'"
   }
 }
 
@@ -206,6 +338,10 @@ try {
 
   if ($pack) {
     Pack
+  }
+
+  if ($regeneratenative) {
+    Regenerate-Native
   }
 }
 catch {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,9 +13,13 @@ build=false
 ci=false
 configuration='Debug'
 help=false
+llvm=''
 pack=false
+regeneratenative=false
 restore=false
+rid=''
 solution=''
+target=''
 test=false
 verbosity='minimal'
 properties=''
@@ -43,16 +47,32 @@ while [[ $# -gt 0 ]]; do
       help=true
       shift 1
       ;;
+    --llvm)
+      llvm=$2
+      shift 2
+      ;;
     --pack)
       pack=true
+      shift 1
+      ;;
+    --regeneratenative)
+      regeneratenative=true
       shift 1
       ;;
     --restore)
       restore=true
       shift 1
       ;;
+    --rid)
+      rid=$2
+      shift 2
+      ;;
     --solution)
       solution=$2
+      shift 2
+      ;;
+    --target)
+      target=$2
       shift 2
       ;;
     --test)
@@ -105,6 +125,8 @@ function Help {
   echo "  --build                   Build solution"
   echo "  --test                    Run all tests in the solution"
   echo "  --pack                    Package build artifacts"
+  echo "  --regeneratenative        Download the matching LLVM release and stage a native binary"
+  echo "                            (use with --target and --rid)"
   echo ""
   echo "Advanced settings:"
   echo "  --solution <value>        Path to solution to build"
@@ -183,6 +205,181 @@ function Test {
   fi
 }
 
+function GetLlvmVersion {
+  if [[ -n "$llvm" ]]; then
+    LASTEXITCODE=0
+    return
+  fi
+
+  llvm="$(sed -n 's/^project(ClangSharp VERSION \([0-9.]*\)).*/\1/p' "$RepoRoot/CMakeLists.txt")"
+
+  if [[ -z "$llvm" ]]; then
+    echo "Could not parse the LLVM version from '$RepoRoot/CMakeLists.txt'"
+    LASTEXITCODE=1
+    return "$LASTEXITCODE"
+  fi
+
+  LASTEXITCODE=0
+}
+
+function DownloadLlvm {
+  runtime="$1"
+  destination="$2"
+
+  case "$runtime" in
+    win-x64)     asset="clang+llvm-${llvm}-x86_64-pc-windows-msvc.tar.xz" ;;
+    win-arm64)   asset="clang+llvm-${llvm}-aarch64-pc-windows-msvc.tar.xz" ;;
+    linux-x64)   asset="LLVM-${llvm}-Linux-X64.tar.xz" ;;
+    linux-arm64) asset="LLVM-${llvm}-Linux-ARM64.tar.xz" ;;
+    osx-arm64)   asset="LLVM-${llvm}-macOS-ARM64.tar.xz" ;;
+    *)
+      echo "Unsupported runtime identifier '$runtime'"
+      LASTEXITCODE=1
+      return "$LASTEXITCODE"
+      ;;
+  esac
+
+  url="https://github.com/llvm/llvm-project/releases/download/llvmorg-${llvm}/${asset}"
+  archive="$ArtifactsDir/llvm-${runtime}.tar.xz"
+
+  CreateDirectory "$destination"
+
+  curl -fSL "$url" -o "$archive"
+  LASTEXITCODE=$?
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    echo "'curl' failed to download '$url'"
+    return "$LASTEXITCODE"
+  fi
+
+  tar -xf "$archive" -C "$destination" --strip-components=1
+  LASTEXITCODE=$?
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    echo "'tar' failed to extract '$archive'"
+    return "$LASTEXITCODE"
+  fi
+}
+
+function ExtractLibclang {
+  runtime="$1"
+  source="$2"
+  destination="$3"
+
+  # The Linux release ships a versioned real .so alongside symlinks, so restrict the
+  # match to real files (-type f) to get actual contents.
+  case "$runtime" in
+    win-*)   name='libclang.dll';   src="$(find "$source" -name 'libclang.dll' -type f | head -n1)" ;;
+    linux-*) name='libclang.so';    src="$(find "$source" -name 'libclang.so*' -type f | head -n1)" ;;
+    osx-*)   name='libclang.dylib'; src="$(find "$source" -name 'libclang.dylib' -type f | head -n1)" ;;
+  esac
+
+  if [[ -z "$src" ]]; then
+    echo "'$name' was not found in the LLVM release for '$runtime'"
+    LASTEXITCODE=1
+    return "$LASTEXITCODE"
+  fi
+
+  cp "$src" "$destination/$name"
+  LASTEXITCODE=$?
+}
+
+function BuildLibclangsharp {
+  runtime="$1"
+  source="$2"
+  destination="$3"
+
+  case "$runtime" in
+    linux-*|osx-*)
+      ;;
+    *)
+      echo "'$runtime' cannot build libClangSharp here; use build.ps1 on the matching runner"
+      LASTEXITCODE=1
+      return "$LASTEXITCODE"
+      ;;
+  esac
+
+  nativeBuildDir="$ArtifactsDir/bin/native/$runtime"
+
+  cmake -B "$nativeBuildDir" -S "$RepoRoot" -DCMAKE_BUILD_TYPE=Release -DPATH_TO_LLVM="$source"
+  LASTEXITCODE=$?
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    echo "'cmake' configure failed for '$runtime'"
+    return "$LASTEXITCODE"
+  fi
+
+  cmake --build "$nativeBuildDir" --target ClangSharp
+  LASTEXITCODE=$?
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    echo "'cmake' build failed for '$runtime'"
+    return "$LASTEXITCODE"
+  fi
+
+  case "$runtime" in
+    osx-*) name='libClangSharp.dylib' ;;
+    *)     name='libClangSharp.so' ;;
+  esac
+
+  # CMake's VERSION/SOVERSION emit a versioned library plus an unversioned symlink, so
+  # copy the dereferenced contents to get a real file.
+  src="$(find "$nativeBuildDir" -name "$name" | head -n1)"
+
+  if [[ -z "$src" ]]; then
+    echo "'$name' was not produced for '$runtime'"
+    LASTEXITCODE=1
+    return "$LASTEXITCODE"
+  fi
+
+  cp -L "$src" "$destination/$name"
+  LASTEXITCODE=$?
+}
+
+function RegenerateNative {
+  if [[ -z "$rid" ]]; then
+    echo "--rid is required with --regeneratenative"
+    LASTEXITCODE=1
+    return "$LASTEXITCODE"
+  fi
+
+  if [[ -z "$target" ]]; then
+    echo "--target is required with --regeneratenative"
+    LASTEXITCODE=1
+    return "$LASTEXITCODE"
+  fi
+
+  GetLlvmVersion
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    return "$LASTEXITCODE"
+  fi
+
+  llvmDir="$ArtifactsDir/llvm/$rid"
+  stagingDir="$ArtifactsDir/native/$rid"
+
+  DownloadLlvm "$rid" "$llvmDir"
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    return "$LASTEXITCODE"
+  fi
+
+  CreateDirectory "$stagingDir"
+
+  if [[ "$target" == "libclang" ]]; then
+    ExtractLibclang "$rid" "$llvmDir" "$stagingDir"
+  elif [[ "$target" == "libClangSharp" ]]; then
+    BuildLibclangsharp "$rid" "$llvmDir" "$stagingDir"
+  else
+    echo "Unsupported target '$target'"
+    LASTEXITCODE=1
+  fi
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    return "$LASTEXITCODE"
+  fi
+}
+
 if $help; then
   Help
   exit 0
@@ -254,6 +451,14 @@ fi
 
 if $pack; then
   Pack
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    return "$LASTEXITCODE"
+  fi
+fi
+
+if $regeneratenative; then
+  RegenerateNative
 
   if [ "$LASTEXITCODE" != 0 ]; then
     return "$LASTEXITCODE"


### PR DESCRIPTION
Adds a CI workflow that regenerates the native runtime packages and bumps the tracked LLVM version to exercise it.

----------

**`.github/workflows/regenerate-native.yml`** — on push to `main` (and via `workflow_dispatch`):
- `libclang.runtime.*` is lifted from the matching `llvmorg-<version>` LLVM release.
- `libClangSharp.runtime.*` is compiled against that same release.
- The resulting nupkgs are packed and signed on a separate native signing leg (`scripts/SignClientFileListNative.txt`), mirroring the managed `sign-nuget` job. Signing runs only for `push` (never PRs) and only when the legs that actually ran succeeded. Publishing to NuGet stays manual.

`libclang` regenerates when the tracked LLVM major.minor changes; `libClangSharp` regenerates for that same reason **or** when `sources/libClangSharp/` changes. A `detect` step fails fast if the nuspec/`runtime.json` versions drift from the `CMakeLists.txt` LLVM version.

----------

**`scripts/build.ps1` / `scripts/build.sh`** — the download-and-stage logic lives behind `-regeneratenative` (with `-target`/`-rid`/`-llvm`) so it can be run locally, rather than being inlined in YAML. Windows `bsdtar` handles `.tar.xz` extraction, so the `libclang` lift runs for all five runtimes on a single host.

----------

**LLVM 21.1.8 → 22.1.8** — the newest release carrying all five runtime assets we map (`win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-arm64`). This is the first real exercise of the workflow. The managed bindings (`// Ported from llvmorg-…` headers, `VersionPrefix`, docs) and the consuming `Directory.Packages.props` references are intentionally left until the packages are regenerated and published.

----------

The `regenerate-native` workflow has not run on Actions before; this is its first trip. README documents the flow under "Regenerating native binaries".