### PR TITLE
Fix InvalidCastException resolving dependent template-specialization bases

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -429,6 +429,18 @@ public sealed partial class PInvokeGenerator
             return (CXXRecordDecl)recordType.Decl;
         }
 
+        // A dependent base (such as `Base<T>` used within a class template) has no resolved
+        // record type. Its canonical type is still a template specialization, so resolve it to
+        // the record templated by the underlying class template. Casting the referenced cursor
+        // directly would throw, as it is the `ClassTemplateDecl` (or, for an alias-template base,
+        // a `TypeAliasTemplateDecl`) rather than a `CXXRecordDecl`. Canonicalization also unwraps
+        // any alias template to the aliased class template, so both cases resolve here.
+        if (baseType.CanonicalType is TemplateSpecializationType templateSpecializationType &&
+            templateSpecializationType.TemplateName.AsTemplateDecl is ClassTemplateDecl classTemplateDecl)
+        {
+            return classTemplateDecl.TemplatedDecl;
+        }
+
         AddDiagnostic(DiagnosticLevel.Error, "Failed to retrieve record type for CXX base specifier. Falling back to referenced type.", cxxBaseSpecifier);
         return (CXXRecordDecl)cxxBaseSpecifier.Referenced;
     }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/DependentTemplateBaseTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/DependentTemplateBaseTest.CSharp.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public partial struct Base
+    {
+        public int value;
+    }
+
+    [NativeTypeName("struct Derived : Base<T>")]
+    public partial struct Derived
+    {
+        public Base Base;
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/DependentTemplateBaseTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/DependentTemplateBaseTest.Xml.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="Base" access="public" layout="Sequential" pack="1">
+      <field name="value" access="public">
+        <type>int</type>
+      </field>
+    </struct>
+    <struct name="Derived" access="public" native="struct Derived : Base&lt;T&gt;">
+      <field name="Base" access="public" inherited="Base">
+        <type>Base</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
@@ -164,6 +164,28 @@ typedef struct
     }
 
     [Test]
+    public Task DependentTemplateBaseTest()
+    {
+        // A dependent template-specialization base (`Base<T>` within a class template) previously
+        // crashed `GetRecordDecl` with an `InvalidCastException` when both template bindings and
+        // empty-record exclusion were enabled, as the base resolves to a `ClassTemplateDecl`
+        // rather than a `CXXRecordDecl`. See microsoft/win32metadata#1686.
+        var inputContents = @"template <typename T>
+struct Base
+{
+    int value;
+};
+
+template <typename T>
+struct Derived : Base<T>
+{
+};
+";
+
+        return ValidateAsync(nameof(DependentTemplateBaseTest), inputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateTemplateBindings | PInvokeGeneratorConfigurationOptions.ExcludeEmptyRecords);
+    }
+
+    [Test]
     public Task ExcludeTest()
     {
         var inputContents = "typedef struct MyStruct MyStruct;";


### PR DESCRIPTION
Fixes the remaining crash for microsoft/win32metadata#1686 (which blocks CsWin32 adoption in microsoft/win32metadata#1287).

## What

`GetRecordDecl` cast a dependent base''s referenced cursor directly to `CXXRecordDecl`. For a dependent template-specialization base -- e.g. `Base<T>` used within a class template -- `IsType<RecordType>` returns `false` (the canonical type is still a dependent `TemplateSpecializationType`), and the referenced cursor is a `ClassTemplateDecl` (or, for an alias-template base, a `TypeAliasTemplateDecl`), so the cast threw `InvalidCastException`.

The crash only reproduces with both `--config exclude-empty-records` (drives `IsEmptyRecord`, which walks base specifiers via `GetRecordDecl`) and `--config generate-template-bindings` (lets class-template partial specializations reach `IsEmptyRecord`). win32metadata sets both.

The fix resolves such bases through the canonical template specialization''s `ClassTemplateDecl` and returns its `TemplatedDecl`. Canonicalization also unwraps an alias-template base (e.g. `bool_constant<is_function_v<_Ty>>` -> `integral_constant`), so both the `ClassTemplateDecl` and `TypeAliasTemplateDecl` cases resolve through one path. Non-template bases are unaffected (they return early via `IsType<RecordType>`), and the existing diagnostic + `Referenced` fallback is unchanged for anything genuinely unresolvable.

----------

Note: the `IsType<T>` StackOverflow originally described in win32metadata#1686 was already resolved on `main` by b9028785 (the `InjectedClassNameType` guard); the reporter was on ClangSharp 16, which predates it. This PR addresses the distinct `InvalidCastException` that remains.

## Test

Adds a golden-file regression test `StructDeclarationTest.DependentTemplateBaseTest` covering the minimal reproducer (`template <typename T> struct Base { int value; }; template <typename T> struct Derived : Base<T> {};`) with `GenerateTemplateBindings | ExcludeEmptyRecords`. Output is identical across all 16 variants, so the baselines are unified to one file per mode.

## Validation

- `dotnet build -c Release`: 0 warnings, 0 errors.
- `dotnet test -c Release`: full suite passes, 0 failures.
- Verified the original riverar/repro-29005f7a7a48rs header now generates with exit 0 and no exception.
