### PR TITLE
Add opt-in Objective-C binding generation

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Close.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Close.cs
@@ -156,6 +156,14 @@ public partial class PInvokeGenerator
                 }
             }
 
+            if (_generatedObjCBindings)
+            {
+                // The Objective-C support surface (`SEL` + `ObjectiveC`) is emitted inside the shared
+                // namespace in single-file mode, so its required using directives are hoisted here.
+                _ = usingDirectives.Add("System");
+                _ = usingDirectives.Add("System.Runtime.InteropServices");
+            }
+
             if (hasAnyContents || generateHelperTypes)
             {
                 using var sw = new StreamWriter(stream, s_defaultStreamWriterEncoding, DefaultStreamWriterBufferSize, leaveStreamOpen);
@@ -413,6 +421,14 @@ public partial class PInvokeGenerator
             hasNamespaceContent = GenerateSetsLastSystemErrorAttribute(this, stream, leaveStreamOpen, hasNamespaceContent);
             hasNamespaceContent = GenerateVtblIndexAttribute(this, stream, leaveStreamOpen, hasNamespaceContent);
             GenerateTransparentStructs(this, stream, leaveStreamOpen, hasNamespaceContent);
+        }
+
+        if (_generatedObjCBindings && (_config.OutputMode == PInvokeGeneratorOutputMode.CSharp))
+        {
+            // In single-file mode the shared namespace was already opened by the emitted protocol
+            // type(s), so the support surface just needs a leading blank line to separate it.
+            var hasNamespaceContent = !_config.GenerateMultipleFiles;
+            GenerateObjectiveCSupport(this, stream, leaveStreamOpen, hasNamespaceContent);
         }
 
         if (leaveStreamOpen && (_outputBuilderFactory.OutputBuilders.Any() || generateHelperTypes))
@@ -775,6 +791,140 @@ public partial class PInvokeGenerator
             }
 
             return true;
+        }
+
+        static void GenerateObjectiveCSupport(PInvokeGenerator generator, Stream? stream, bool leaveStreamOpen, bool hasNamespaceContent)
+        {
+            var config = generator.Config;
+
+            if (stream is null)
+            {
+                var outputPath = Path.Combine(config.OutputLocation, "ObjectiveC.cs");
+                stream = generator._outputStreamFactory(outputPath);
+            }
+
+            using var sw = new StreamWriter(stream, s_defaultStreamWriterEncoding, DefaultStreamWriterBufferSize, leaveStreamOpen);
+            sw.NewLine = "\n";
+
+            var indentString = "    ";
+
+            if (config.GenerateMultipleFiles)
+            {
+                if (!string.IsNullOrEmpty(config.HeaderText))
+                {
+                    sw.WriteLine(config.HeaderText);
+                }
+
+                sw.WriteLine("using System;");
+                sw.WriteLine("using System.Runtime.InteropServices;");
+                sw.WriteLine();
+
+                sw.Write("namespace ");
+                sw.Write(generator.GetNamespace("ObjectiveC"));
+
+                if (config.GenerateFileScopedNamespaces)
+                {
+                    sw.WriteLine(';');
+                    sw.WriteLine();
+                    indentString = "";
+                }
+                else
+                {
+                    sw.WriteLine();
+                    sw.WriteLine('{');
+                }
+            }
+            else
+            {
+                // The shared namespace is already open; emit only the type bodies, separated from
+                // the preceding content by a blank line.
+
+                if (config.GenerateFileScopedNamespaces)
+                {
+                    indentString = "";
+                }
+
+                if (hasNamespaceContent)
+                {
+                    sw.WriteLine();
+                }
+            }
+
+            // `SEL` is a strongly typed wrapper over the opaque selector pointer, mirroring how the
+            // Objective-C runtime models `SEL` as an opaque pointer.
+            sw.Write(indentString);
+            sw.WriteLine("/// <summary>Represents an Objective-C selector (<c>SEL</c>).</summary>");
+            sw.Write(indentString);
+            sw.WriteLine("public unsafe partial struct SEL : IEquatable<SEL>");
+            sw.Write(indentString);
+            sw.WriteLine('{');
+            sw.Write(indentString);
+            sw.WriteLine("    public void* Value;");
+            sw.WriteLine();
+            sw.Write(indentString);
+            sw.WriteLine("    public SEL(void* value)");
+            sw.Write(indentString);
+            sw.WriteLine("    {");
+            sw.Write(indentString);
+            sw.WriteLine("        Value = value;");
+            sw.Write(indentString);
+            sw.WriteLine("    }");
+            sw.WriteLine();
+            sw.Write(indentString);
+            sw.WriteLine("    public static bool operator ==(SEL left, SEL right) => left.Value == right.Value;");
+            sw.WriteLine();
+            sw.Write(indentString);
+            sw.WriteLine("    public static bool operator !=(SEL left, SEL right) => left.Value != right.Value;");
+            sw.WriteLine();
+            sw.Write(indentString);
+            sw.WriteLine("    public override bool Equals(object? obj) => (obj is SEL other) && Equals(other);");
+            sw.WriteLine();
+            sw.Write(indentString);
+            sw.WriteLine("    public bool Equals(SEL other) => Value == other.Value;");
+            sw.WriteLine();
+            sw.Write(indentString);
+            sw.WriteLine("    public override int GetHashCode() => ((nuint)Value).GetHashCode();");
+            sw.Write(indentString);
+            sw.WriteLine('}');
+            sw.WriteLine();
+
+            // The runtime surface: the cached raw `objc_msgSend` entry point (cast per call site to
+            // the selector's signature) plus the minimal registration/lookup helpers.
+            sw.Write(indentString);
+            sw.WriteLine("/// <summary>Provides access to the Objective-C runtime (<c>libobjc</c>).</summary>");
+            sw.Write(indentString);
+            sw.WriteLine("public static unsafe partial class ObjectiveC");
+            sw.Write(indentString);
+            sw.WriteLine('{');
+            sw.Write(indentString);
+            sw.WriteLine("    private const string LibObjC = \"/usr/lib/libobjc.A.dylib\";");
+            sw.WriteLine();
+            sw.Write(indentString);
+            sw.WriteLine("    /// <summary>The raw <c>objc_msgSend</c> entry point, cast per call site to the selector's signature.</summary>");
+            sw.Write(indentString);
+            sw.WriteLine("    public static readonly void* objc_msgSend = (void*)NativeLibrary.GetExport(NativeLibrary.Load(LibObjC), \"objc_msgSend\");");
+            sw.WriteLine();
+            sw.Write(indentString);
+            sw.WriteLine("    [DllImport(LibObjC, EntryPoint = \"sel_registerName\", ExactSpelling = true)]");
+            sw.Write(indentString);
+            sw.WriteLine("    public static extern SEL sel_registerName([MarshalAs(UnmanagedType.LPUTF8Str)] string name);");
+            sw.WriteLine();
+            sw.Write(indentString);
+            sw.WriteLine("    [DllImport(LibObjC, EntryPoint = \"objc_getClass\", ExactSpelling = true)]");
+            sw.Write(indentString);
+            sw.WriteLine("    public static extern void* objc_getClass([MarshalAs(UnmanagedType.LPUTF8Str)] string name);");
+            sw.Write(indentString);
+            sw.WriteLine('}');
+
+            if (config.GenerateMultipleFiles && !config.GenerateFileScopedNamespaces)
+            {
+                sw.WriteLine('}');
+            }
+
+            if (!leaveStreamOpen)
+            {
+                stream = null;
+            }
         }
 
         static bool GenerateNativeTypeNameAttribute(PInvokeGenerator generator, Stream? stream, bool leaveStreamOpen, bool hasNamespaceContent)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
@@ -540,6 +540,22 @@ public sealed partial class PInvokeGenerator
             {
                 result.typeName = GetTypeName(cursor, context, rootType, usingType.Desugar, ignoreTransparentStructsWhereRequired, isTemplate, out _);
             }
+            else if (type is ObjCObjectPointerType objCObjectPointerType)
+            {
+                // An Objective-C object reference (`id`, `NSObject *`, ...) is a pointer to the
+                // object. When it names a concrete `@interface` we map it to that generated struct
+                // pointer; the generic `id` (no interface) maps to `void*`.
+                var interfaceDecl = objCObjectPointerType.InterfaceDecl;
+                result.typeName = interfaceDecl is not null ? $"{EscapeName(GetRemappedCursorName(interfaceDecl))}*" : "void*";
+            }
+            else if (type is ObjCObjectType objCObjectType)
+            {
+                result.typeName = objCObjectType.Interface is ObjCInterfaceDecl objCInterfaceDecl ? EscapeName(GetRemappedCursorName(objCInterfaceDecl)) : "void";
+            }
+            else if (type is ObjCInterfaceType objCInterfaceType)
+            {
+                result.typeName = EscapeName(GetRemappedCursorName(objCInterfaceType.Decl));
+            }
             else
             {
                 AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported type: '{type.TypeClass}'. Falling back '{result.typeName}'.", cursor);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -110,7 +110,16 @@ public partial class PInvokeGenerator
             // case CX_DeclKind_ObjCCategory:
             // case CX_DeclKind_ObjCCategoryImpl:
             // case CX_DeclKind_ObjCImplementation:
-            // case CX_DeclKind_ObjCInterface:
+
+            case CX_DeclKind_ObjCInterface:
+            {
+                if (_config.GenerateObjectiveCBindings)
+                {
+                    VisitObjCInterfaceDecl((ObjCInterfaceDecl)decl);
+                    break;
+                }
+                goto default;
+            }
 
             case CX_DeclKind_ObjCProtocol:
             {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -107,7 +107,17 @@ public partial class PInvokeGenerator
 
             // case CX_DeclKind_NamespaceAlias:
             // case CX_DeclKind_ObjCCompatibleAlias:
-            // case CX_DeclKind_ObjCCategory:
+
+            case CX_DeclKind_ObjCCategory:
+            {
+                if (_config.GenerateObjectiveCBindings)
+                {
+                    VisitObjCCategoryDecl((ObjCCategoryDecl)decl);
+                    break;
+                }
+                goto default;
+            }
+
             // case CX_DeclKind_ObjCCategoryImpl:
             // case CX_DeclKind_ObjCImplementation:
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -111,7 +111,17 @@ public partial class PInvokeGenerator
             // case CX_DeclKind_ObjCCategoryImpl:
             // case CX_DeclKind_ObjCImplementation:
             // case CX_DeclKind_ObjCInterface:
-            // case CX_DeclKind_ObjCProtocol:
+
+            case CX_DeclKind_ObjCProtocol:
+            {
+                if (_config.GenerateObjectiveCBindings)
+                {
+                    VisitObjCProtocolDecl((ObjCProtocolDecl)decl);
+                    break;
+                }
+                goto default;
+            }
+
             // case CX_DeclKind_ObjCMethod:
             // case CX_DeclKind_ObjCProperty:
             // case CX_DeclKind_BuiltinTemplate:

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitObjCDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitObjCDecl.cs
@@ -71,18 +71,29 @@ public partial class PInvokeGenerator
         StopUsingOutputBuilder();
     }
 
-    // Emits the raw `Selectors` cache plus the friendly `objc_msgSend` members for the instance
-    // methods that fall within the v1 scalar/pointer/void subset. Anything outside that subset is
-    // diagnosed rather than emitted with a wrong ABI.
+    // Emits the raw `Selectors` cache plus the friendly `objc_msgSend` members (methods and
+    // properties) that fall within the v1 scalar/pointer/void subset. Anything outside that subset
+    // is diagnosed rather than emitted with a wrong ABI.
     private void EmitObjCMessageMembers(ObjCProtocolDecl objCProtocolDecl, string escapedParentName)
     {
         Debug.Assert(_outputBuilder is not null);
 
-        var emitted = new List<ObjCMessageMember>();
+        var selectors = new List<(string Field, string NativeSelector)>();
+        var seenSelectors = new HashSet<string>(StringComparer.Ordinal);
+        var methods = new List<ObjCMessageMember>();
+        var properties = new List<ObjCPropertyMember>();
+
+        void AddSelector(string field, string nativeSelector)
+        {
+            if (seenSelectors.Add(field))
+            {
+                selectors.Add((field, nativeSelector));
+            }
+        }
 
         foreach (var method in objCProtocolDecl.InstanceMethods)
         {
-            // Property accessors are surfaced via their properties in a later phase; class methods,
+            // Property accessors are surfaced through their `@property` below; class methods,
             // variadics, and by-value aggregate returns/parameters need dispatch machinery that is
             // deliberately out of scope for the first slice.
             if (method.IsPropertyAccessor)
@@ -109,10 +120,39 @@ public partial class PInvokeGenerator
                 parameters.Add((parmTypeName, parmName));
             }
 
-            emitted.Add(new ObjCMessageMember(memberName, nativeSelector, returnTypeName, parameters));
+            AddSelector(memberName, nativeSelector);
+            methods.Add(new ObjCMessageMember(memberName, returnTypeName, parameters));
         }
 
-        if (emitted.Count == 0)
+        foreach (var property in objCProtocolDecl.InstanceProperties)
+        {
+            if (IsAggregateType(property.Type))
+            {
+                AddDiagnostic(DiagnosticLevel.Warning, $"Objective-C property '{GetCursorName(property)}' on '@protocol {GetCursorName(objCProtocolDecl)}' is not supported: by-value aggregate types are not yet supported. It was skipped.", property);
+                continue;
+            }
+
+            var propertyName = EscapeName(GetRemappedCursorName(property));
+            var typeName = GetRemappedTypeName(property, objCProtocolDecl, property.Type, out _);
+
+            var getterSelector = property.GetterMethodDecl.Selector;
+            var getterField = EscapeName(getterSelector.Replace(':', '_'));
+            AddSelector(getterField, getterSelector);
+
+            var isReadOnly = (property.PropertyAttributes & CXObjCPropertyAttrKind.CXObjCPropertyAttr_readonly) != 0;
+            string? setterField = null;
+
+            if (!isReadOnly)
+            {
+                var setterSelector = property.SetterMethodDecl.Selector;
+                setterField = EscapeName(setterSelector.Replace(':', '_'));
+                AddSelector(setterField, setterSelector);
+            }
+
+            properties.Add(new ObjCPropertyMember(propertyName, typeName, getterField, setterField));
+        }
+
+        if (selectors.Count == 0)
         {
             return;
         }
@@ -128,9 +168,9 @@ public partial class PInvokeGenerator
         output.WriteIndentedLine("public static class Selectors");
         output.WriteBlockStart();
         {
-            foreach (var member in emitted)
+            foreach (var (field, nativeSelector) in selectors)
             {
-                output.WriteIndented($"public static readonly SEL {member.MemberName} = ObjectiveC.sel_registerName(\"{member.NativeSelector}\");");
+                output.WriteIndented($"public static readonly SEL {field} = ObjectiveC.sel_registerName(\"{nativeSelector}\");");
                 output.WriteNewline();
             }
         }
@@ -138,16 +178,11 @@ public partial class PInvokeGenerator
 
         // Friendly layer: named members that hide the selector lookup and the `objc_msgSend` cast,
         // dispatched on `this` exactly like the COM vtbl helpers dispatch on `lpVtbl`.
-        foreach (var member in emitted)
+        foreach (var member in methods)
         {
             output.WriteNewline();
 
             var prototype = new StringBuilder();
-            var fnPtrArgs = new StringBuilder();
-            var callArgs = new StringBuilder();
-
-            _ = fnPtrArgs.Append(escapedParentName).Append("*, SEL");
-            _ = callArgs.Append('(').Append(escapedParentName).Append("*)Unsafe.AsPointer(ref this), Selectors.").Append(member.MemberName);
 
             for (var i = 0; i < member.Parameters.Count; i++)
             {
@@ -159,18 +194,63 @@ public partial class PInvokeGenerator
                 }
 
                 _ = prototype.Append(typeName).Append(' ').Append(parmName);
-                _ = fnPtrArgs.Append(", ").Append(typeName);
-                _ = callArgs.Append(", ").Append(parmName);
             }
 
-            _ = fnPtrArgs.Append(", ").Append(member.ReturnTypeName);
+            var msgSend = BuildObjCMsgSend(escapedParentName, member.MemberName, member.ReturnTypeName, member.Parameters);
 
-            output.WriteIndented($"public {member.ReturnTypeName} {member.MemberName}({prototype}) => ");
-            output.Write($"((delegate* unmanaged<{fnPtrArgs}>)ObjectiveC.objc_msgSend)({callArgs});");
+            output.WriteIndented($"public {member.ReturnTypeName} {member.MemberName}({prototype}) => {msgSend};");
             output.WriteNewline();
         }
 
+        foreach (var property in properties)
+        {
+            output.WriteNewline();
+
+            var getter = BuildObjCMsgSend(escapedParentName, property.GetterField, property.TypeName, []);
+
+            if (property.SetterField is null)
+            {
+                output.WriteIndented($"public {property.TypeName} {property.PropertyName} => {getter};");
+                output.WriteNewline();
+            }
+            else
+            {
+                var setter = BuildObjCMsgSend(escapedParentName, property.SetterField, "void", [(property.TypeName, "value")]);
+
+                output.WriteIndentedLine($"public {property.TypeName} {property.PropertyName}");
+                output.WriteBlockStart();
+                {
+                    output.WriteIndented($"get => {getter};");
+                    output.WriteNewline();
+                    output.WriteIndented($"set => {setter};");
+                    output.WriteNewline();
+                }
+                output.WriteBlockEnd();
+            }
+        }
+
         _outputBuilder.EndCSharpCode(output);
+    }
+
+    // Builds the friendly-member body: a per-call-site cast of the cached `objc_msgSend` pointer to
+    // the selector's signature, invoked on `this` with the registered selector.
+    private static string BuildObjCMsgSend(string escapedParentName, string selectorField, string returnTypeName, IReadOnlyList<(string TypeName, string ArgExpr)> args)
+    {
+        var fnPtrArgs = new StringBuilder();
+        var callArgs = new StringBuilder();
+
+        _ = fnPtrArgs.Append(escapedParentName).Append("*, SEL");
+        _ = callArgs.Append('(').Append(escapedParentName).Append("*)Unsafe.AsPointer(ref this), Selectors.").Append(selectorField);
+
+        foreach (var (typeName, argExpr) in args)
+        {
+            _ = fnPtrArgs.Append(", ").Append(typeName);
+            _ = callArgs.Append(", ").Append(argExpr);
+        }
+
+        _ = fnPtrArgs.Append(", ").Append(returnTypeName);
+
+        return $"((delegate* unmanaged<{fnPtrArgs}>)ObjectiveC.objc_msgSend)({callArgs})";
     }
 
     // v1 message-send subset: no variadics and no by-value aggregate return/parameter types, so the
@@ -207,11 +287,18 @@ public partial class PInvokeGenerator
         return type.CanonicalType.Kind is CXTypeKind.CXType_Record;
     }
 
-    private readonly struct ObjCMessageMember(string memberName, string nativeSelector, string returnTypeName, List<(string TypeName, string EscapedName)> parameters)
+    private readonly struct ObjCMessageMember(string memberName, string returnTypeName, List<(string TypeName, string EscapedName)> parameters)
     {
         public string MemberName { get; } = memberName;
-        public string NativeSelector { get; } = nativeSelector;
         public string ReturnTypeName { get; } = returnTypeName;
         public List<(string TypeName, string EscapedName)> Parameters { get; } = parameters;
+    }
+
+    private readonly struct ObjCPropertyMember(string propertyName, string typeName, string getterField, string? setterField)
+    {
+        public string PropertyName { get; } = propertyName;
+        public string TypeName { get; } = typeName;
+        public string GetterField { get; } = getterField;
+        public string? SetterField { get; } = setterField;
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitObjCDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitObjCDecl.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using ClangSharp.Abstractions;
+using ClangSharp.CSharp;
 using ClangSharp.Interop;
 
 namespace ClangSharp;
@@ -64,19 +65,123 @@ public partial class PInvokeGenerator
                 _outputBuilder.WriteRegularField("void*", "isa");
                 _outputBuilder.EndField(in fieldDesc);
 
-                EmitObjCMessageMembers(objCProtocolDecl, escapedName);
+                EmitObjCMessageMembers(objCProtocolDecl, escapedName, supportsClassMembers: false);
             }
             _outputBuilder.EndStruct(in desc);
         }
         StopUsingOutputBuilder();
     }
 
-    // Emits the raw `Selectors` cache plus the friendly `objc_msgSend` members (methods and
+    private void VisitObjCInterfaceDecl(ObjCInterfaceDecl objCInterfaceDecl)
+    {
+        // Forward `@class Foo;` references carry no members; only the definition is emitted.
+        if (!objCInterfaceDecl.IsThisDeclarationADefinition)
+        {
+            return;
+        }
+
+        var nativeName = GetCursorName(objCInterfaceDecl);
+        var name = GetRemappedCursorName(objCInterfaceDecl);
+        var escapedName = EscapeName(name);
+
+        var superClass = objCInterfaceDecl.SuperClass;
+
+        _generatedObjCBindings = true;
+
+        // Record the full native declaration (superclass + adopted protocols) so the relationship is
+        // not lost. The generated structs are all `{ void* isa }` with identical layout, so an
+        // `{escapedName}*` can simply be reinterpreted as a superclass pointer to send inherited
+        // messages -- inherited members are intentionally not re-emitted (unlike a COM vtbl, dispatch
+        // is dynamic, so flattening would only bloat the output).
+        var nativeType = new StringBuilder($"@interface {nativeName}");
+
+        if (superClass is not null)
+        {
+            _ = nativeType.Append(" : ").Append(GetCursorName(superClass));
+        }
+
+        if (objCInterfaceDecl.Protocols.Count != 0)
+        {
+            _ = nativeType.Append(" <");
+
+            for (var i = 0; i < objCInterfaceDecl.Protocols.Count; i++)
+            {
+                if (i != 0)
+                {
+                    _ = nativeType.Append(", ");
+                }
+
+                _ = nativeType.Append(GetCursorName(objCInterfaceDecl.Protocols[i]));
+            }
+
+            _ = nativeType.Append('>');
+        }
+
+        StartUsingOutputBuilder(name, includeTestOutput: false);
+        {
+            Debug.Assert(_outputBuilder is not null);
+
+            var desc = new StructDesc {
+                AccessSpecifier = GetAccessSpecifier(objCInterfaceDecl, matchStar: true),
+                EscapedName = escapedName,
+                IsUnsafe = true,
+                NativeType = nativeType.ToString(),
+                NativeInheritance = (_config.GenerateNativeInheritanceAttribute && superClass is not null) ? GetRemappedCursorName(superClass) : null,
+                Location = objCInterfaceDecl.Location,
+                IsNested = false,
+                WriteCustomAttrs = static context => {
+                    (var objCInterfaceDecl, var generator) = ((ObjCInterfaceDecl, PInvokeGenerator))context;
+
+                    generator.WithAttributes(objCInterfaceDecl, emitGeneratedCodeAttribute: true);
+                    generator.WithUsings(objCInterfaceDecl);
+                },
+                CustomAttrGeneratorData = (objCInterfaceDecl, this),
+            };
+
+            _outputBuilder.BeginStruct(in desc);
+            {
+                // Raw layer: the object's first field (`isa`), a byte-for-byte match of
+                // `struct objc_object` and of every other generated Objective-C struct, which is what
+                // makes the pointer reinterpret to a superclass valid.
+                var fieldDesc = new FieldDesc {
+                    AccessSpecifier = AccessSpecifier.Public,
+                    NativeTypeName = "Class",
+                    EscapedName = "isa",
+                    ParentName = escapedName,
+                    Offset = null,
+                    NeedsNewKeyword = false,
+                };
+
+                _outputBuilder.BeginField(in fieldDesc);
+                _outputBuilder.WriteRegularField("void*", "isa");
+                _outputBuilder.EndField(in fieldDesc);
+
+                // The backing class object, used as the receiver for class (`+`) members and exposed
+                // for hand-rolled sends. Resolved once by name via the runtime.
+                var classOutput = _outputBuilder.BeginCSharpCode();
+                classOutput.WriteNewline();
+                classOutput.WriteIndented($"public static readonly void* Class = ObjectiveC.objc_getClass(\"{nativeName}\");");
+                classOutput.WriteNewline();
+                _outputBuilder.EndCSharpCode(classOutput);
+
+                EmitObjCMessageMembers(objCInterfaceDecl, escapedName, supportsClassMembers: true);
+            }
+            _outputBuilder.EndStruct(in desc);
+        }
+        StopUsingOutputBuilder();
+    }
     // properties) that fall within the v1 scalar/pointer/void subset. Anything outside that subset
     // is diagnosed rather than emitted with a wrong ABI.
-    private void EmitObjCMessageMembers(ObjCProtocolDecl objCProtocolDecl, string escapedParentName)
+    //
+    // Instance members dispatch on `this`; class members dispatch on the backing class object and
+    // are only emitted when the container has one (i.e. an `@interface`, via `supportsClassMembers`).
+    // A `@protocol` has no backing class, so its class-method/-property requirements are diagnosed
+    // and skipped rather than wired to a receiver that does not exist.
+    private void EmitObjCMessageMembers(ObjCContainerDecl container, string escapedParentName, bool supportsClassMembers)
     {
         Debug.Assert(_outputBuilder is not null);
+
+        var containerDesc = $"{(container is ObjCProtocolDecl ? "@protocol" : "@interface")} {GetCursorName(container)}";
 
         var selectors = new List<(string Field, string NativeSelector)>();
         var seenSelectors = new HashSet<string>(StringComparer.Ordinal);
@@ -91,25 +196,25 @@ public partial class PInvokeGenerator
             }
         }
 
-        foreach (var method in objCProtocolDecl.InstanceMethods)
+        void ProcessMethod(ObjCMethodDecl method, bool isClassMember)
         {
-            // Property accessors are surfaced through their `@property` below; class methods,
-            // variadics, and by-value aggregate returns/parameters need dispatch machinery that is
-            // deliberately out of scope for the first slice.
+            // Property accessors are surfaced through their `@property` below.
             if (method.IsPropertyAccessor)
             {
-                continue;
+                return;
             }
 
+            // Variadics and by-value aggregate returns/parameters need dispatch machinery
+            // (`objc_msgSend_stret`/promotion) that is deliberately out of scope for now.
             if (!IsInObjCMessageSubset(method, out var reason))
             {
-                AddDiagnostic(DiagnosticLevel.Warning, $"Objective-C method '{method.Selector}' on '@protocol {GetCursorName(objCProtocolDecl)}' is not supported: {reason}. It was skipped.", method);
-                continue;
+                AddDiagnostic(DiagnosticLevel.Warning, $"Objective-C method '{method.Selector}' on '{containerDesc}' is not supported: {reason}. It was skipped.", method);
+                return;
             }
 
             var nativeSelector = method.Selector;
             var memberName = EscapeName(nativeSelector.Replace(':', '_'));
-            var returnTypeName = IsTypeVoid(method, method.ReturnType) ? "void" : GetRemappedTypeName(method, objCProtocolDecl, method.ReturnType, out _);
+            var returnTypeName = IsTypeVoid(method, method.ReturnType) ? "void" : GetRemappedTypeName(method, container, method.ReturnType, out _);
 
             var parameters = new List<(string TypeName, string EscapedName)>();
 
@@ -121,19 +226,19 @@ public partial class PInvokeGenerator
             }
 
             AddSelector(memberName, nativeSelector);
-            methods.Add(new ObjCMessageMember(memberName, returnTypeName, parameters));
+            methods.Add(new ObjCMessageMember(memberName, returnTypeName, parameters, isClassMember, method.Handle.IsObjCOptional));
         }
 
-        foreach (var property in objCProtocolDecl.InstanceProperties)
+        void ProcessProperty(ObjCPropertyDecl property, bool isClassMember)
         {
             if (IsAggregateType(property.Type))
             {
-                AddDiagnostic(DiagnosticLevel.Warning, $"Objective-C property '{GetCursorName(property)}' on '@protocol {GetCursorName(objCProtocolDecl)}' is not supported: by-value aggregate types are not yet supported. It was skipped.", property);
-                continue;
+                AddDiagnostic(DiagnosticLevel.Warning, $"Objective-C property '{GetCursorName(property)}' on '{containerDesc}' is not supported: by-value aggregate types are not yet supported. It was skipped.", property);
+                return;
             }
 
             var propertyName = EscapeName(GetRemappedCursorName(property));
-            var typeName = GetRemappedTypeName(property, objCProtocolDecl, property.Type, out _);
+            var typeName = GetRemappedTypeName(property, container, property.Type, out _);
 
             var getterSelector = property.GetterMethodDecl.Selector;
             var getterField = EscapeName(getterSelector.Replace(':', '_'));
@@ -149,7 +254,42 @@ public partial class PInvokeGenerator
                 AddSelector(setterField, setterSelector);
             }
 
-            properties.Add(new ObjCPropertyMember(propertyName, typeName, getterField, setterField));
+            properties.Add(new ObjCPropertyMember(propertyName, typeName, getterField, setterField, isClassMember, property.Handle.IsObjCOptional));
+        }
+
+        foreach (var method in container.InstanceMethods)
+        {
+            ProcessMethod(method, isClassMember: false);
+        }
+
+        foreach (var property in container.InstanceProperties)
+        {
+            ProcessProperty(property, isClassMember: false);
+        }
+
+        if (supportsClassMembers)
+        {
+            foreach (var method in container.ClassMethods)
+            {
+                ProcessMethod(method, isClassMember: true);
+            }
+
+            foreach (var property in container.ClassProperties)
+            {
+                ProcessProperty(property, isClassMember: true);
+            }
+        }
+        else
+        {
+            foreach (var method in container.ClassMethods)
+            {
+                AddDiagnostic(DiagnosticLevel.Warning, $"Objective-C class method '{method.Selector}' on '{containerDesc}' is not supported: a protocol has no backing class object to dispatch on. It was skipped.", method);
+            }
+
+            foreach (var property in container.ClassProperties)
+            {
+                AddDiagnostic(DiagnosticLevel.Warning, $"Objective-C class property '{GetCursorName(property)}' on '{containerDesc}' is not supported: a protocol has no backing class object to dispatch on. It was skipped.", property);
+            }
         }
 
         if (selectors.Count == 0)
@@ -176,11 +316,13 @@ public partial class PInvokeGenerator
         }
         output.WriteBlockEnd();
 
-        // Friendly layer: named members that hide the selector lookup and the `objc_msgSend` cast,
-        // dispatched on `this` exactly like the COM vtbl helpers dispatch on `lpVtbl`.
+        // Friendly layer: named members that hide the selector lookup and the `objc_msgSend` cast.
+        // Instance members dispatch on `this` (like COM vtbl helpers dispatch on `lpVtbl`); class
+        // members are `static` and dispatch on the backing class object.
         foreach (var member in methods)
         {
             output.WriteNewline();
+            WriteObjCOptionalNote(output, member.IsOptional);
 
             var prototype = new StringBuilder();
 
@@ -196,28 +338,31 @@ public partial class PInvokeGenerator
                 _ = prototype.Append(typeName).Append(' ').Append(parmName);
             }
 
-            var msgSend = BuildObjCMsgSend(escapedParentName, member.MemberName, member.ReturnTypeName, member.Parameters);
+            var msgSend = BuildObjCMsgSend(member.IsClassMember, escapedParentName, member.MemberName, member.ReturnTypeName, member.Parameters);
+            var staticModifier = member.IsClassMember ? "static " : "";
 
-            output.WriteIndented($"public {member.ReturnTypeName} {member.MemberName}({prototype}) => {msgSend};");
+            output.WriteIndented($"public {staticModifier}{member.ReturnTypeName} {member.MemberName}({prototype}) => {msgSend};");
             output.WriteNewline();
         }
 
         foreach (var property in properties)
         {
             output.WriteNewline();
+            WriteObjCOptionalNote(output, property.IsOptional);
 
-            var getter = BuildObjCMsgSend(escapedParentName, property.GetterField, property.TypeName, []);
+            var getter = BuildObjCMsgSend(property.IsClassMember, escapedParentName, property.GetterField, property.TypeName, []);
+            var staticModifier = property.IsClassMember ? "static " : "";
 
             if (property.SetterField is null)
             {
-                output.WriteIndented($"public {property.TypeName} {property.PropertyName} => {getter};");
+                output.WriteIndented($"public {staticModifier}{property.TypeName} {property.PropertyName} => {getter};");
                 output.WriteNewline();
             }
             else
             {
-                var setter = BuildObjCMsgSend(escapedParentName, property.SetterField, "void", [(property.TypeName, "value")]);
+                var setter = BuildObjCMsgSend(property.IsClassMember, escapedParentName, property.SetterField, "void", [(property.TypeName, "value")]);
 
-                output.WriteIndentedLine($"public {property.TypeName} {property.PropertyName}");
+                output.WriteIndentedLine($"public {staticModifier}{property.TypeName} {property.PropertyName}");
                 output.WriteBlockStart();
                 {
                     output.WriteIndented($"get => {getter};");
@@ -232,15 +377,29 @@ public partial class PInvokeGenerator
         _outputBuilder.EndCSharpCode(output);
     }
 
-    // Builds the friendly-member body: a per-call-site cast of the cached `objc_msgSend` pointer to
-    // the selector's signature, invoked on `this` with the registered selector.
-    private static string BuildObjCMsgSend(string escapedParentName, string selectorField, string returnTypeName, IReadOnlyList<(string TypeName, string ArgExpr)> args)
+    // Optional protocol members may be unimplemented by a conforming object, so sending the message
+    // blindly can trap; flag them so callers know to guard with `respondsToSelector:`.
+    private static void WriteObjCOptionalNote(CSharpOutputBuilder output, bool isOptional)
     {
+        if (isOptional)
+        {
+            output.WriteIndentedLine("// @optional; guard with respondsToSelector: before sending.");
+        }
+    }
+
+    // Builds the friendly-member body: a per-call-site cast of the cached `objc_msgSend` pointer to
+    // the selector's signature. Instance members dispatch on `this`; class members dispatch on the
+    // backing class object exposed as the `Class` field.
+    private static string BuildObjCMsgSend(bool isClassMember, string escapedParentName, string selectorField, string returnTypeName, IReadOnlyList<(string TypeName, string ArgExpr)> args)
+    {
+        var receiverType = isClassMember ? "void*" : $"{escapedParentName}*";
+        var receiverExpr = isClassMember ? "Class" : $"({escapedParentName}*)Unsafe.AsPointer(ref this)";
+
         var fnPtrArgs = new StringBuilder();
         var callArgs = new StringBuilder();
 
-        _ = fnPtrArgs.Append(escapedParentName).Append("*, SEL");
-        _ = callArgs.Append('(').Append(escapedParentName).Append("*)Unsafe.AsPointer(ref this), Selectors.").Append(selectorField);
+        _ = fnPtrArgs.Append(receiverType).Append(", SEL");
+        _ = callArgs.Append(receiverExpr).Append(", Selectors.").Append(selectorField);
 
         foreach (var (typeName, argExpr) in args)
         {
@@ -287,18 +446,22 @@ public partial class PInvokeGenerator
         return type.CanonicalType.Kind is CXTypeKind.CXType_Record;
     }
 
-    private readonly struct ObjCMessageMember(string memberName, string returnTypeName, List<(string TypeName, string EscapedName)> parameters)
+    private readonly struct ObjCMessageMember(string memberName, string returnTypeName, List<(string TypeName, string EscapedName)> parameters, bool isClassMember, bool isOptional)
     {
         public string MemberName { get; } = memberName;
         public string ReturnTypeName { get; } = returnTypeName;
         public List<(string TypeName, string EscapedName)> Parameters { get; } = parameters;
+        public bool IsClassMember { get; } = isClassMember;
+        public bool IsOptional { get; } = isOptional;
     }
 
-    private readonly struct ObjCPropertyMember(string propertyName, string typeName, string getterField, string? setterField)
+    private readonly struct ObjCPropertyMember(string propertyName, string typeName, string getterField, string? setterField, bool isClassMember, bool isOptional)
     {
         public string PropertyName { get; } = propertyName;
         public string TypeName { get; } = typeName;
         public string GetterField { get; } = getterField;
         public string? SetterField { get; } = setterField;
+        public bool IsClassMember { get; } = isClassMember;
+        public bool IsOptional { get; } = isOptional;
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitObjCDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitObjCDecl.cs
@@ -171,7 +171,57 @@ public partial class PInvokeGenerator
         StopUsingOutputBuilder();
     }
 
-    // Emits the raw `Selectors` cache plus the friendly `objc_msgSend` members (methods and
+    private void VisitObjCCategoryDecl(ObjCCategoryDecl objCCategoryDecl)
+    {
+        var classInterface = objCCategoryDecl.ClassInterface;
+
+        // A category with no resolvable class (e.g. the base `@interface` was not parsed) has nowhere
+        // to attach its members, so there is no faithful mapping to emit.
+        if (classInterface is null)
+        {
+            AddDiagnostic(DiagnosticLevel.Warning, $"Objective-C category '{GetCursorName(objCCategoryDecl)}' has no resolvable class interface and was skipped.", objCCategoryDecl);
+            return;
+        }
+
+        var categoryName = GetCursorName(objCCategoryDecl);
+        var name = GetRemappedCursorName(classInterface);
+        var escapedName = EscapeName(name);
+
+        _generatedObjCBindings = true;
+
+        // A category extends an existing class, so it reopens that class's `partial struct` and adds
+        // only the new message members. The `isa` field and backing `Class` object already belong to
+        // the `@interface`'s emission, so they are not repeated here.
+        StartUsingOutputBuilder(name, includeTestOutput: false);
+        {
+            Debug.Assert(_outputBuilder is not null);
+
+            var desc = new StructDesc {
+                AccessSpecifier = GetAccessSpecifier(classInterface, matchStar: true),
+                EscapedName = escapedName,
+                IsUnsafe = true,
+                NativeType = $"@interface {GetCursorName(classInterface)} ({categoryName})",
+                Location = objCCategoryDecl.Location,
+                IsNested = false,
+                WriteCustomAttrs = static context => {
+                    (var objCCategoryDecl, var generator) = ((ObjCCategoryDecl, PInvokeGenerator))context;
+
+                    generator.WithAttributes(objCCategoryDecl, emitGeneratedCodeAttribute: true);
+                    generator.WithUsings(objCCategoryDecl);
+                },
+                CustomAttrGeneratorData = (objCCategoryDecl, this),
+            };
+
+            _outputBuilder.BeginStruct(in desc);
+            {
+                EmitObjCMessageMembers(objCCategoryDecl, escapedName, supportsClassMembers: true, hasPrecedingMembers: false);
+            }
+            _outputBuilder.EndStruct(in desc);
+        }
+        StopUsingOutputBuilder();
+    }
+
+
     // properties) that fall within the supported subset. Anything outside that subset is diagnosed
     // rather than emitted with a wrong ABI.
     //
@@ -179,11 +229,15 @@ public partial class PInvokeGenerator
     // are only emitted when the container has one (i.e. an `@interface`, via `supportsClassMembers`).
     // A `@protocol` has no backing class, so its class-method/-property requirements are diagnosed
     // and skipped rather than wired to a receiver that does not exist.
-    private void EmitObjCMessageMembers(ObjCContainerDecl container, string escapedParentName, bool supportsClassMembers)
+    private void EmitObjCMessageMembers(ObjCContainerDecl container, string escapedParentName, bool supportsClassMembers, bool hasPrecedingMembers = true)
     {
         Debug.Assert(_outputBuilder is not null);
 
-        var containerDesc = $"{(container is ObjCProtocolDecl ? "@protocol" : "@interface")} {GetCursorName(container)}";
+        var containerDesc = container switch {
+            ObjCProtocolDecl => $"@protocol {GetCursorName(container)}",
+            ObjCCategoryDecl category => $"@interface {GetCursorName(category.ClassInterface)} ({GetCursorName(category)})",
+            _ => $"@interface {GetCursorName(container)}",
+        };
 
         var selectors = new List<(string Field, string NativeSelector)>();
         var seenSelectors = new HashSet<string>(StringComparer.Ordinal);
@@ -303,9 +357,15 @@ public partial class PInvokeGenerator
         output.AddUsingDirective("System.Runtime.CompilerServices");
 
         // Raw layer: the registered selectors, kept public so nothing is hidden and any selector we
-        // did not wrap can still be sent by hand via `&ObjectiveC.objc_msgSend`.
-        output.WriteNewline();
-        output.WriteIndentedLine("public static class Selectors");
+        // did not wrap can still be sent by hand via `&ObjectiveC.objc_msgSend`. The leading blank line
+        // separates the cache from the preceding fields; a category reopens an otherwise-empty struct
+        // body, so it is suppressed there.
+        if (hasPrecedingMembers)
+        {
+            output.WriteNewline();
+        }
+
+        output.WriteIndentedLine("public static partial class Selectors");
         output.WriteBlockStart();
         {
             foreach (var (field, nativeSelector) in selectors)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitObjCDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitObjCDecl.cs
@@ -170,8 +170,10 @@ public partial class PInvokeGenerator
         }
         StopUsingOutputBuilder();
     }
-    // properties) that fall within the v1 scalar/pointer/void subset. Anything outside that subset
-    // is diagnosed rather than emitted with a wrong ABI.
+
+    // Emits the raw `Selectors` cache plus the friendly `objc_msgSend` members (methods and
+    // properties) that fall within the supported subset. Anything outside that subset is diagnosed
+    // rather than emitted with a wrong ABI.
     //
     // Instance members dispatch on `this`; class members dispatch on the backing class object and
     // are only emitted when the container has one (i.e. an `@interface`, via `supportsClassMembers`).
@@ -204,8 +206,8 @@ public partial class PInvokeGenerator
                 return;
             }
 
-            // Variadics and by-value aggregate returns/parameters need dispatch machinery
-            // (`objc_msgSend_stret`/promotion) that is deliberately out of scope for now.
+            // Variadics can't be expressed as a fixed unmanaged function-pointer signature, so they
+            // are the one remaining out-of-subset shape and are diagnosed rather than mis-emitted.
             if (!IsInObjCMessageSubset(method, out var reason))
             {
                 AddDiagnostic(DiagnosticLevel.Warning, $"Objective-C method '{method.Selector}' on '{containerDesc}' is not supported: {reason}. It was skipped.", method);
@@ -216,6 +218,7 @@ public partial class PInvokeGenerator
             var memberName = EscapeName(nativeSelector.Replace(':', '_'));
             var returnTypeName = IsTypeVoid(method, method.ReturnType) ? "void" : GetRemappedTypeName(method, container, method.ReturnType, out _);
 
+            var involvesAggregate = IsAggregateType(method.ReturnType);
             var parameters = new List<(string TypeName, string EscapedName)>();
 
             foreach (var parmVarDecl in method.Parameters)
@@ -223,22 +226,19 @@ public partial class PInvokeGenerator
                 var parmTypeName = GetRemappedTypeName(parmVarDecl, method, parmVarDecl.Type, out _);
                 var parmName = EscapeName(GetRemappedCursorName(parmVarDecl));
                 parameters.Add((parmTypeName, parmName));
+
+                involvesAggregate |= IsAggregateType(parmVarDecl.Type);
             }
 
             AddSelector(memberName, nativeSelector);
-            methods.Add(new ObjCMessageMember(memberName, returnTypeName, parameters, isClassMember, method.Handle.IsObjCOptional));
+            methods.Add(new ObjCMessageMember(memberName, returnTypeName, parameters, isClassMember, method.Handle.IsObjCOptional, involvesAggregate));
         }
 
         void ProcessProperty(ObjCPropertyDecl property, bool isClassMember)
         {
-            if (IsAggregateType(property.Type))
-            {
-                AddDiagnostic(DiagnosticLevel.Warning, $"Objective-C property '{GetCursorName(property)}' on '{containerDesc}' is not supported: by-value aggregate types are not yet supported. It was skipped.", property);
-                return;
-            }
-
             var propertyName = EscapeName(GetRemappedCursorName(property));
             var typeName = GetRemappedTypeName(property, container, property.Type, out _);
+            var involvesAggregate = IsAggregateType(property.Type);
 
             var getterSelector = property.GetterMethodDecl.Selector;
             var getterField = EscapeName(getterSelector.Replace(':', '_'));
@@ -254,7 +254,7 @@ public partial class PInvokeGenerator
                 AddSelector(setterField, setterSelector);
             }
 
-            properties.Add(new ObjCPropertyMember(propertyName, typeName, getterField, setterField, isClassMember, property.Handle.IsObjCOptional));
+            properties.Add(new ObjCPropertyMember(propertyName, typeName, getterField, setterField, isClassMember, property.Handle.IsObjCOptional, involvesAggregate));
         }
 
         foreach (var method in container.InstanceMethods)
@@ -323,7 +323,7 @@ public partial class PInvokeGenerator
         {
             output.WriteNewline();
             WriteObjCOptionalNote(output, member.IsOptional);
-
+            WriteObjCAggregateNote(output, member.InvolvesAggregate);
             var prototype = new StringBuilder();
 
             for (var i = 0; i < member.Parameters.Count; i++)
@@ -349,6 +349,7 @@ public partial class PInvokeGenerator
         {
             output.WriteNewline();
             WriteObjCOptionalNote(output, property.IsOptional);
+            WriteObjCAggregateNote(output, property.InvolvesAggregate);
 
             var getter = BuildObjCMsgSend(property.IsClassMember, escapedParentName, property.GetterField, property.TypeName, []);
             var staticModifier = property.IsClassMember ? "static " : "";
@@ -387,6 +388,18 @@ public partial class PInvokeGenerator
         }
     }
 
+    // A by-value struct in the signature is dispatched through the plain `objc_msgSend` on the
+    // assumption of the arm64 (Apple Silicon) ABI, where struct returns/arguments go through the
+    // normal entry point. The legacy x86-64 ABI would need `objc_msgSend_stret`/`_fpret` for some of
+    // these, which is intentionally unsupported now that Apple has dropped x86-64 macOS.
+    private static void WriteObjCAggregateNote(CSharpOutputBuilder output, bool involvesAggregate)
+    {
+        if (involvesAggregate)
+        {
+            output.WriteIndentedLine("// By-value struct in signature: assumes the arm64 objc_msgSend ABI (x86-64 objc_msgSend_stret is unsupported).");
+        }
+    }
+
     // Builds the friendly-member body: a per-call-site cast of the cached `objc_msgSend` pointer to
     // the selector's signature. Instance members dispatch on `this`; class members dispatch on the
     // backing class object exposed as the `Class` field.
@@ -412,29 +425,15 @@ public partial class PInvokeGenerator
         return $"((delegate* unmanaged<{fnPtrArgs}>)ObjectiveC.objc_msgSend)({callArgs})";
     }
 
-    // v1 message-send subset: no variadics and no by-value aggregate return/parameter types, so the
-    // plain `objc_msgSend` entry point is ABI-correct (aggregate returns would need `_stret`).
+    // Message-send subset: only variadics are excluded, since a C-style `...` cannot be expressed as
+    // a fixed unmanaged function-pointer signature. By-value aggregates are supported via the plain
+    // `objc_msgSend` under the arm64 ABI (see `WriteObjCAggregateNote`).
     private static bool IsInObjCMessageSubset(ObjCMethodDecl method, out string reason)
     {
         if (method.Handle.IsVariadic)
         {
-            reason = "variadic methods are not yet supported";
+            reason = "variadic methods cannot be expressed as a fixed function-pointer signature";
             return false;
-        }
-
-        if (IsAggregateType(method.ReturnType))
-        {
-            reason = "by-value aggregate return types are not yet supported (would require objc_msgSend_stret)";
-            return false;
-        }
-
-        foreach (var parmVarDecl in method.Parameters)
-        {
-            if (IsAggregateType(parmVarDecl.Type))
-            {
-                reason = "by-value aggregate parameter types are not yet supported";
-                return false;
-            }
         }
 
         reason = "";
@@ -446,16 +445,17 @@ public partial class PInvokeGenerator
         return type.CanonicalType.Kind is CXTypeKind.CXType_Record;
     }
 
-    private readonly struct ObjCMessageMember(string memberName, string returnTypeName, List<(string TypeName, string EscapedName)> parameters, bool isClassMember, bool isOptional)
+    private readonly struct ObjCMessageMember(string memberName, string returnTypeName, List<(string TypeName, string EscapedName)> parameters, bool isClassMember, bool isOptional, bool involvesAggregate)
     {
         public string MemberName { get; } = memberName;
         public string ReturnTypeName { get; } = returnTypeName;
         public List<(string TypeName, string EscapedName)> Parameters { get; } = parameters;
         public bool IsClassMember { get; } = isClassMember;
         public bool IsOptional { get; } = isOptional;
+        public bool InvolvesAggregate { get; } = involvesAggregate;
     }
 
-    private readonly struct ObjCPropertyMember(string propertyName, string typeName, string getterField, string? setterField, bool isClassMember, bool isOptional)
+    private readonly struct ObjCPropertyMember(string propertyName, string typeName, string getterField, string? setterField, bool isClassMember, bool isOptional, bool involvesAggregate)
     {
         public string PropertyName { get; } = propertyName;
         public string TypeName { get; } = typeName;
@@ -463,5 +463,6 @@ public partial class PInvokeGenerator
         public string? SetterField { get; } = setterField;
         public bool IsClassMember { get; } = isClassMember;
         public bool IsOptional { get; } = isOptional;
+        public bool InvolvesAggregate { get; } = involvesAggregate;
     }
 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitObjCDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitObjCDecl.cs
@@ -1,0 +1,217 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using ClangSharp.Abstractions;
+using ClangSharp.Interop;
+
+namespace ClangSharp;
+
+public partial class PInvokeGenerator
+{
+    private void VisitObjCProtocolDecl(ObjCProtocolDecl objCProtocolDecl)
+    {
+        // Forward `@protocol Foo;` references carry no members; only the definition is emitted.
+        if (!objCProtocolDecl.IsThisDeclarationADefinition)
+        {
+            return;
+        }
+
+        var nativeName = GetCursorName(objCProtocolDecl);
+        var name = GetRemappedCursorName(objCProtocolDecl);
+        var escapedName = EscapeName(name);
+
+        _generatedObjCBindings = true;
+
+        StartUsingOutputBuilder(name, includeTestOutput: false);
+        {
+            Debug.Assert(_outputBuilder is not null);
+
+            var desc = new StructDesc {
+                AccessSpecifier = GetAccessSpecifier(objCProtocolDecl, matchStar: true),
+                EscapedName = escapedName,
+                IsUnsafe = true,
+                NativeType = $"@protocol {nativeName}",
+                Location = objCProtocolDecl.Location,
+                IsNested = false,
+                WriteCustomAttrs = static context => {
+                    (var objCProtocolDecl, var generator) = ((ObjCProtocolDecl, PInvokeGenerator))context;
+
+                    generator.WithAttributes(objCProtocolDecl, emitGeneratedCodeAttribute: true);
+                    generator.WithUsings(objCProtocolDecl);
+                },
+                CustomAttrGeneratorData = (objCProtocolDecl, this),
+            };
+
+            _outputBuilder.BeginStruct(in desc);
+            {
+                // Raw layer: the object's first field (`isa`), a byte-for-byte match of
+                // `struct objc_object`. Dispatch itself is done through the Objective-C runtime
+                // (`objc_msgSend`) rather than a fixed-offset table, so unlike COM's `lpVtbl` this
+                // field is only the identity/class hook, not the callable surface.
+                var fieldDesc = new FieldDesc {
+                    AccessSpecifier = AccessSpecifier.Public,
+                    NativeTypeName = "Class",
+                    EscapedName = "isa",
+                    ParentName = escapedName,
+                    Offset = null,
+                    NeedsNewKeyword = false,
+                };
+
+                _outputBuilder.BeginField(in fieldDesc);
+                _outputBuilder.WriteRegularField("void*", "isa");
+                _outputBuilder.EndField(in fieldDesc);
+
+                EmitObjCMessageMembers(objCProtocolDecl, escapedName);
+            }
+            _outputBuilder.EndStruct(in desc);
+        }
+        StopUsingOutputBuilder();
+    }
+
+    // Emits the raw `Selectors` cache plus the friendly `objc_msgSend` members for the instance
+    // methods that fall within the v1 scalar/pointer/void subset. Anything outside that subset is
+    // diagnosed rather than emitted with a wrong ABI.
+    private void EmitObjCMessageMembers(ObjCProtocolDecl objCProtocolDecl, string escapedParentName)
+    {
+        Debug.Assert(_outputBuilder is not null);
+
+        var emitted = new List<ObjCMessageMember>();
+
+        foreach (var method in objCProtocolDecl.InstanceMethods)
+        {
+            // Property accessors are surfaced via their properties in a later phase; class methods,
+            // variadics, and by-value aggregate returns/parameters need dispatch machinery that is
+            // deliberately out of scope for the first slice.
+            if (method.IsPropertyAccessor)
+            {
+                continue;
+            }
+
+            if (!IsInObjCMessageSubset(method, out var reason))
+            {
+                AddDiagnostic(DiagnosticLevel.Warning, $"Objective-C method '{method.Selector}' on '@protocol {GetCursorName(objCProtocolDecl)}' is not supported: {reason}. It was skipped.", method);
+                continue;
+            }
+
+            var nativeSelector = method.Selector;
+            var memberName = EscapeName(nativeSelector.Replace(':', '_'));
+            var returnTypeName = IsTypeVoid(method, method.ReturnType) ? "void" : GetRemappedTypeName(method, objCProtocolDecl, method.ReturnType, out _);
+
+            var parameters = new List<(string TypeName, string EscapedName)>();
+
+            foreach (var parmVarDecl in method.Parameters)
+            {
+                var parmTypeName = GetRemappedTypeName(parmVarDecl, method, parmVarDecl.Type, out _);
+                var parmName = EscapeName(GetRemappedCursorName(parmVarDecl));
+                parameters.Add((parmTypeName, parmName));
+            }
+
+            emitted.Add(new ObjCMessageMember(memberName, nativeSelector, returnTypeName, parameters));
+        }
+
+        if (emitted.Count == 0)
+        {
+            return;
+        }
+
+        var output = _outputBuilder.BeginCSharpCode();
+
+        // `Unsafe.AsPointer(ref this)` recovers the object pointer to pass as `self`.
+        output.AddUsingDirective("System.Runtime.CompilerServices");
+
+        // Raw layer: the registered selectors, kept public so nothing is hidden and any selector we
+        // did not wrap can still be sent by hand via `&ObjectiveC.objc_msgSend`.
+        output.WriteNewline();
+        output.WriteIndentedLine("public static class Selectors");
+        output.WriteBlockStart();
+        {
+            foreach (var member in emitted)
+            {
+                output.WriteIndented($"public static readonly SEL {member.MemberName} = ObjectiveC.sel_registerName(\"{member.NativeSelector}\");");
+                output.WriteNewline();
+            }
+        }
+        output.WriteBlockEnd();
+
+        // Friendly layer: named members that hide the selector lookup and the `objc_msgSend` cast,
+        // dispatched on `this` exactly like the COM vtbl helpers dispatch on `lpVtbl`.
+        foreach (var member in emitted)
+        {
+            output.WriteNewline();
+
+            var prototype = new StringBuilder();
+            var fnPtrArgs = new StringBuilder();
+            var callArgs = new StringBuilder();
+
+            _ = fnPtrArgs.Append(escapedParentName).Append("*, SEL");
+            _ = callArgs.Append('(').Append(escapedParentName).Append("*)Unsafe.AsPointer(ref this), Selectors.").Append(member.MemberName);
+
+            for (var i = 0; i < member.Parameters.Count; i++)
+            {
+                var (typeName, parmName) = member.Parameters[i];
+
+                if (i != 0)
+                {
+                    _ = prototype.Append(", ");
+                }
+
+                _ = prototype.Append(typeName).Append(' ').Append(parmName);
+                _ = fnPtrArgs.Append(", ").Append(typeName);
+                _ = callArgs.Append(", ").Append(parmName);
+            }
+
+            _ = fnPtrArgs.Append(", ").Append(member.ReturnTypeName);
+
+            output.WriteIndented($"public {member.ReturnTypeName} {member.MemberName}({prototype}) => ");
+            output.Write($"((delegate* unmanaged<{fnPtrArgs}>)ObjectiveC.objc_msgSend)({callArgs});");
+            output.WriteNewline();
+        }
+
+        _outputBuilder.EndCSharpCode(output);
+    }
+
+    // v1 message-send subset: no variadics and no by-value aggregate return/parameter types, so the
+    // plain `objc_msgSend` entry point is ABI-correct (aggregate returns would need `_stret`).
+    private static bool IsInObjCMessageSubset(ObjCMethodDecl method, out string reason)
+    {
+        if (method.Handle.IsVariadic)
+        {
+            reason = "variadic methods are not yet supported";
+            return false;
+        }
+
+        if (IsAggregateType(method.ReturnType))
+        {
+            reason = "by-value aggregate return types are not yet supported (would require objc_msgSend_stret)";
+            return false;
+        }
+
+        foreach (var parmVarDecl in method.Parameters)
+        {
+            if (IsAggregateType(parmVarDecl.Type))
+            {
+                reason = "by-value aggregate parameter types are not yet supported";
+                return false;
+            }
+        }
+
+        reason = "";
+        return true;
+    }
+
+    private static bool IsAggregateType(Type type)
+    {
+        return type.CanonicalType.Kind is CXTypeKind.CXType_Record;
+    }
+
+    private readonly struct ObjCMessageMember(string memberName, string nativeSelector, string returnTypeName, List<(string TypeName, string EscapedName)> parameters)
+    {
+        public string MemberName { get; } = memberName;
+        public string NativeSelector { get; } = nativeSelector;
+        public string ReturnTypeName { get; } = returnTypeName;
+        public List<(string TypeName, string EscapedName)> Parameters { get; } = parameters;
+    }
+}

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRef.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRef.cs
@@ -6,6 +6,14 @@ public partial class PInvokeGenerator
 {
     private void VisitRef(Ref @ref)
     {
+        if (_outputBuilder is null)
+        {
+            // A reference visited without an active output builder (e.g. a stray top-level
+            // Objective-C class/protocol ref hanging off the translation unit) has nowhere to be
+            // written; there is nothing meaningful to emit for it.
+            return;
+        }
+
         var name = GetRemappedCursorName(@ref.Referenced);
         StartCSharpCode().Write(name);
         StopCSharpCode();

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -107,6 +107,7 @@ public sealed partial class PInvokeGenerator : IDisposable
     private int _outputBuilderUsers;
     private CXXRecordDecl? _cxxRecordDeclContext;
     private bool _disposed;
+    private bool _generatedObjCBindings;
 
     public PInvokeGenerator(PInvokeGeneratorConfiguration config, Func<string, Stream>? outputStreamFactory = null)
     {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfiguration.cs
@@ -342,6 +342,8 @@ public sealed class PInvokeGeneratorConfiguration
 
     public bool GenerateNativeInheritanceAttribute => (_options & PInvokeGeneratorConfigurationOptions.GenerateNativeInheritanceAttribute) != 0;
 
+    public bool GenerateObjectiveCBindings => (_options & PInvokeGeneratorConfigurationOptions.GenerateObjectiveCBindings) != 0;
+
     public bool GeneratePreviewCode => (_options & PInvokeGeneratorConfigurationOptions.GeneratePreviewCode) != 0;
 
     public bool GenerateSetsLastSystemErrorAttribute => (_options & PInvokeGeneratorConfigurationOptions.GenerateSetsLastSystemErrorAttribute) != 0;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGeneratorConfigurationOptions.cs
@@ -98,4 +98,6 @@ public enum PInvokeGeneratorConfigurationOptions : long
     ExcludeGeneratedCodeAttribute = 1L << 43,
 
     GenerateExternVariables = 1L << 44,
+
+    GenerateObjectiveCBindings = 1L << 45,
 }

--- a/sources/ClangSharpPInvokeGenerator/Program.Options.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.Options.cs
@@ -61,7 +61,7 @@ internal static partial class Program
     private static readonly CommandLineOption s_headerFile = Single(s_headerOptionAliases, "A file which contains the header to prefix every generated file with.");
     private static readonly CommandLineOption s_includedNames = Multi(s_includeOptionAliases, "A declaration name to include in binding generation.");
     private static readonly CommandLineOption s_includeDirectories = Multi(s_includeDirectoryOptionAliases, "Add directory to include search path.");
-    private static readonly CommandLineOption s_language = Single(s_languageOptionAliases, "Treat subsequent input files as having type <language>.", defaultValue: "c++", valueName: "c|c++", allowedValues: ["c", "c++"]);
+    private static readonly CommandLineOption s_language = Single(s_languageOptionAliases, "Treat subsequent input files as having type <language>.", defaultValue: "c++", valueName: "c|c++|objective-c|objective-c++", allowedValues: ["c", "c++", "objective-c", "objective-c++"]);
     private static readonly CommandLineOption s_libraryPath = Single(s_libraryOptionAliases, "The string to use in the DllImport attribute used when generating bindings.");
     private static readonly CommandLineOption s_methodClassName = Single(s_methodClassNameOptionAliases, "The name of the static class that will contain the generated method bindings.", defaultValue: "Methods");
     private static readonly CommandLineOption s_namespaceName = Single(s_namespaceOptionAliases, "The namespace in which to place the generated bindings.");
@@ -227,6 +227,7 @@ internal static partial class Program
         new HelpRow("generate-marker-interfaces", "Bindings for marker interfaces representing native inheritance hierarchies should be generated."),
         new HelpRow("generate-native-bitfield-attribute", "[NativeBitfield(\"\", offset: #, length: #)] attribute should be generated to document the encountered bitfield layout."),
         new HelpRow("generate-native-inheritance-attribute", "[NativeInheritance(\"\")] attribute should be generated to document the encountered C++ base type."),
+        new HelpRow("generate-objective-c-bindings", "Bindings for Objective-C declarations (currently @protocol types) should be generated. This is experimental and requires the Objective-C runtime (libobjc) at runtime."),
         new HelpRow("generate-generic-pointer-wrapper", "Pointer<T> should be used for limited generic type support."),
         new HelpRow("generate-setslastsystemerror-attribute", "[SetsLastSystemError] attribute should be generated rather than using SetLastError = true."),
         new HelpRow("generate-template-bindings", "Bindings for template-definitions should be generated. This is currently experimental."),

--- a/sources/ClangSharpPInvokeGenerator/Program.cs
+++ b/sources/ClangSharpPInvokeGenerator/Program.cs
@@ -466,6 +466,12 @@ internal static partial class Program
                     break;
                 }
 
+                case "generate-objective-c-bindings":
+                {
+                    configOptions |= PInvokeGeneratorConfigurationOptions.GenerateObjectiveCBindings;
+                    break;
+                }
+
                 case "generate-generic-pointer-wrapper":
                 {
                     configOptions |= PInvokeGeneratorConfigurationOptions.GenerateGenericPointerWrapper;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/ObjectiveCDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/ObjectiveCDeclarationTest.cs
@@ -35,7 +35,7 @@ namespace ClangSharp.Test
         [NativeTypeName(""Class"")]
         public void* isa;
 
-        public static class Selectors
+        public static partial class Selectors
         {
             public static readonly SEL hello = ObjectiveC.sel_registerName(""hello"");
             public static readonly SEL addLeft_right_ = ObjectiveC.sel_registerName(""addLeft:right:"");
@@ -123,7 +123,7 @@ namespace ClangSharp.Test
         [NativeTypeName(""Class"")]
         public void* isa;
 
-        public static class Selectors
+        public static partial class Selectors
         {
             public static readonly SEL count = ObjectiveC.sel_registerName(""count"");
         }
@@ -199,7 +199,7 @@ namespace ClangSharp.Test
         [NativeTypeName(""Class"")]
         public void* isa;
 
-        public static class Selectors
+        public static partial class Selectors
         {
             public static readonly SEL count = ObjectiveC.sel_registerName(""count"");
             public static readonly SEL step = ObjectiveC.sel_registerName(""step"");
@@ -289,7 +289,7 @@ namespace ClangSharp.Test
 
         public static readonly void* Class = ObjectiveC.objc_getClass(""Base"");
 
-        public static class Selectors
+        public static partial class Selectors
         {
             public static readonly SEL baseMethod = ObjectiveC.sel_registerName(""baseMethod"");
         }
@@ -305,7 +305,7 @@ namespace ClangSharp.Test
 
         public static readonly void* Class = ObjectiveC.objc_getClass(""Widget"");
 
-        public static class Selectors
+        public static partial class Selectors
         {
             public static readonly SEL render = ObjectiveC.sel_registerName(""render"");
             public static readonly SEL width = ObjectiveC.sel_registerName(""width"");
@@ -394,7 +394,7 @@ namespace ClangSharp.Test
         [NativeTypeName(""Class"")]
         public void* isa;
 
-        public static class Selectors
+        public static partial class Selectors
         {
             public static readonly SEL identifier = ObjectiveC.sel_registerName(""identifier"");
             public static readonly SEL greet = ObjectiveC.sel_registerName(""greet"");
@@ -487,7 +487,7 @@ namespace ClangSharp.Test
 
         public static readonly void* Class = ObjectiveC.objc_getClass(""View"");
 
-        public static class Selectors
+        public static partial class Selectors
         {
             public static readonly SEL center = ObjectiveC.sel_registerName(""center"");
             public static readonly SEL moveBy_ = ObjectiveC.sel_registerName(""moveBy:"");
@@ -509,6 +509,107 @@ namespace ClangSharp.Test
         {
             get => ((delegate* unmanaged<View*, SEL, CGPoint>)ObjectiveC.objc_msgSend)((View*)Unsafe.AsPointer(ref this), Selectors.origin);
             set => ((delegate* unmanaged<View*, SEL, CGPoint, void>)ObjectiveC.objc_msgSend)((View*)Unsafe.AsPointer(ref this), Selectors.setOrigin_, value);
+        }
+    }
+
+    /// <summary>Represents an Objective-C selector (<c>SEL</c>).</summary>
+    public unsafe partial struct SEL : IEquatable<SEL>
+    {
+        public void* Value;
+
+        public SEL(void* value)
+        {
+            Value = value;
+        }
+
+        public static bool operator ==(SEL left, SEL right) => left.Value == right.Value;
+
+        public static bool operator !=(SEL left, SEL right) => left.Value != right.Value;
+
+        public override bool Equals(object? obj) => (obj is SEL other) && Equals(other);
+
+        public bool Equals(SEL other) => Value == other.Value;
+
+        public override int GetHashCode() => ((nuint)Value).GetHashCode();
+    }
+
+    /// <summary>Provides access to the Objective-C runtime (<c>libobjc</c>).</summary>
+    public static unsafe partial class ObjectiveC
+    {
+        private const string LibObjC = ""/usr/lib/libobjc.A.dylib"";
+
+        /// <summary>The raw <c>objc_msgSend</c> entry point, cast per call site to the selector's signature.</summary>
+        public static readonly void* objc_msgSend = (void*)NativeLibrary.GetExport(NativeLibrary.Load(LibObjC), ""objc_msgSend"");
+
+        [DllImport(LibObjC, EntryPoint = ""sel_registerName"", ExactSpelling = true)]
+        public static extern SEL sel_registerName([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+        [DllImport(LibObjC, EntryPoint = ""objc_getClass"", ExactSpelling = true)]
+        public static extern void* objc_getClass([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateObjectiveCBindings, commandLineArgs: s_objectiveCCommandLineArgs, language: "objective-c", languageStandard: DefaultCStandard);
+    }
+
+    [Test]
+    public Task CategoryTest()
+    {
+        var inputContents = @"@interface Widget
+- (int)tag;
+@end
+
+@interface Widget (Extras)
+- (int)extraValue;
+@property int label;
++ (int)defaultLabel;
+@end
+";
+
+        // A category reopens the class's `partial struct` and its `partial` Selectors cache, adding
+        // only the new members; class members still dispatch on the `Class` object from the interface.
+        var expectedOutputContents = @"using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    [NativeTypeName(""@interface Widget"")]
+    public unsafe partial struct Widget
+    {
+        [NativeTypeName(""Class"")]
+        public void* isa;
+
+        public static readonly void* Class = ObjectiveC.objc_getClass(""Widget"");
+
+        public static partial class Selectors
+        {
+            public static readonly SEL tag = ObjectiveC.sel_registerName(""tag"");
+        }
+
+        public int tag() => ((delegate* unmanaged<Widget*, SEL, int>)ObjectiveC.objc_msgSend)((Widget*)Unsafe.AsPointer(ref this), Selectors.tag);
+    }
+
+    [NativeTypeName(""@interface Widget (Extras)"")]
+    public unsafe partial struct Widget
+    {
+        public static partial class Selectors
+        {
+            public static readonly SEL extraValue = ObjectiveC.sel_registerName(""extraValue"");
+            public static readonly SEL label = ObjectiveC.sel_registerName(""label"");
+            public static readonly SEL setLabel_ = ObjectiveC.sel_registerName(""setLabel:"");
+            public static readonly SEL defaultLabel = ObjectiveC.sel_registerName(""defaultLabel"");
+        }
+
+        public int extraValue() => ((delegate* unmanaged<Widget*, SEL, int>)ObjectiveC.objc_msgSend)((Widget*)Unsafe.AsPointer(ref this), Selectors.extraValue);
+
+        public static int defaultLabel() => ((delegate* unmanaged<void*, SEL, int>)ObjectiveC.objc_msgSend)(Class, Selectors.defaultLabel);
+
+        public int label
+        {
+            get => ((delegate* unmanaged<Widget*, SEL, int>)ObjectiveC.objc_msgSend)((Widget*)Unsafe.AsPointer(ref this), Selectors.label);
+            set => ((delegate* unmanaged<Widget*, SEL, int, void>)ObjectiveC.objc_msgSend)((Widget*)Unsafe.AsPointer(ref this), Selectors.setLabel_, value);
         }
     }
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/ObjectiveCDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/ObjectiveCDeclarationTest.cs
@@ -173,4 +173,84 @@ namespace ClangSharp.Test
 
         return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateObjectiveCBindings, expectedDiagnostics: expectedDiagnostics, commandLineArgs: s_objectiveCCommandLineArgs, language: "objective-c", languageStandard: DefaultCStandard);
     }
+
+    [Test]
+    public Task PropertyTest()
+    {
+        var inputContents = @"@protocol Counter
+@property (readonly) int count;
+@property int step;
+@end
+";
+
+        // A `readonly` property maps to an expression-bodied getter; a read-write property maps to a
+        // `get`/`set` block whose setter dispatches the synthesized `setStep:` selector.
+        var expectedOutputContents = @"using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    [NativeTypeName(""@protocol Counter"")]
+    public unsafe partial struct Counter
+    {
+        [NativeTypeName(""Class"")]
+        public void* isa;
+
+        public static class Selectors
+        {
+            public static readonly SEL count = ObjectiveC.sel_registerName(""count"");
+            public static readonly SEL step = ObjectiveC.sel_registerName(""step"");
+            public static readonly SEL setStep_ = ObjectiveC.sel_registerName(""setStep:"");
+        }
+
+        public int count => ((delegate* unmanaged<Counter*, SEL, int>)ObjectiveC.objc_msgSend)((Counter*)Unsafe.AsPointer(ref this), Selectors.count);
+
+        public int step
+        {
+            get => ((delegate* unmanaged<Counter*, SEL, int>)ObjectiveC.objc_msgSend)((Counter*)Unsafe.AsPointer(ref this), Selectors.step);
+            set => ((delegate* unmanaged<Counter*, SEL, int, void>)ObjectiveC.objc_msgSend)((Counter*)Unsafe.AsPointer(ref this), Selectors.setStep_, value);
+        }
+    }
+
+    /// <summary>Represents an Objective-C selector (<c>SEL</c>).</summary>
+    public unsafe partial struct SEL : IEquatable<SEL>
+    {
+        public void* Value;
+
+        public SEL(void* value)
+        {
+            Value = value;
+        }
+
+        public static bool operator ==(SEL left, SEL right) => left.Value == right.Value;
+
+        public static bool operator !=(SEL left, SEL right) => left.Value != right.Value;
+
+        public override bool Equals(object? obj) => (obj is SEL other) && Equals(other);
+
+        public bool Equals(SEL other) => Value == other.Value;
+
+        public override int GetHashCode() => ((nuint)Value).GetHashCode();
+    }
+
+    /// <summary>Provides access to the Objective-C runtime (<c>libobjc</c>).</summary>
+    public static unsafe partial class ObjectiveC
+    {
+        private const string LibObjC = ""/usr/lib/libobjc.A.dylib"";
+
+        /// <summary>The raw <c>objc_msgSend</c> entry point, cast per call site to the selector's signature.</summary>
+        public static readonly void* objc_msgSend = (void*)NativeLibrary.GetExport(NativeLibrary.Load(LibObjC), ""objc_msgSend"");
+
+        [DllImport(LibObjC, EntryPoint = ""sel_registerName"", ExactSpelling = true)]
+        public static extern SEL sel_registerName([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+        [DllImport(LibObjC, EntryPoint = ""objc_getClass"", ExactSpelling = true)]
+        public static extern void* objc_getClass([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateObjectiveCBindings, commandLineArgs: s_objectiveCCommandLineArgs, language: "objective-c", languageStandard: DefaultCStandard);
+    }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/ObjectiveCDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/ObjectiveCDeclarationTest.cs
@@ -6,12 +6,14 @@ using NUnit.Framework;
 namespace ClangSharp.UnitTests;
 
 /// <summary>
-/// Covers the first slice of Objective-C binding generation (issue https://github.com/dotnet/ClangSharp/issues/254):
-/// an opt-in <c>--generate-objective-c-bindings</c> flag that maps an <c>@protocol</c> onto a
-/// layout-faithful struct (first field <c>isa</c>, mirroring <c>struct objc_object</c>) plus a raw
-/// <c>Selectors</c> cache and friendly <c>objc_msgSend</c> members, alongside a small <c>libobjc</c>
-/// support surface. Only instance methods with scalar/pointer/void signatures are in scope; anything
-/// outside that subset is diagnosed rather than emitted with a wrong ABI.
+/// Covers Objective-C binding generation (issue https://github.com/dotnet/ClangSharp/issues/254):
+/// an opt-in <c>--generate-objective-c-bindings</c> flag that maps an <c>@protocol</c> or
+/// <c>@interface</c> onto a layout-faithful struct (first field <c>isa</c>, mirroring
+/// <c>struct objc_object</c>) plus a raw <c>Selectors</c> cache and friendly <c>objc_msgSend</c>
+/// members, alongside a small <c>libobjc</c> support surface. Instance members dispatch on <c>this</c>;
+/// class (<c>+</c>) members are <c>static</c> and dispatch on the backing <c>Class</c> object.
+/// <c>@optional</c> protocol members are flagged, and only scalar/pointer/void signatures are in
+/// scope; anything outside that subset is diagnosed rather than emitted with a wrong ABI.
 /// </summary>
 public sealed class ObjectiveCDeclarationTest : PInvokeGeneratorTest
 {
@@ -211,6 +213,201 @@ namespace ClangSharp.Test
             get => ((delegate* unmanaged<Counter*, SEL, int>)ObjectiveC.objc_msgSend)((Counter*)Unsafe.AsPointer(ref this), Selectors.step);
             set => ((delegate* unmanaged<Counter*, SEL, int, void>)ObjectiveC.objc_msgSend)((Counter*)Unsafe.AsPointer(ref this), Selectors.setStep_, value);
         }
+    }
+
+    /// <summary>Represents an Objective-C selector (<c>SEL</c>).</summary>
+    public unsafe partial struct SEL : IEquatable<SEL>
+    {
+        public void* Value;
+
+        public SEL(void* value)
+        {
+            Value = value;
+        }
+
+        public static bool operator ==(SEL left, SEL right) => left.Value == right.Value;
+
+        public static bool operator !=(SEL left, SEL right) => left.Value != right.Value;
+
+        public override bool Equals(object? obj) => (obj is SEL other) && Equals(other);
+
+        public bool Equals(SEL other) => Value == other.Value;
+
+        public override int GetHashCode() => ((nuint)Value).GetHashCode();
+    }
+
+    /// <summary>Provides access to the Objective-C runtime (<c>libobjc</c>).</summary>
+    public static unsafe partial class ObjectiveC
+    {
+        private const string LibObjC = ""/usr/lib/libobjc.A.dylib"";
+
+        /// <summary>The raw <c>objc_msgSend</c> entry point, cast per call site to the selector's signature.</summary>
+        public static readonly void* objc_msgSend = (void*)NativeLibrary.GetExport(NativeLibrary.Load(LibObjC), ""objc_msgSend"");
+
+        [DllImport(LibObjC, EntryPoint = ""sel_registerName"", ExactSpelling = true)]
+        public static extern SEL sel_registerName([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+        [DllImport(LibObjC, EntryPoint = ""objc_getClass"", ExactSpelling = true)]
+        public static extern void* objc_getClass([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateObjectiveCBindings, commandLineArgs: s_objectiveCCommandLineArgs, language: "objective-c", languageStandard: DefaultCStandard);
+    }
+
+    [Test]
+    public Task InterfaceTest()
+    {
+        var inputContents = @"@interface Base
+- (void)baseMethod;
+@end
+
+@interface Widget : Base
+@property (class, readonly) int sharedCount;
+@property int width;
++ (int)defaultWidth;
+- (void)render;
+@end
+";
+
+        // An `@interface` maps to the same opaque `{ void* isa }` struct as an `@protocol` (Objective-C
+        // uses non-fragile ivars, so there is no stable field layout to mirror), plus a cached `Class`
+        // object. Class (`+`) members are `static` and dispatch on `Class`; the superclass is recorded
+        // in the `[NativeTypeName]` since every struct shares the same layout and can be reinterpreted.
+        var expectedOutputContents = @"using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    [NativeTypeName(""@interface Base"")]
+    public unsafe partial struct Base
+    {
+        [NativeTypeName(""Class"")]
+        public void* isa;
+
+        public static readonly void* Class = ObjectiveC.objc_getClass(""Base"");
+
+        public static class Selectors
+        {
+            public static readonly SEL baseMethod = ObjectiveC.sel_registerName(""baseMethod"");
+        }
+
+        public void baseMethod() => ((delegate* unmanaged<Base*, SEL, void>)ObjectiveC.objc_msgSend)((Base*)Unsafe.AsPointer(ref this), Selectors.baseMethod);
+    }
+
+    [NativeTypeName(""@interface Widget : Base"")]
+    public unsafe partial struct Widget
+    {
+        [NativeTypeName(""Class"")]
+        public void* isa;
+
+        public static readonly void* Class = ObjectiveC.objc_getClass(""Widget"");
+
+        public static class Selectors
+        {
+            public static readonly SEL render = ObjectiveC.sel_registerName(""render"");
+            public static readonly SEL width = ObjectiveC.sel_registerName(""width"");
+            public static readonly SEL setWidth_ = ObjectiveC.sel_registerName(""setWidth:"");
+            public static readonly SEL defaultWidth = ObjectiveC.sel_registerName(""defaultWidth"");
+            public static readonly SEL sharedCount = ObjectiveC.sel_registerName(""sharedCount"");
+        }
+
+        public void render() => ((delegate* unmanaged<Widget*, SEL, void>)ObjectiveC.objc_msgSend)((Widget*)Unsafe.AsPointer(ref this), Selectors.render);
+
+        public static int defaultWidth() => ((delegate* unmanaged<void*, SEL, int>)ObjectiveC.objc_msgSend)(Class, Selectors.defaultWidth);
+
+        public int width
+        {
+            get => ((delegate* unmanaged<Widget*, SEL, int>)ObjectiveC.objc_msgSend)((Widget*)Unsafe.AsPointer(ref this), Selectors.width);
+            set => ((delegate* unmanaged<Widget*, SEL, int, void>)ObjectiveC.objc_msgSend)((Widget*)Unsafe.AsPointer(ref this), Selectors.setWidth_, value);
+        }
+
+        public static int sharedCount => ((delegate* unmanaged<void*, SEL, int>)ObjectiveC.objc_msgSend)(Class, Selectors.sharedCount);
+    }
+
+    /// <summary>Represents an Objective-C selector (<c>SEL</c>).</summary>
+    public unsafe partial struct SEL : IEquatable<SEL>
+    {
+        public void* Value;
+
+        public SEL(void* value)
+        {
+            Value = value;
+        }
+
+        public static bool operator ==(SEL left, SEL right) => left.Value == right.Value;
+
+        public static bool operator !=(SEL left, SEL right) => left.Value != right.Value;
+
+        public override bool Equals(object? obj) => (obj is SEL other) && Equals(other);
+
+        public bool Equals(SEL other) => Value == other.Value;
+
+        public override int GetHashCode() => ((nuint)Value).GetHashCode();
+    }
+
+    /// <summary>Provides access to the Objective-C runtime (<c>libobjc</c>).</summary>
+    public static unsafe partial class ObjectiveC
+    {
+        private const string LibObjC = ""/usr/lib/libobjc.A.dylib"";
+
+        /// <summary>The raw <c>objc_msgSend</c> entry point, cast per call site to the selector's signature.</summary>
+        public static readonly void* objc_msgSend = (void*)NativeLibrary.GetExport(NativeLibrary.Load(LibObjC), ""objc_msgSend"");
+
+        [DllImport(LibObjC, EntryPoint = ""sel_registerName"", ExactSpelling = true)]
+        public static extern SEL sel_registerName([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+        [DllImport(LibObjC, EntryPoint = ""objc_getClass"", ExactSpelling = true)]
+        public static extern void* objc_getClass([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateObjectiveCBindings, commandLineArgs: s_objectiveCCommandLineArgs, language: "objective-c", languageStandard: DefaultCStandard);
+    }
+
+    [Test]
+    public Task OptionalMemberTest()
+    {
+        var inputContents = @"@protocol Named
+@required
+- (int)identifier;
+@optional
+- (void)greet;
+@property (readonly) int badge;
+@end
+";
+
+        // Optional members are still emitted, but flagged: a conforming object may not implement them,
+        // so callers must guard with `respondsToSelector:` before sending.
+        var expectedOutputContents = @"using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    [NativeTypeName(""@protocol Named"")]
+    public unsafe partial struct Named
+    {
+        [NativeTypeName(""Class"")]
+        public void* isa;
+
+        public static class Selectors
+        {
+            public static readonly SEL identifier = ObjectiveC.sel_registerName(""identifier"");
+            public static readonly SEL greet = ObjectiveC.sel_registerName(""greet"");
+            public static readonly SEL badge = ObjectiveC.sel_registerName(""badge"");
+        }
+
+        public int identifier() => ((delegate* unmanaged<Named*, SEL, int>)ObjectiveC.objc_msgSend)((Named*)Unsafe.AsPointer(ref this), Selectors.identifier);
+
+        // @optional; guard with respondsToSelector: before sending.
+        public void greet() => ((delegate* unmanaged<Named*, SEL, void>)ObjectiveC.objc_msgSend)((Named*)Unsafe.AsPointer(ref this), Selectors.greet);
+
+        // @optional; guard with respondsToSelector: before sending.
+        public int badge => ((delegate* unmanaged<Named*, SEL, int>)ObjectiveC.objc_msgSend)((Named*)Unsafe.AsPointer(ref this), Selectors.badge);
     }
 
     /// <summary>Represents an Objective-C selector (<c>SEL</c>).</summary>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/ObjectiveCDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/ObjectiveCDeclarationTest.cs
@@ -170,7 +170,7 @@ namespace ClangSharp.Test
 ";
 
         var expectedDiagnostics = new[] {
-            new Diagnostic(DiagnosticLevel.Warning, "Objective-C method 'logValue:' on '@protocol Logger' is not supported: variadic methods are not yet supported. It was skipped.", "Line 2, Column 9 in ClangUnsavedFile.h")
+            new Diagnostic(DiagnosticLevel.Warning, "Objective-C method 'logValue:' on '@protocol Logger' is not supported: variadic methods cannot be expressed as a fixed function-pointer signature. It was skipped.", "Line 2, Column 9 in ClangUnsavedFile.h")
         };
 
         return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateObjectiveCBindings, expectedDiagnostics: expectedDiagnostics, commandLineArgs: s_objectiveCCommandLineArgs, language: "objective-c", languageStandard: DefaultCStandard);
@@ -408,6 +408,108 @@ namespace ClangSharp.Test
 
         // @optional; guard with respondsToSelector: before sending.
         public int badge => ((delegate* unmanaged<Named*, SEL, int>)ObjectiveC.objc_msgSend)((Named*)Unsafe.AsPointer(ref this), Selectors.badge);
+    }
+
+    /// <summary>Represents an Objective-C selector (<c>SEL</c>).</summary>
+    public unsafe partial struct SEL : IEquatable<SEL>
+    {
+        public void* Value;
+
+        public SEL(void* value)
+        {
+            Value = value;
+        }
+
+        public static bool operator ==(SEL left, SEL right) => left.Value == right.Value;
+
+        public static bool operator !=(SEL left, SEL right) => left.Value != right.Value;
+
+        public override bool Equals(object? obj) => (obj is SEL other) && Equals(other);
+
+        public bool Equals(SEL other) => Value == other.Value;
+
+        public override int GetHashCode() => ((nuint)Value).GetHashCode();
+    }
+
+    /// <summary>Provides access to the Objective-C runtime (<c>libobjc</c>).</summary>
+    public static unsafe partial class ObjectiveC
+    {
+        private const string LibObjC = ""/usr/lib/libobjc.A.dylib"";
+
+        /// <summary>The raw <c>objc_msgSend</c> entry point, cast per call site to the selector's signature.</summary>
+        public static readonly void* objc_msgSend = (void*)NativeLibrary.GetExport(NativeLibrary.Load(LibObjC), ""objc_msgSend"");
+
+        [DllImport(LibObjC, EntryPoint = ""sel_registerName"", ExactSpelling = true)]
+        public static extern SEL sel_registerName([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+        [DllImport(LibObjC, EntryPoint = ""objc_getClass"", ExactSpelling = true)]
+        public static extern void* objc_getClass([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+    }
+}
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateObjectiveCBindings, commandLineArgs: s_objectiveCCommandLineArgs, language: "objective-c", languageStandard: DefaultCStandard);
+    }
+
+    [Test]
+    public Task AggregateSignatureTest()
+    {
+        var inputContents = @"typedef struct CGPoint { double x; double y; } CGPoint;
+
+@interface View
+@property CGPoint origin;
+- (CGPoint)center;
+- (void)moveBy:(CGPoint)delta;
+- (int)tag;
+@end
+";
+
+        // By-value struct returns/parameters are emitted through the plain `objc_msgSend` on the arm64
+        // ABI and flagged; the scalar `tag` is not flagged.
+        var expectedOutputContents = @"using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct CGPoint
+    {
+        public double x;
+
+        public double y;
+    }
+
+    [NativeTypeName(""@interface View"")]
+    public unsafe partial struct View
+    {
+        [NativeTypeName(""Class"")]
+        public void* isa;
+
+        public static readonly void* Class = ObjectiveC.objc_getClass(""View"");
+
+        public static class Selectors
+        {
+            public static readonly SEL center = ObjectiveC.sel_registerName(""center"");
+            public static readonly SEL moveBy_ = ObjectiveC.sel_registerName(""moveBy:"");
+            public static readonly SEL tag = ObjectiveC.sel_registerName(""tag"");
+            public static readonly SEL origin = ObjectiveC.sel_registerName(""origin"");
+            public static readonly SEL setOrigin_ = ObjectiveC.sel_registerName(""setOrigin:"");
+        }
+
+        // By-value struct in signature: assumes the arm64 objc_msgSend ABI (x86-64 objc_msgSend_stret is unsupported).
+        public CGPoint center() => ((delegate* unmanaged<View*, SEL, CGPoint>)ObjectiveC.objc_msgSend)((View*)Unsafe.AsPointer(ref this), Selectors.center);
+
+        // By-value struct in signature: assumes the arm64 objc_msgSend ABI (x86-64 objc_msgSend_stret is unsupported).
+        public void moveBy_(CGPoint delta) => ((delegate* unmanaged<View*, SEL, CGPoint, void>)ObjectiveC.objc_msgSend)((View*)Unsafe.AsPointer(ref this), Selectors.moveBy_, delta);
+
+        public int tag() => ((delegate* unmanaged<View*, SEL, int>)ObjectiveC.objc_msgSend)((View*)Unsafe.AsPointer(ref this), Selectors.tag);
+
+        // By-value struct in signature: assumes the arm64 objc_msgSend ABI (x86-64 objc_msgSend_stret is unsupported).
+        public CGPoint origin
+        {
+            get => ((delegate* unmanaged<View*, SEL, CGPoint>)ObjectiveC.objc_msgSend)((View*)Unsafe.AsPointer(ref this), Selectors.origin);
+            set => ((delegate* unmanaged<View*, SEL, CGPoint, void>)ObjectiveC.objc_msgSend)((View*)Unsafe.AsPointer(ref this), Selectors.setOrigin_, value);
+        }
     }
 
     /// <summary>Represents an Objective-C selector (<c>SEL</c>).</summary>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/ObjectiveCDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/ObjectiveCDeclarationTest.cs
@@ -1,0 +1,176 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>
+/// Covers the first slice of Objective-C binding generation (issue https://github.com/dotnet/ClangSharp/issues/254):
+/// an opt-in <c>--generate-objective-c-bindings</c> flag that maps an <c>@protocol</c> onto a
+/// layout-faithful struct (first field <c>isa</c>, mirroring <c>struct objc_object</c>) plus a raw
+/// <c>Selectors</c> cache and friendly <c>objc_msgSend</c> members, alongside a small <c>libobjc</c>
+/// support surface. Only instance methods with scalar/pointer/void signatures are in scope; anything
+/// outside that subset is diagnosed rather than emitted with a wrong ABI.
+/// </summary>
+public sealed class ObjectiveCDeclarationTest : PInvokeGeneratorTest
+{
+    private const string ProtocolInputContents = @"@protocol Greeter
+- (void)hello;
+- (int)addLeft:(int)left right:(int)right;
+@end
+";
+
+    private const string ProtocolExpectedOutputContents = @"using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    [NativeTypeName(""@protocol Greeter"")]
+    public unsafe partial struct Greeter
+    {
+        [NativeTypeName(""Class"")]
+        public void* isa;
+
+        public static class Selectors
+        {
+            public static readonly SEL hello = ObjectiveC.sel_registerName(""hello"");
+            public static readonly SEL addLeft_right_ = ObjectiveC.sel_registerName(""addLeft:right:"");
+        }
+
+        public void hello() => ((delegate* unmanaged<Greeter*, SEL, void>)ObjectiveC.objc_msgSend)((Greeter*)Unsafe.AsPointer(ref this), Selectors.hello);
+
+        public int addLeft_right_(int left, int right) => ((delegate* unmanaged<Greeter*, SEL, int, int, int>)ObjectiveC.objc_msgSend)((Greeter*)Unsafe.AsPointer(ref this), Selectors.addLeft_right_, left, right);
+    }
+
+    /// <summary>Represents an Objective-C selector (<c>SEL</c>).</summary>
+    public unsafe partial struct SEL : IEquatable<SEL>
+    {
+        public void* Value;
+
+        public SEL(void* value)
+        {
+            Value = value;
+        }
+
+        public static bool operator ==(SEL left, SEL right) => left.Value == right.Value;
+
+        public static bool operator !=(SEL left, SEL right) => left.Value != right.Value;
+
+        public override bool Equals(object? obj) => (obj is SEL other) && Equals(other);
+
+        public bool Equals(SEL other) => Value == other.Value;
+
+        public override int GetHashCode() => ((nuint)Value).GetHashCode();
+    }
+
+    /// <summary>Provides access to the Objective-C runtime (<c>libobjc</c>).</summary>
+    public static unsafe partial class ObjectiveC
+    {
+        private const string LibObjC = ""/usr/lib/libobjc.A.dylib"";
+
+        /// <summary>The raw <c>objc_msgSend</c> entry point, cast per call site to the selector's signature.</summary>
+        public static readonly void* objc_msgSend = (void*)NativeLibrary.GetExport(NativeLibrary.Load(LibObjC), ""objc_msgSend"");
+
+        [DllImport(LibObjC, EntryPoint = ""sel_registerName"", ExactSpelling = true)]
+        public static extern SEL sel_registerName([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+        [DllImport(LibObjC, EntryPoint = ""objc_getClass"", ExactSpelling = true)]
+        public static extern void* objc_getClass([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+    }
+}
+";
+
+    private static readonly string[] s_objectiveCCommandLineArgs = ["-xobjective-c"];
+
+    [Test]
+    public Task ProtocolWindowsTest()
+    {
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(ProtocolInputContents, ProtocolExpectedOutputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateObjectiveCBindings, commandLineArgs: s_objectiveCCommandLineArgs, language: "objective-c", languageStandard: DefaultCStandard);
+    }
+
+    [Test]
+    public Task ProtocolUnixTest()
+    {
+        // The first-slice output uses only platform-independent types (`void*`, `int`) and the same
+        // `objc_msgSend` entry point on every target, so the Windows and Unix bindings are identical.
+        return ValidateGeneratedCSharpLatestUnixBindingsAsync(ProtocolInputContents, ProtocolExpectedOutputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateObjectiveCBindings, commandLineArgs: s_objectiveCCommandLineArgs, language: "objective-c", languageStandard: DefaultCStandard);
+    }
+
+    [Test]
+    public Task UnsupportedMethodIsDiagnosedTest()
+    {
+        var inputContents = @"@protocol Logger
+- (void)logValue:(int)value, ...;
+- (int)count;
+@end
+";
+
+        // The variadic method is outside the v1 subset, so it is diagnosed and skipped; the in-subset
+        // `count` method is still emitted.
+        var expectedOutputContents = @"using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    [NativeTypeName(""@protocol Logger"")]
+    public unsafe partial struct Logger
+    {
+        [NativeTypeName(""Class"")]
+        public void* isa;
+
+        public static class Selectors
+        {
+            public static readonly SEL count = ObjectiveC.sel_registerName(""count"");
+        }
+
+        public int count() => ((delegate* unmanaged<Logger*, SEL, int>)ObjectiveC.objc_msgSend)((Logger*)Unsafe.AsPointer(ref this), Selectors.count);
+    }
+
+    /// <summary>Represents an Objective-C selector (<c>SEL</c>).</summary>
+    public unsafe partial struct SEL : IEquatable<SEL>
+    {
+        public void* Value;
+
+        public SEL(void* value)
+        {
+            Value = value;
+        }
+
+        public static bool operator ==(SEL left, SEL right) => left.Value == right.Value;
+
+        public static bool operator !=(SEL left, SEL right) => left.Value != right.Value;
+
+        public override bool Equals(object? obj) => (obj is SEL other) && Equals(other);
+
+        public bool Equals(SEL other) => Value == other.Value;
+
+        public override int GetHashCode() => ((nuint)Value).GetHashCode();
+    }
+
+    /// <summary>Provides access to the Objective-C runtime (<c>libobjc</c>).</summary>
+    public static unsafe partial class ObjectiveC
+    {
+        private const string LibObjC = ""/usr/lib/libobjc.A.dylib"";
+
+        /// <summary>The raw <c>objc_msgSend</c> entry point, cast per call site to the selector's signature.</summary>
+        public static readonly void* objc_msgSend = (void*)NativeLibrary.GetExport(NativeLibrary.Load(LibObjC), ""objc_msgSend"");
+
+        [DllImport(LibObjC, EntryPoint = ""sel_registerName"", ExactSpelling = true)]
+        public static extern SEL sel_registerName([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+        [DllImport(LibObjC, EntryPoint = ""objc_getClass"", ExactSpelling = true)]
+        public static extern void* objc_getClass([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new Diagnostic(DiagnosticLevel.Warning, "Objective-C method 'logValue:' on '@protocol Logger' is not supported: variadic methods are not yet supported. It was skipped.", "Line 2, Column 9 in ClangUnsavedFile.h")
+        };
+
+        return ValidateGeneratedCSharpLatestWindowsBindingsAsync(inputContents, expectedOutputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateObjectiveCBindings, expectedDiagnostics: expectedDiagnostics, commandLineArgs: s_objectiveCCommandLineArgs, language: "objective-c", languageStandard: DefaultCStandard);
+    }
+}


### PR DESCRIPTION
Opt-in Objective-C binding generation, behind `--generate-objective-c-bindings`. This is the first phased slice of #254 and mirrors how we already emit COM: expose the raw C ABI and a friendly wrapper on the same type, keeping the layout faithful.

The parse/interop half of #254 has been in place for years (ClangSharp self-hosts the full Clang AST, and `clangsharp_Cursor_getSelector` already exists), so this PR is emitter-only.

----------

### Model

An `@protocol`/`@interface`/category maps to a `public unsafe partial struct` whose only field is `void* isa` — a byte-for-byte `struct objc_object`. The object pointer *is* `this`; `isa` is the identity/class hook. Unlike COM's `lpVtbl` there is no fixed dispatch table, because Objective-C dispatch is dynamic through `objc_msgSend`. Modern non-fragile ivars are exactly why the struct is opaque rather than a fixed-layout record.

Each in-subset method/property emits: a cached `SEL` in a nested `public static partial class Selectors`, and a friendly member that casts the single raw `objc_msgSend` entry point to the call site's exact `delegate* unmanaged<...>` signature and invokes it with the implicit `(self, _cmd)` leading args. Instance members recover `self` via `Unsafe.AsPointer(ref this)`; class (`+`) members are `static` and dispatch on `objc_getClass(...)`. A small inline `ObjectiveC`/`SEL` runtime surface is emitted once per output.

### ABI

Targets **arm64 only, and says so**. On Apple Silicon there is no `objc_msgSend_stret`/`_fpret` split — struct and FP returns/args all go through the single `objc_msgSend` under AAPCS64, which is what the JIT follows for the generated signature. By-value aggregates are therefore emitted through plain `objc_msgSend` with the real struct type, each flagged with a one-line note that x86-64 `_stret` is intentionally unsupported (Apple dropped x86-64 macOS). This sidesteps per-triple variant selection entirely.

### What's included

- Opt-in flag + decl dispatch for `ObjCProtocol`, `ObjCInterface`, `ObjCCategory` (`goto default` when off).
- `@protocol` → opaque struct + `isa` + `Selectors` + friendly instance methods/properties.
- `@interface` → same, plus the backing `Class` object and class (`+`) members.
- `@required`/`@optional` surfaced, with a `respondsToSelector:`-guard note on optional members.
- Inheritance + adopted protocols recorded in `[NativeTypeName]`; members are not flattened (dynamic dispatch + identical layout means a pointer cast to the superclass just works).
- `ObjCObjectPointerType` mapping (`id` → `void*`, `NSObject *` → `NSObject*`).
- By-value aggregate return/param support (arm64, flagged).
- Categories reopen the class's `partial struct` and `partial` `Selectors`, adding only new members.
- Out-of-subset constructs are diagnosed and skipped rather than mis-emitted: variadic methods, and class members on a `@protocol` (no backing class).
- 8 golden tests (Windows + Unix variants where relevant); full suite green, 0 warnings.

### Non-goals (intentional)

- **Variadic methods** — a C `...` can't be a fixed function-pointer signature.
- **`@implementation`** — definition-side; adds no callable surface over the `@interface`.
- **Foundation/SDK base types** — users point the generator at the SDK headers, same as any other platform SDK.
- **x86-64 macOS** — dropped by Apple; the `_stret`/`_fpret` variants are not supported.
- **ARC / retain-release** — no C# equivalent; ownership is the caller's, as with any unsafe interop.

### Before this is ready to merge

- API review for the new config option and emitted public surface.
- A decision on whether the inline `ObjectiveC`/`SEL` runtime surface should stay generated, move to a small hand-written support library, or be left to the consumer.
- On-device arm64 validation — the golden tests prove *shape*, not runtime correctness.

Contributes to #254.
