### PR TITLE
Update baselines and docs for the 21.1.8.4 version bump

### DIFF
--- a/docs/using-clangsharp-as-a-library.md
+++ b/docs/using-clangsharp-as-a-library.md
@@ -106,7 +106,7 @@ so the correct platform-specific runtime package is restored:
 
   <ItemGroup>
     <!-- The native libClang/libClangSharp runtimes come in transitively -->
-    <PackageReference Include="ClangSharp" Version="21.1.8.3" />
+    <PackageReference Include="ClangSharp" Version="21.1.8.4" />
   </ItemGroup>
 
 </Project>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsAssemblyAttributeWithHelperTypes.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsAssemblyAttributeWithHelperTypes.CSharp.Latest.Windows.cs
@@ -3,7 +3,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
-[assembly: GeneratedCode("ClangSharp", "21.1.8.3")]
+[assembly: GeneratedCode("ClangSharp", "21.1.8.4")]
 
 namespace ClangSharp.Test
 {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsPerTypeAttributeInTypeMode.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsPerTypeAttributeInTypeMode.CSharp.Latest.Windows.cs
@@ -3,19 +3,19 @@ using System.Runtime.InteropServices;
 
 namespace ClangSharp.Test
 {
-    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    [GeneratedCode("ClangSharp", "21.1.8.4")]
     public enum MyEnum
     {
         MyEnum_Value,
     }
 
-    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    [GeneratedCode("ClangSharp", "21.1.8.4")]
     public partial struct MyStruct
     {
         public int value;
     }
 
-    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    [GeneratedCode("ClangSharp", "21.1.8.4")]
     public static unsafe partial class Methods
     {
         [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?MyFunction@@YAXP6AXH@Z@Z", ExactSpelling = true)]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsPerTypeAttributeOnDelegateInTypeMode.CSharp.Compatible.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsPerTypeAttributeOnDelegateInTypeMode.CSharp.Compatible.Windows.cs
@@ -4,23 +4,23 @@ using System.Runtime.InteropServices;
 
 namespace ClangSharp.Test
 {
-    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    [GeneratedCode("ClangSharp", "21.1.8.4")]
     public enum MyEnum
     {
         MyEnum_Value,
     }
 
-    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    [GeneratedCode("ClangSharp", "21.1.8.4")]
     public partial struct MyStruct
     {
         public int value;
     }
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    [GeneratedCode("ClangSharp", "21.1.8.4")]
     public delegate void MyCallback(int value);
 
-    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    [GeneratedCode("ClangSharp", "21.1.8.4")]
     public static partial class Methods
     {
         [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?MyFunction@@YAXP6AXH@Z@Z", ExactSpelling = true)]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsPerTypeInsteadOfAssemblyWithHelperTypes.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/GeneratedCodeAttribute/EmitsPerTypeInsteadOfAssemblyWithHelperTypes.CSharp.Latest.Windows.cs
@@ -5,19 +5,19 @@ using System.Runtime.InteropServices;
 
 namespace ClangSharp.Test
 {
-    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    [GeneratedCode("ClangSharp", "21.1.8.4")]
     public enum MyEnum
     {
         MyEnum_Value,
     }
 
-    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    [GeneratedCode("ClangSharp", "21.1.8.4")]
     public partial struct MyStruct
     {
         public int value;
     }
 
-    [GeneratedCode("ClangSharp", "21.1.8.3")]
+    [GeneratedCode("ClangSharp", "21.1.8.4")]
     public static unsafe partial class Methods
     {
         [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?MyFunction@@YAXP6AXH@Z@Z", ExactSpelling = true)]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedAfterMethodClass.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedAfterMethodClass.CSharp.Latest.Windows.cs
@@ -3,7 +3,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
-[assembly: GeneratedCode("ClangSharp", "21.1.8.3")]
+[assembly: GeneratedCode("ClangSharp", "21.1.8.4")]
 
 namespace ClangSharp.Test
 {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedAfterMethodClassFileScoped.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedAfterMethodClassFileScoped.CSharp.Latest.Windows.cs
@@ -3,7 +3,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
-[assembly: GeneratedCode("ClangSharp", "21.1.8.3")]
+[assembly: GeneratedCode("ClangSharp", "21.1.8.4")]
 
 namespace ClangSharp.Test;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedInSharedFileScopedNamespace.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedInSharedFileScopedNamespace.CSharp.Latest.Windows.cs
@@ -2,7 +2,7 @@ using System;
 using System.CodeDom.Compiler;
 using System.Diagnostics;
 
-[assembly: GeneratedCode("ClangSharp", "21.1.8.3")]
+[assembly: GeneratedCode("ClangSharp", "21.1.8.4")]
 
 namespace ClangSharp.Test;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedInSharedNamespace.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/HelperTypes/HelperTypesEmittedInSharedNamespace.CSharp.Latest.Windows.cs
@@ -2,7 +2,7 @@ using System;
 using System.CodeDom.Compiler;
 using System.Diagnostics;
 
-[assembly: GeneratedCode("ClangSharp", "21.1.8.3")]
+[assembly: GeneratedCode("ClangSharp", "21.1.8.4")]
 
 namespace ClangSharp.Test
 {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/TransparentStruct/BooleanKindGeneratesValidHelper.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/TransparentStruct/BooleanKindGeneratesValidHelper.CSharp.Latest.Windows.cs
@@ -2,7 +2,7 @@ using System;
 using System.CodeDom.Compiler;
 using System.Diagnostics;
 
-[assembly: GeneratedCode("ClangSharp", "21.1.8.3")]
+[assembly: GeneratedCode("ClangSharp", "21.1.8.4")]
 
 namespace ClangSharp.Test
 {


### PR DESCRIPTION
The `VersionPrefix` bump to `21.1.8.4` in `64b6e475` left the generator baselines that embed `[assembly: GeneratedCode("ClangSharp", "...")]` reading the old `21.1.8.3`, so the affected `GeneratedCodeAttribute`, `HelperTypes`, and `TransparentStruct` tests fail on `main`. Updates those 9 baselines to `21.1.8.4`.

----------

Also bumps the stale `ClangSharp` `PackageReference` example in `docs/using-clangsharp-as-a-library.md` to match.

Full Release build is clean (0 warnings) and the suite passes (3973 passed, 0 failed).