### PR TITLE
Use the LLVM release libLTO when linking libClangSharp on macOS

### DIFF
--- a/sources/libClangSharp/CMakeLists.txt
+++ b/sources/libClangSharp/CMakeLists.txt
@@ -76,6 +76,15 @@ add_library(ClangSharp SHARED ${SOURCES})
 
 target_link_libraries(ClangSharp PRIVATE clangAST clangFrontend libclang)
 
+# The official LLVM macOS release ships LTO bitcode in its static archives, so
+# linking them requires a libLTO that understands LLVM 22 bitcode. Apple's system
+# linker defaults to Xcode's older libLTO and fails ("could not parse bitcode
+# object file ... Unknown attribute kind"). Point the linker at the libLTO.dylib
+# from the LLVM release being consumed.
+if(APPLE AND EXISTS "${PATH_TO_LLVM}/lib/libLTO.dylib")
+  target_link_options(ClangSharp PRIVATE "LINKER:-lto_library,${PATH_TO_LLVM}/lib/libLTO.dylib")
+endif()
+
 target_include_directories(ClangSharp PRIVATE ${CLANG_INCLUDE_DIRS})
 
 set_target_properties(ClangSharp PROPERTIES


### PR DESCRIPTION
Follow-up to #790. That PR fixed the `win-x64`, `linux-x64`, and `linux-arm64` legs of `regenerate-native`, but it merged before the macOS fix was added, so `osx-arm64` is still red.

The official LLVM **macOS** release ships LTO bitcode in its static archives, so linking them requires a libLTO that understands LLVM 22 bitcode. Apple's system linker defaults to Xcode's older libLTO (v21) and fails:

```
ld: could not parse bitcode object file .../libclangOptions.a(OptionUtils.cpp.o):
'Unknown attribute kind (105)' (Producer: 'LLVM22.1.8' Reader: 'LLVM APPLE_1_2100...'),
using libLTO version 'LLVM version 21.0.0'
```

Point the linker at the `libLTO.dylib` from the LLVM release being consumed. Unlike the macOS release, the Linux release archives are native objects, so this is Apple-only.

`regenerate-native` runs on `push: main` / `workflow_dispatch` (not on PRs), so this is validated by the next post-merge run.

> [!NOTE]
> This PR body and the code change were drafted by Copilot.