### PR TITLE
Qualify cross-enum references to stripped members

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -1102,7 +1102,16 @@ public partial class PInvokeGenerator
             {
                 var enumName = GetRemappedCursorName(namedDecl, out _, skipUsing: true);
 
-                if (!_config.DontUseUsingStaticsForEnums)
+                // In C all enum constants share a single ordinary-identifier namespace, so un-stripped member
+                // names are unique across the translation unit and can be imported via `using static` and
+                // referenced unqualified. Stripping breaks that guarantee: two enums can strip to the same
+                // member name, so an unqualified cross-enum reference may bind to a sibling in the referencing
+                // enum (a `BOOLEAN = BOOLEAN` self-cycle) or become ambiguous between two `using static`
+                // imports. When the referenced member's name was actually changed by stripping, qualify the
+                // reference with the enum name instead. See https://github.com/dotnet/ClangSharp/issues/792.
+                var wasStripped = escapedName != EscapeName(name);
+
+                if (!_config.DontUseUsingStaticsForEnums && !wasStripped)
                 {
                     if (IsAnonymousEnum(enumName))
                     {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/WithEnumMemberStrip/CrossEnumReferenceIsQualifiedOnAmbiguousImport.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/WithEnumMemberStrip/CrossEnumReferenceIsQualifiedOnAmbiguousImport.CSharp.Latest.Windows.cs
@@ -1,0 +1,20 @@
+namespace ClangSharp.Test
+{
+    public enum element_type
+    {
+        boolean,
+        char,
+    }
+
+    public enum other_type
+    {
+        boolean,
+        wchar,
+    }
+
+    public enum consumer_type
+    {
+        a = element_type.boolean,
+        b = other_type.wchar,
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/WithEnumMemberStrip/CrossEnumReferenceIsQualifiedOnCollision.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/WithEnumMemberStrip/CrossEnumReferenceIsQualifiedOnCollision.CSharp.Latest.Windows.cs
@@ -1,0 +1,14 @@
+namespace ClangSharp.Test
+{
+    public enum element_type
+    {
+        boolean,
+        char,
+    }
+
+    public enum serialization_type
+    {
+        boolean = element_type.boolean,
+        char = element_type.char,
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/WithEnumMemberStripTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/WithEnumMemberStripTest.cs
@@ -177,4 +177,55 @@ enum second_group
 
         return ValidateGeneratedCSharpLatestWindowsBaselineAsync(inputContents, withEnumMemberStrip: new Dictionary<string, string> { ["*"] = "common-prefix" });
     }
+
+    // A cross-enum reference whose stripped name collides with a member of the referencing enum must be
+    // qualified with the referenced enum name; an unqualified reference would bind to the referencing
+    // enum's own member and produce a `Cycle in constant value computation` error. See
+    // https://github.com/dotnet/ClangSharp/issues/792.
+    [Test]
+    public Task CrossEnumReferenceIsQualifiedOnCollision()
+    {
+        var inputContents = @"enum element_type
+{
+    element_type_boolean,
+    element_type_char,
+};
+
+enum serialization_type
+{
+    serialization_type_boolean = element_type_boolean,
+    serialization_type_char = element_type_char,
+};
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(inputContents, withEnumMemberStrip: new Dictionary<string, string> { ["*"] = "common-prefix" });
+    }
+
+    // Two enums can strip to the same member name (`boolean`); a third enum referencing either then imports
+    // both via `using static`, so an unqualified `boolean` is ambiguous (CS0229). Cross-enum references to a
+    // stripped member must be qualified with the enum name. See https://github.com/dotnet/ClangSharp/issues/792.
+    [Test]
+    public Task CrossEnumReferenceIsQualifiedOnAmbiguousImport()
+    {
+        var inputContents = @"enum element_type
+{
+    element_type_boolean,
+    element_type_char,
+};
+
+enum other_type
+{
+    other_type_boolean,
+    other_type_wchar,
+};
+
+enum consumer_type
+{
+    consumer_type_a = element_type_boolean,
+    consumer_type_b = other_type_wchar,
+};
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(inputContents, withEnumMemberStrip: new Dictionary<string, string> { ["*"] = "common-prefix" });
+    }
 }


### PR DESCRIPTION
Fixes #792.

In C all enum constants share a single ordinary-identifier namespace, so un-stripped member names are unique across the translation unit and can be imported via `using static` and referenced unqualified. Stripping (via `--with-enum-member-strip`, or the legacy `strip-enum-member-type-name`/prefix strip) breaks that guarantee: two enums can strip to the same member name, so an unqualified cross-enum reference may

- bind to a same-named sibling in the referencing enum, producing a `BOOLEAN = BOOLEAN` self-cycle (`error: Cycle in constant value computation`) -- the reported case, or
- become ambiguous between two `using static` imports when two enums strip to the same name (`CS0229`).

The fix qualifies such references with the enum name (e.g. `element_type.boolean`) whenever the referenced member''s name was actually changed by stripping, instead of relying on `using static`. This also drops the now-unused `using static` directives.

Before/after for the reported case:

```cs
// before (broken)              // after
boolean = boolean,             boolean = element_type.boolean,
char = char,                   char = element_type.char,
```

----------

Same-enum sibling references (`primary = vulkan | metal`) are unaffected -- they go through the `DeclContext ==` path and stay unqualified. `MemberExpr` instance accesses already emit an explicit base, so they were never at risk.

Two regression tests added (`CrossEnumReferenceIsQualifiedOnCollision`, `CrossEnumReferenceIsQualifiedOnAmbiguousImport`) with baselines. Full suite passes with 0 warnings and no other baselines change.

> [!NOTE]
> This PR body was drafted by Copilot.
