### PR TITLE
Port libClangSharp to the LLVM 22 Clang AST

### DIFF
--- a/.github/workflows/regenerate-native.yml
+++ b/.github/workflows/regenerate-native.yml
@@ -37,7 +37,6 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      llvm-version: ${{ steps.detect.outputs.llvm-version }}
       libclang: ${{ steps.detect.outputs.libclang }}
       libclangsharp: ${{ steps.detect.outputs.libclangsharp }}
     steps:
@@ -48,97 +47,22 @@ jobs:
       shell: bash
       run: |
         set -euo pipefail
-
-        parse_version() { sed -n 's/^project(ClangSharp VERSION \([0-9.]*\)).*/\1/p' "$1"; }
-
-        # The top-level CMakeLists.txt is the source of truth for the tracked LLVM version.
-        version="$(parse_version CMakeLists.txt)"
-        if [ -z "${version}" ]; then echo "could not parse LLVM version from CMakeLists.txt" >&2; exit 1; fi
-        major_minor="${version%.*}"
-        echo "llvm-version=${version}" >> "$GITHUB_OUTPUT"
-
-        libclang=false
-        libclangsharp=false
-
         if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-          if [ "${{ inputs.libclang }}" = "true" ]; then libclang=true; fi
-          if [ "${{ inputs.libclangsharp }}" = "true" ]; then libclangsharp=true; fi
+          # Manual runs pick the families explicitly.
+          echo "libclang=${{ inputs.libclang }}" >> "$GITHUB_OUTPUT"
+          echo "libclangsharp=${{ inputs.libclangsharp }}" >> "$GITHUB_OUTPUT"
         else
-          before="${{ github.event.before }}"
-          if [ -z "${before}" ] || [ "${before}" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "${before}^{commit}" 2>/dev/null; then
-            # No usable baseline to diff against (new/recreated branch, force-push,
-            # unfetched history); regenerate everything conservatively.
-            libclang=true
-            libclangsharp=true
-          else
-            # libclang regenerates when the tracked LLVM major.minor changes.
-            prev_version="$(git show "${before}:CMakeLists.txt" 2>/dev/null | sed -n 's/^project(ClangSharp VERSION \([0-9.]*\)).*/\1/p')"
-            prev_major_minor="${prev_version%.*}"
-            if [ "${major_minor}" != "${prev_major_minor}" ]; then
-              libclang=true
-            fi
-
-            # libClangSharp regenerates for the same reason or when its sources change.
-            if [ "${libclang}" = "true" ] || ! git diff --quiet "${before}" HEAD -- sources/libClangSharp/; then
-              libclangsharp=true
-            fi
-          fi
+          # Pushes diff against the prior commit; the script owns the change-detection
+          # logic so it stays reproducible and testable locally.
+          ./scripts/build.sh --detectchanges --base "${{ github.event.before }}" | tee -a "$GITHUB_OUTPUT"
         fi
-
-        echo "libclang=${libclang}" >> "$GITHUB_OUTPUT"
-        echo "libclangsharp=${libclangsharp}" >> "$GITHUB_OUTPUT"
-        echo "Resolved: llvm=${version} (major.minor=${major_minor}) libclang=${libclang} libclangsharp=${libclangsharp}"
     - name: Verify package versions match the tracked LLVM version
       # Guards against bumping CMakeLists.txt without updating the nuspec/runtime.json
-      # versions. libclang versions must equal the LLVM version exactly; libClangSharp
-      # versions must be that version plus an independent build revision (e.g. 21.1.8.2).
+      # versions before regenerating. The check lives in the build script so it is
+      # reproducible locally (./scripts/build.sh --verifypackages).
+      if: steps.detect.outputs.libclang == 'true' || steps.detect.outputs.libclangsharp == 'true'
       shell: bash
-      run: |
-        set -euo pipefail
-        version="${{ steps.detect.outputs.llvm-version }}"
-        rc=0
-
-        nuspec_version() { sed -n 's:.*<version>\([^<]*\)</version>.*:\1:p' "$1" | head -n1; }
-        nuspec_branch()  { sed -n 's:.*<repository[^>]*branch="\([^"]*\)".*:\1:p' "$1" | head -n1; }
-        json_versions()  { grep -oE '"[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?"' "$1" | tr -d '"'; }
-
-        fail() { echo "::error file=$1::$2"; rc=1; }
-
-        if [ "${{ steps.detect.outputs.libclang }}" = "true" ]; then
-          for f in packages/libclang/libclang/libclang.nuspec packages/libclang/libclang.runtime.*/*.nuspec; do
-            v="$(nuspec_version "$f")"
-            [ "${v}" = "${version}" ] || fail "$f" "version '${v}' does not match LLVM version '${version}'"
-            b="$(nuspec_branch "$f")"
-            if [ -n "${b}" ] && [ "${b}" != "llvmorg-${version}" ]; then
-              fail "$f" "repository branch '${b}' does not match 'llvmorg-${version}'"
-            fi
-          done
-          for v in $(json_versions packages/libclang/libclang/runtime.json); do
-            [ "${v}" = "${version}" ] || fail "packages/libclang/libclang/runtime.json" "mapped version '${v}' does not match LLVM version '${version}'"
-          done
-        fi
-
-        if [ "${{ steps.detect.outputs.libclangsharp }}" = "true" ]; then
-          for f in packages/libClangSharp/libClangSharp/libClangSharp.nuspec packages/libClangSharp/libClangSharp.runtime.*/*.nuspec; do
-            v="$(nuspec_version "$f")"
-            case "${v}" in
-              "${version}".*) : ;;
-              *) fail "$f" "version '${v}' is not 'llvm-version.<revision>' (expected '${version}.<n>')" ;;
-            esac
-          done
-          for v in $(json_versions packages/libClangSharp/libClangSharp/runtime.json); do
-            case "${v}" in
-              "${version}".*) : ;;
-              *) fail "packages/libClangSharp/libClangSharp/runtime.json" "mapped version '${v}' is not '${version}.<revision>'" ;;
-            esac
-          done
-        fi
-
-        if [ "${rc}" -ne 0 ]; then
-          echo "Update the package versions to match the tracked LLVM version (${version}) before regenerating." >&2
-          exit 1
-        fi
-        echo "Package versions verified against LLVM ${version}"
+      run: ./scripts/build.sh --verifypackages
 
   # -------- libclang: lift the prebuilt libclang out of the matching LLVM release --------
 
@@ -158,6 +82,7 @@ jobs:
         New-Item -ItemType Directory -Force -Path out | Out-Null
         foreach ($rid in @("win-x64", "win-arm64", "linux-x64", "linux-arm64", "osx-arm64")) {
           ./scripts/build.ps1 -regeneratenative -target libclang -rid $rid
+          if ($LASTEXITCODE -ne 0) { throw "build.ps1 failed for $rid" }
           Copy-Item "artifacts/native/$rid/*" "packages/libclang/libclang.runtime.$rid/"
           nuget pack "packages/libclang/libclang.runtime.$rid/libclang.runtime.$rid.nuspec" -OutputDirectory out
           if ($LASTEXITCODE -ne 0) { throw "nuget pack failed for $rid" }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 
 project(ClangSharp VERSION 22.1.8)
+
+# The official LLVM release binaries link the static CRT (/MT); match them so
+# libClangSharp links against them without LNK2038 runtime-library mismatches.
+if(MSVC)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ The tracked LLVM version is the `project(ClangSharp VERSION X.Y.Z)` value in the
 ./scripts/build.sh --regeneratenative --target libClangSharp --rid linux-x64
 ```
 
+The change-detection and version-verification the workflow gates on live in the same scripts, so they can be reproduced locally: `./scripts/build.sh --detectchanges --base <ref>` prints which families a range of commits regenerates, and `./scripts/build.sh --verifypackages` checks the nuspec/`runtime.json` versions match the tracked LLVM version.
+
 The staged binary is written to `artifacts/native/<rid>/`. The LLVM release distribution bundles both the prebuilt `libclang` and the `lib/cmake/{llvm,clang}` config, headers, and import libraries used as `PATH_TO_LLVM` when building `libClangSharp`, so no from-source LLVM build is required (the manual [Building Native](#building-native) steps remain the way to reproduce a build locally). Because lifting `libclang` is just unpacking prebuilt binaries, the workflow does all five runtimes on a single Windows runner (its bundled `bsdtar` handles `.tar.xz`); `libClangSharp` is compiled per-runtime on native runners.
 
 The jobs run when:

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,9 +1,11 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
   [ValidateSet("<auto>", "amd64", "x64", "x86", "arm64", "arm")][string] $architecture = "",
+  [string] $base = "",
   [switch] $build,
   [switch] $ci,
   [ValidateSet("Debug", "Release")][string] $configuration = "Debug",
+  [switch] $detectchanges,
   [switch] $help,
   [string] $llvm = "",
   [switch] $pack,
@@ -15,6 +17,7 @@ Param(
   [switch] $test,
   [switch] $testwin32metadata,
   [ValidateSet("quiet", "minimal", "normal", "detailed", "diagnostic")][string] $verbosity = "minimal",
+  [switch] $verifypackages,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -50,6 +53,8 @@ function Help() {
     Write-Host -Object "  -pack                   Package build artifacts"
     Write-Host -Object "  -regeneratenative       Download the matching LLVM release and stage a native binary"
     Write-Host -Object "                          (use with -target and -rid)"
+    Write-Host -Object "  -verifypackages         Verify the libclang/libClangSharp package versions match CMakeLists.txt"
+    Write-Host -Object "  -detectchanges          Print which native packages need regenerating since -base <ref>"
     Write-Host -Object ""
     Write-Host -Object "Advanced settings:"
     Write-Host -Object "  -solution <value>       Path to solution to build"
@@ -215,6 +220,113 @@ function Regenerate-Native() {
   }
 }
 
+function Verify-Packages() {
+  $version = Get-LlvmVersion
+  $failed = $false
+
+  # libclang packages track the LLVM version exactly, including the repository branch.
+  $libclangNuspecs = @(Join-Path -Path $RepoRoot -ChildPath "packages\libclang\libclang\libclang.nuspec")
+  $libclangNuspecs += Get-ChildItem -Path (Join-Path -Path $RepoRoot -ChildPath "packages\libclang") -Filter "*.nuspec" -Recurse | Where-Object { $_.Name -ne "libclang.nuspec" } | ForEach-Object { $_.FullName }
+
+  foreach ($nuspec in $libclangNuspecs) {
+    $content = Get-Content -Path $nuspec -Raw
+
+    if ($content -match "<version>([^<]*)</version>") {
+      if ($Matches[1] -ne $version) {
+        Write-Host -Object "${nuspec}: version '$($Matches[1])' does not match LLVM version '$version'"
+        $failed = $true
+      }
+    }
+
+    if ($content -match 'branch="([^"]*)"') {
+      if ($Matches[1] -ne "llvmorg-$version") {
+        Write-Host -Object "${nuspec}: repository branch '$($Matches[1])' does not match 'llvmorg-$version'"
+        $failed = $true
+      }
+    }
+  }
+
+  $libclangRuntimeJson = Join-Path -Path $RepoRoot -ChildPath "packages\libclang\libclang\runtime.json"
+
+  foreach ($match in ([regex]'"(\d+\.\d+\.\d+(\.\d+)?)"').Matches((Get-Content -Path $libclangRuntimeJson -Raw))) {
+    if ($match.Groups[1].Value -ne $version) {
+      Write-Host -Object "packages\libclang\libclang\runtime.json: mapped version '$($match.Groups[1].Value)' does not match LLVM version '$version'"
+      $failed = $true
+    }
+  }
+
+  # libClangSharp packages are the LLVM version plus an independent build revision.
+  $libclangsharpNuspecs = @(Join-Path -Path $RepoRoot -ChildPath "packages\libClangSharp\libClangSharp\libClangSharp.nuspec")
+  $libclangsharpNuspecs += Get-ChildItem -Path (Join-Path -Path $RepoRoot -ChildPath "packages\libClangSharp") -Filter "*.nuspec" -Recurse | Where-Object { $_.Name -ne "libClangSharp.nuspec" } | ForEach-Object { $_.FullName }
+
+  foreach ($nuspec in $libclangsharpNuspecs) {
+    $content = Get-Content -Path $nuspec -Raw
+
+    if ($content -match "<version>([^<]*)</version>") {
+      if (-not $Matches[1].StartsWith("$version.")) {
+        Write-Host -Object "${nuspec}: version '$($Matches[1])' is not 'llvm-version.<revision>' (expected '$version.<n>')"
+        $failed = $true
+      }
+    }
+  }
+
+  $libclangsharpRuntimeJson = Join-Path -Path $RepoRoot -ChildPath "packages\libClangSharp\libClangSharp\runtime.json"
+
+  foreach ($match in ([regex]'"(\d+\.\d+\.\d+(\.\d+)?)"').Matches((Get-Content -Path $libclangsharpRuntimeJson -Raw))) {
+    if (-not $match.Groups[1].Value.StartsWith("$version.")) {
+      Write-Host -Object "packages\libClangSharp\libClangSharp\runtime.json: mapped version '$($match.Groups[1].Value)' is not '$version.<revision>'"
+      $failed = $true
+    }
+  }
+
+  if ($failed) {
+    throw "Update the package versions to match the tracked LLVM version ($version) before regenerating."
+  }
+
+  Write-Host -Object "Package versions verified against LLVM $version"
+}
+
+function Detect-Changes() {
+  if ($base -eq "") {
+    throw "-base <ref> is required with -detectchanges"
+  }
+
+  $version = Get-LlvmVersion
+  $detectLibclang = $false
+  $detectLibclangsharp = $false
+
+  & git -C "$RepoRoot" cat-file -e "$base^{commit}" 2>$null
+
+  if ($LastExitCode -ne 0) {
+    # No resolvable baseline to diff against, so regenerate everything conservatively.
+    $detectLibclang = $true
+    $detectLibclangsharp = $true
+  }
+  else {
+    # libclang regenerates when the tracked LLVM major.minor changes.
+    $previous = & git -C "$RepoRoot" show "${base}:CMakeLists.txt" 2>$null | Select-String -Pattern 'project\(ClangSharp VERSION ([0-9.]+)\)' | Select-Object -First 1
+
+    $previousVersion = if ($previous) { $previous.Matches[0].Groups[1].Value } else { "" }
+
+    $currentMajorMinor = ($version -split '\.')[0..1] -join '.'
+    $previousMajorMinor = ($previousVersion -split '\.')[0..1] -join '.'
+
+    if ($currentMajorMinor -ne $previousMajorMinor) {
+      $detectLibclang = $true
+    }
+
+    # libClangSharp regenerates for that same reason or when its sources change.
+    & git -C "$RepoRoot" diff --quiet "$base" HEAD -- sources/libClangSharp/
+
+    if ($detectLibclang -or ($LastExitCode -ne 0)) {
+      $detectLibclangsharp = $true
+    }
+  }
+
+  Write-Output "libclang=$($detectLibclang.ToString().ToLowerInvariant())"
+  Write-Output "libclangsharp=$($detectLibclangsharp.ToString().ToLowerInvariant())"
+}
+
 function Test() {
   $logFile = Join-Path -Path $LogDir -ChildPath "$configuration\test.binlog"
   & dotnet test -c "$configuration" --no-build --no-restore -v "$verbosity" /bl:"$logFile" /err $properties "$solution"
@@ -342,6 +454,14 @@ try {
 
   if ($regeneratenative) {
     Regenerate-Native
+  }
+
+  if ($verifypackages) {
+    Verify-Packages
+  }
+
+  if ($detectchanges) {
+    Detect-Changes
   }
 }
 catch {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,9 +9,11 @@ done
 ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 architecture=''
+base=''
 build=false
 ci=false
 configuration='Debug'
+detectchanges=false
 help=false
 llvm=''
 pack=false
@@ -22,6 +24,7 @@ solution=''
 target=''
 test=false
 verbosity='minimal'
+verifypackages=false
 properties=''
 
 while [[ $# -gt 0 ]]; do
@@ -29,6 +32,10 @@ while [[ $# -gt 0 ]]; do
   case $lower in
     --architecture)
       architecture=$2
+      shift 2
+      ;;
+    --base)
+      base=$2
       shift 2
       ;;
     --build)
@@ -42,6 +49,10 @@ while [[ $# -gt 0 ]]; do
     --configuration)
       configuration=$2
       shift 2
+      ;;
+    --detectchanges)
+      detectchanges=true
+      shift 1
       ;;
     --help)
       help=true
@@ -82,6 +93,10 @@ while [[ $# -gt 0 ]]; do
     --verbosity)
       verbosity=$2
       shift 2
+      ;;
+    --verifypackages)
+      verifypackages=true
+      shift 1
       ;;
     *)
       properties="$properties $1"
@@ -127,6 +142,8 @@ function Help {
   echo "  --pack                    Package build artifacts"
   echo "  --regeneratenative        Download the matching LLVM release and stage a native binary"
   echo "                            (use with --target and --rid)"
+  echo "  --verifypackages          Verify the libclang/libClangSharp package versions match CMakeLists.txt"
+  echo "  --detectchanges           Print which native packages need regenerating since --base <ref>"
   echo ""
   echo "Advanced settings:"
   echo "  --solution <value>        Path to solution to build"
@@ -380,6 +397,111 @@ function RegenerateNative {
   fi
 }
 
+function VerifyPackages {
+  GetLlvmVersion
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    return "$LASTEXITCODE"
+  fi
+
+  rc=0
+
+  # libclang packages track the LLVM version exactly, including the repository branch.
+  for f in "$RepoRoot"/packages/libclang/libclang/libclang.nuspec "$RepoRoot"/packages/libclang/libclang.runtime.*/*.nuspec; do
+    v="$(sed -n 's:.*<version>\([^<]*\)</version>.*:\1:p' "$f" | head -n1)"
+
+    if [ "$v" != "$llvm" ]; then
+      echo "$f: version '$v' does not match LLVM version '$llvm'"
+      rc=1
+    fi
+
+    b="$(sed -n 's:.*<repository[^>]*branch="\([^"]*\)".*:\1:p' "$f" | head -n1)"
+
+    if [ -n "$b" ] && [ "$b" != "llvmorg-$llvm" ]; then
+      echo "$f: repository branch '$b' does not match 'llvmorg-$llvm'"
+      rc=1
+    fi
+  done
+
+  for v in $(grep -oE '"[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?"' "$RepoRoot/packages/libclang/libclang/runtime.json" | tr -d '"'); do
+    if [ "$v" != "$llvm" ]; then
+      echo "packages/libclang/libclang/runtime.json: mapped version '$v' does not match LLVM version '$llvm'"
+      rc=1
+    fi
+  done
+
+  # libClangSharp packages are the LLVM version plus an independent build revision.
+  for f in "$RepoRoot"/packages/libClangSharp/libClangSharp/libClangSharp.nuspec "$RepoRoot"/packages/libClangSharp/libClangSharp.runtime.*/*.nuspec; do
+    v="$(sed -n 's:.*<version>\([^<]*\)</version>.*:\1:p' "$f" | head -n1)"
+
+    case "$v" in
+      "$llvm".*) : ;;
+      *)
+        echo "$f: version '$v' is not 'llvm-version.<revision>' (expected '$llvm.<n>')"
+        rc=1
+        ;;
+    esac
+  done
+
+  for v in $(grep -oE '"[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?"' "$RepoRoot/packages/libClangSharp/libClangSharp/runtime.json" | tr -d '"'); do
+    case "$v" in
+      "$llvm".*) : ;;
+      *)
+        echo "packages/libClangSharp/libClangSharp/runtime.json: mapped version '$v' is not '$llvm.<revision>'"
+        rc=1
+        ;;
+    esac
+  done
+
+  if [ "$rc" != 0 ]; then
+    echo "Update the package versions to match the tracked LLVM version ($llvm) before regenerating."
+    LASTEXITCODE=1
+    return "$LASTEXITCODE"
+  fi
+
+  echo "Package versions verified against LLVM $llvm"
+  LASTEXITCODE=0
+}
+
+function DetectChanges {
+  if [[ -z "$base" ]]; then
+    echo "--base <ref> is required with --detectchanges"
+    LASTEXITCODE=1
+    return "$LASTEXITCODE"
+  fi
+
+  GetLlvmVersion
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    return "$LASTEXITCODE"
+  fi
+
+  detectLibclang=false
+  detectLibclangsharp=false
+
+  if ! git -C "$RepoRoot" cat-file -e "$base^{commit}" 2>/dev/null; then
+    # No resolvable baseline to diff against, so regenerate everything conservatively.
+    detectLibclang=true
+    detectLibclangsharp=true
+  else
+    # libclang regenerates when the tracked LLVM major.minor changes.
+    prevVersion="$(git -C "$RepoRoot" show "$base:CMakeLists.txt" 2>/dev/null | sed -n 's/^project(ClangSharp VERSION \([0-9.]*\)).*/\1/p')"
+
+    if [ "${llvm%.*}" != "${prevVersion%.*}" ]; then
+      detectLibclang=true
+    fi
+
+    # libClangSharp regenerates for that same reason or when its sources change.
+    if [ "$detectLibclang" = true ] || ! git -C "$RepoRoot" diff --quiet "$base" HEAD -- sources/libClangSharp/; then
+      detectLibclangsharp=true
+    fi
+  fi
+
+  echo "libclang=$detectLibclang"
+  echo "libclangsharp=$detectLibclangsharp"
+  LASTEXITCODE=0
+}
+
 if $help; then
   Help
   exit 0
@@ -457,10 +579,29 @@ if $pack; then
   fi
 fi
 
+# The native subcommands below are only ever executed directly (never sourced via
+# cibuild.sh), so they exit with the failure code -- a top-level return would merely
+# warn and let the script fall through to a later block, masking the failure.
 if $regeneratenative; then
   RegenerateNative
 
   if [ "$LASTEXITCODE" != 0 ]; then
-    return "$LASTEXITCODE"
+    exit "$LASTEXITCODE"
+  fi
+fi
+
+if $verifypackages; then
+  VerifyPackages
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    exit "$LASTEXITCODE"
+  fi
+fi
+
+if $detectchanges; then
+  DetectChanges
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    exit "$LASTEXITCODE"
   fi
 fi

--- a/sources/libClangSharp/CXType.cpp
+++ b/sources/libClangSharp/CXType.cpp
@@ -110,7 +110,6 @@ namespace clang::cxtype {
             TKCASE(ExtVector);
             TKCASE(MemberPointer);
             TKCASE(Auto);
-            TKCASE(Elaborated);
             TKCASE(Pipe);
             TKCASE(Attributed);
             TKCASE(BTFTagAttributed);

--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -1997,12 +1997,12 @@ CXType clangsharp_Cursor_getInjectedSpecializationType(CXCursor C) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
 
-        if (ClassTemplateDecl* CTD = const_cast<ClassTemplateDecl*>(dyn_cast<ClassTemplateDecl>(D))) {
-            return MakeCXType(CTD->getInjectedClassNameSpecialization(), getCursorTU(C));
+        if (const ClassTemplateDecl* CTD = dyn_cast<ClassTemplateDecl>(D)) {
+            return MakeCXType(CTD->getCanonicalInjectedSpecializationType(D->getASTContext()), getCursorTU(C));
         }
 
         if (const ClassTemplatePartialSpecializationDecl* CTPSD = dyn_cast<ClassTemplatePartialSpecializationDecl>(D)) {
-            return MakeCXType(CTPSD->getInjectedSpecializationType(), getCursorTU(C));
+            return MakeCXType(CTPSD->getCanonicalInjectedSpecializationType(D->getASTContext()), getCursorTU(C));
         }
     }
 
@@ -5495,7 +5495,7 @@ CXCursor clangsharp_Type_getDeclaration(CXType CT) {
     }
 
     if (const UsingType* UT = dyn_cast<UsingType>(TP)) {
-        return MakeCXCursor(UT->getFoundDecl(), GetTypeTU(CT));
+        return MakeCXCursor(UT->getDecl(), GetTypeTU(CT));
     }
 
     return clang_getTypeDeclaration(CT);
@@ -5573,7 +5573,9 @@ CXType clangsharp_Type_getInjectedSpecializationType(CXType CT) {
     const Type* TP = T.getTypePtrOrNull();
 
     if (const InjectedClassNameType* ICNT = dyn_cast<InjectedClassNameType>(TP)) {
-        return MakeCXType(ICNT->getInjectedSpecializationType(), GetTypeTU(CT));
+        ASTContext& ctx = getASTUnit(GetTypeTU(CT))->getASTContext();
+        QualType QT = ctx.getCanonicalTemplateSpecializationType(ElaboratedTypeKeyword::None, ICNT->getTemplateName(ctx), ICNT->getTemplateArgs(ctx));
+        return MakeCXType(QT, GetTypeTU(CT));
     }
 
     return MakeCXType(QualType(), GetTypeTU(CT));
@@ -5584,7 +5586,8 @@ CXType clangsharp_Type_getInjectedTST(CXType CT) {
     const Type* TP = T.getTypePtrOrNull();
 
     if (const InjectedClassNameType* ICNT = dyn_cast<InjectedClassNameType>(TP)) {
-        QualType QT = QualType(ICNT->getInjectedTST(), 0);
+        ASTContext& ctx = getASTUnit(GetTypeTU(CT))->getASTContext();
+        QualType QT = ctx.getCanonicalTemplateSpecializationType(ElaboratedTypeKeyword::None, ICNT->getTemplateName(ctx), ICNT->getTemplateArgs(ctx));
         return MakeCXType(QT, GetTypeTU(CT));
     }
 
@@ -5765,8 +5768,10 @@ CXCursor clangsharp_Type_getOwnedTagDecl(CXType CT) {
     QualType T = GetQualType(CT);
     const Type* TP = T.getTypePtrOrNull();
 
-    if (const ElaboratedType* ET = dyn_cast<ElaboratedType>(TP)) {
-        return MakeCXCursor(ET->getOwnedTagDecl(), GetTypeTU(CT));
+    if (const TagType* TT = dyn_cast<TagType>(TP)) {
+        if (TT->isTagOwned()) {
+            return MakeCXCursor(TT->getDecl(), GetTypeTU(CT));
+        }
     }
 
     return clang_getNullCursor();
@@ -5838,13 +5843,6 @@ CX_TemplateArgument clangsharp_Type_getTemplateArgument(CXType CT, unsigned i) {
         }
     }
 
-    if (const DependentTemplateSpecializationType* DTST = dyn_cast<DependentTemplateSpecializationType>(TP)) {
-        ArrayRef<TemplateArgument> templateArguments = DTST->template_arguments();
-        if (i < templateArguments.size()) {
-            return MakeCXTemplateArgument(&templateArguments[i], GetTypeTU(CT));
-        }
-    }
-
     if (const SubstTemplateTypeParmPackType* STTPPT = dyn_cast<SubstTemplateTypeParmPackType>(TP)) {
         if (i == 0) {
             const TemplateArgument* TA = new TemplateArgument(STTPPT->getArgumentPack());
@@ -5880,7 +5878,8 @@ CX_TemplateName clangsharp_Type_getTemplateName(CXType CT) {
     }
 
     if (const InjectedClassNameType* ICNT = dyn_cast<InjectedClassNameType>(TP)) {
-        TemplateName TN = ICNT->getTemplateName();
+        ASTContext& ctx = getASTUnit(GetTypeTU(CT))->getASTContext();
+        TemplateName TN = ICNT->getTemplateName(ctx);
         return MakeCXTemplateName(TN, GetTypeTU(CT));
     }
 


### PR DESCRIPTION
> [!NOTE]
> This PR body was drafted by Copilot.

Updates `sources/libClangSharp` for the LLVM 21 -> 22 type-sugar refactor so the native library compiles and links against the 22.1.8 release (#779 bumped the tracked version ahead of the C++ port, leaving the `regenerate-native` legs red).

### libClangSharp port
- `ElaboratedType` is removed; the elaboration keyword/qualifier and tag ownership moved onto `TagType`. `clangsharp_Type_getOwnedTagDecl` now uses `TagType::isTagOwned()`/`getDecl()`, and the `Elaborated` `CXType` kind mapping is dropped from `CXType.cpp`.
- `InjectedClassNameType` is now a `TagType`. The injected specialization is recovered via `getCanonicalInjectedSpecializationType(ctx)` (decl-level, the same replacement clang itself uses in `findPartialSpecialization`) and via `getCanonicalTemplateSpecializationType(None, getTemplateName(ctx), getTemplateArgs(ctx))` (type-level, matching clang's own `ClassTemplatePartialSpecializationDecl::getCanonicalInjectedSpecializationType` construction).
- `DependentTemplateSpecializationType` is folded into `TemplateSpecializationType`; its template-argument branch is dropped and handled by the existing `TemplateSpecializationType` branch.
- `UsingType::getFoundDecl` -> `getDecl` (same underlying `UsingShadowDecl`).

One inherent behavior shift: the injected-specialization getters now return the **canonical** injected type -- LLVM 22 no longer stores the as-written one. Same template and injected args.

### Build
- `CMakeLists.txt`: set `CMAKE_MSVC_RUNTIME_LIBRARY` to the static CRT (`/MT`) so libClangSharp links against the official `/MT` LLVM release binaries without `LNK2038`. Bumped `cmake_minimum_required` 3.13 -> 3.15 so the runtime-library policy applies. Validated locally: compiles with 0 errors and links `libClangSharp.dll` against the real 22.1.8 release via a plain `-DPATH_TO_LLVM` invocation.

----------

### Detect refactor
Moves the `regenerate-native` change-detection and package-version verification out of YAML into `build.ps1`/`build.sh` (`--detectchanges`/`--verifypackages`) so they're reproducible and testable locally, and thins the workflow down to glue around the scripts.

----------

`Directory.Packages.props` intentionally stays on the `21.1.8` consuming refs so `ci.yml` restore stays green -- the `22.1.8` native packages are published by this workflow first. A **stacked follow-up** then bumps the consuming refs, regenerates the managed bindings, and fixes the `CX_TypeClass` ordinals (the LLVM 22 `TypeNodes` change removes `Elaborated`/`DependentTemplateSpecialization` and reparents `InjectedClassName`, shifting the ordinals that `clangsharp_Type_getTypeClass` feeds into the managed enum).