### PR TITLE
Expose additional managed C++ API surface for types, methods, and fields

### DIFF
--- a/sources/ClangSharp/Cursors/Decls/CXXMethodDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CXXMethodDecl.cs
@@ -38,6 +38,8 @@ public class CXXMethodDecl : FunctionDecl
 
     public bool IsMoveAssignmentOperator => Handle.CXXMethod_IsMoveAssignmentOperator;
 
+    public bool IsPureVirtual => Handle.CXXMethod_IsPureVirtual;
+
     public bool IsVirtual => Handle.CXXMethod_IsVirtual;
 
     public new CXXMethodDecl MostRecentDecl => (CXXMethodDecl)base.MostRecentDecl;

--- a/sources/ClangSharp/Cursors/Decls/FieldDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/FieldDecl.cs
@@ -50,6 +50,8 @@ public class FieldDecl : DeclaratorDecl, IMergeable<FieldDecl>
 
     public bool IsUnnamedBitfield => Handle.IsUnnamedBitfield;
 
+    public long OffsetOfField => Handle.OffsetOfField;
+
     public new RecordDecl? Parent => (DeclContext as RecordDecl) ?? ((SemanticParentCursor is ClassTemplateDecl classTemplateDecl) ? (RecordDecl)classTemplateDecl.TemplatedDecl : null);
 
     private static unsafe bool IsAnonymousFieldFactory(FieldDecl self) {

--- a/sources/ClangSharp/TemplateName.cs
+++ b/sources/ClangSharp/TemplateName.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using ClangSharp.Interop;
+using static ClangSharp.Interop.CX_TemplateNameKind;
 
 namespace ClangSharp;
 
@@ -20,6 +21,10 @@ public sealed unsafe class TemplateName
     public TemplateDecl AsTemplateDecl => _asTemplateDecl.GetValue(this);
 
     public CX_TemplateName Handle { get; }
+
+    public bool IsNull => Handle.kind == CX_TNK_Invalid;
+
+    public CX_TemplateNameKind Kind => Handle.kind;
 
     public TranslationUnit TranslationUnit => _translationUnit.GetValue(this);
 

--- a/sources/ClangSharp/Types/MemberPointerType.cs
+++ b/sources/ClangSharp/Types/MemberPointerType.cs
@@ -8,7 +8,14 @@ namespace ClangSharp;
 
 public sealed class MemberPointerType : Type
 {
-    internal MemberPointerType(CXType handle) : base(handle, CXType_MemberPointer, CX_TypeClass_MemberPointer)
+    private ValueLazy<MemberPointerType, Type> _classType;
+
+    internal unsafe MemberPointerType(CXType handle) : base(handle, CXType_MemberPointer, CX_TypeClass_MemberPointer)
     {
+        _classType = new ValueLazy<MemberPointerType, Type>(&ClassTypeFactory);
     }
+
+    public Type ClassType => _classType.GetValue(this);
+
+    private static unsafe Type ClassTypeFactory(MemberPointerType self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.ClassType);
 }

--- a/sources/ClangSharp/Types/Type.cs
+++ b/sources/ClangSharp/Types/Type.cs
@@ -15,6 +15,7 @@ public unsafe class Type : IEquatable<Type>
     private ValueLazy<Type, Type> _canonicalType;
     private ValueLazy<Type, Type> _desugar;
     private ValueLazy<Type, string> _kindSpelling;
+    private ValueLazy<Type, Type> _nonReferenceType;
     private ValueLazy<Type, Type> _pointeeType;
     private ValueLazy<Type, TranslationUnit> _translationUnit;
     private ValueLazy<Type, Type> _unqualifiedType;
@@ -50,6 +51,7 @@ public unsafe class Type : IEquatable<Type>
         _canonicalType = new ValueLazy<Type, Type>(&CanonicalTypeFactory);
         _desugar = new ValueLazy<Type, Type>(&DesugarFactory);
         _kindSpelling = new ValueLazy<Type, string>(&KindSpellingFactory);
+        _nonReferenceType = new ValueLazy<Type, Type>(&NonReferenceTypeFactory);
         _pointeeType = new ValueLazy<Type, Type>(&PointeeTypeFactory);
         _translationUnit = new ValueLazy<Type, TranslationUnit>(&TranslationUnitFactory);
         _unqualifiedType = new ValueLazy<Type, Type>(&UnqualifiedTypeFactory);
@@ -68,6 +70,10 @@ public unsafe class Type : IEquatable<Type>
         return false;
     }
 #endif
+
+    public uint AddressSpace => Handle.AddressSpace;
+
+    public long AlignOf => Handle.AlignOf;
 
     public CXXRecordDecl? AsCXXRecordDecl => AsTagDecl as CXXRecordDecl;
 
@@ -91,7 +97,19 @@ public unsafe class Type : IEquatable<Type>
 
     public bool IsAnyPointerType => IsPointerType || IsObjCObjectPointerType;
 
+    public bool IsArrayType => CanonicalType is ArrayType;
+
+    public bool IsAtomicType => CanonicalType is AtomicType;
+
     public bool IsBitIntType => CanonicalType is BitIntType;
+
+    public bool IsBlockPointerType => CanonicalType is BlockPointerType;
+
+    public bool IsBooleanType => (CanonicalType is BuiltinType builtinType) && builtinType.Kind == CXType_Bool;
+
+    public bool IsEnumeralType => CanonicalType is EnumType;
+
+    public bool IsFunctionType => CanonicalType is FunctionType;
 
     public bool IsIntegerType => (CanonicalType is BuiltinType builtinType) && builtinType.Kind is >= CXType_Bool and <= CXType_Int128;
 
@@ -105,21 +123,49 @@ public unsafe class Type : IEquatable<Type>
         }
     }
 
+    public bool IsLValueReferenceType => CanonicalType is LValueReferenceType;
+
     public bool IsLocalConstQualified => Handle.IsConstQualified;
+
+    public bool IsLocalRestrictQualified => Handle.IsRestrictQualified;
+
+    public bool IsLocalVolatileQualified => Handle.IsVolatileQualified;
+
+    public bool IsMemberPointerType => CanonicalType is MemberPointerType;
+
+    public bool IsNullPtrType => (CanonicalType is BuiltinType builtinType) && builtinType.Kind == CXType_NullPtr;
 
     public bool IsObjCInstanceType => Handle.IsObjCInstanceType;
 
     public bool IsObjCObjectPointerType => CanonicalType is ObjCObjectPointerType;
 
+    public bool IsPODType => Handle.IsPODType;
+
     public bool IsPointerType => CanonicalType is PointerType;
 
+    public bool IsRValueReferenceType => CanonicalType is RValueReferenceType;
+
+    public bool IsRecordType => CanonicalType is RecordType;
+
+    public bool IsReferenceType => CanonicalType is ReferenceType;
+
     public bool IsSugared => Handle.IsSugared;
+
+    public bool IsVectorType => CanonicalType is VectorType or ExtVectorType;
+
+    public bool IsVoidType => (CanonicalType is BuiltinType builtinType) && builtinType.Kind == CXType_Void;
 
     public CXTypeKind Kind => Handle.kind;
 
     public string KindSpelling => _kindSpelling.GetValue(this);
 
+    public Type NonReferenceType => _nonReferenceType.GetValue(this);
+
+    public CXTypeNullabilityKind Nullability => Handle.Nullability;
+
     public Type PointeeType => _pointeeType.GetValue(this);
+
+    public long SizeOf => Handle.SizeOf;
 
     public TranslationUnit TranslationUnit => _translationUnit.GetValue(this);
 
@@ -247,6 +293,8 @@ public unsafe class Type : IEquatable<Type>
     private static unsafe TranslationUnit TranslationUnitFactory(Type self) => TranslationUnit.GetOrCreate((CXTranslationUnit)self.Handle.data[1]);
 
     private static unsafe Type PointeeTypeFactory(Type self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.PointeeType);
+
+    private static unsafe Type NonReferenceTypeFactory(Type self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.NonReferenceType);
 
     private static unsafe Type UnqualifiedTypeFactory(Type self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.UnqualifiedType);
 

--- a/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
@@ -317,6 +317,56 @@ enum E {
         });
     }
 
+    [Test]
+    public void CXXMethodIsPureVirtualTest()
+    {
+        var inputContents = """
+struct S
+{
+    virtual void PureMethod() = 0;
+    virtual void VirtualMethod() {}
+    void PlainMethod() {}
+};
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var recordDecl = translationUnit.TranslationUnitDecl.Decls.OfType<CXXRecordDecl>().Single((decl) => decl.Name.Equals("S", StringComparison.Ordinal));
+
+        CXXMethodDecl Method(string name)
+        {
+            return recordDecl.Methods.First((method) => method.Name.Equals(name, StringComparison.Ordinal));
+        }
+
+        Assert.That(Method("PureMethod").IsPureVirtual, Is.True);
+        Assert.That(Method("VirtualMethod").IsPureVirtual, Is.False);
+        Assert.That(Method("PlainMethod").IsPureVirtual, Is.False);
+    }
+
+    [Test]
+    public void FieldOffsetOfFieldTest()
+    {
+        var inputContents = """
+struct S
+{
+    int first;
+    int second;
+};
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var recordDecl = translationUnit.TranslationUnitDecl.Decls.OfType<CXXRecordDecl>().Single((decl) => decl.Name.Equals("S", StringComparison.Ordinal));
+
+        FieldDecl Field(string name)
+        {
+            return recordDecl.Fields.First((field) => field.Name.Equals(name, StringComparison.Ordinal));
+        }
+
+        Assert.That(Field("first").OffsetOfField, Is.EqualTo(0));
+        Assert.That(Field("second").OffsetOfField, Is.EqualTo(32));
+    }
+
     // Some tests depend on native libClangSharp shims that the pinned 21.1 prebuilt package predates
     // (e.g. clangsharp_Cursor_getNumTemplateArguments / getTemplateArgument and
     // clangsharp_Cursor_getUsingEnumDeclEnumDecl). Skip those until the native lib is rebuilt for a

--- a/tests/ClangSharp.UnitTests/TypeTest.cs
+++ b/tests/ClangSharp.UnitTests/TypeTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Linq;
+using ClangSharp.Interop;
 using NUnit.Framework;
 
 namespace ClangSharp.UnitTests;
@@ -31,5 +32,110 @@ pcint g();
 
         Assert.That(unqualifiedType.IsLocalConstQualified, Is.False, "UnqualifiedType should drop the local const");
         Assert.That(unqualifiedType.AsString, Is.EqualTo("int"));
+    }
+
+    [Test]
+    public void PredicatesTest()
+    {
+        var inputContents = """
+struct S { int field; };
+enum E { AValue };
+
+using VoidT = void;
+using BoolT = bool;
+using NullPtrT = decltype(nullptr);
+using LRefT = int&;
+using RRefT = int&&;
+using ArrT = int[4];
+using PtrT = int*;
+using RecordT = S;
+using EnumT = E;
+using FuncT = void();
+using MemPtrT = int S::*;
+using VecT = int __attribute__((vector_size(16)));
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var typedefs = translationUnit.TranslationUnitDecl.Decls.OfType<TypedefNameDecl>()
+                                      .ToDictionary((typedef) => typedef.Name, (typedef) => typedef.UnderlyingType, StringComparer.Ordinal);
+
+        Assert.That(typedefs["VoidT"].IsVoidType, Is.True);
+        Assert.That(typedefs["VoidT"].IsIntegerType, Is.False);
+
+        Assert.That(typedefs["BoolT"].IsBooleanType, Is.True);
+        Assert.That(typedefs["NullPtrT"].IsNullPtrType, Is.True);
+
+        Assert.That(typedefs["LRefT"].IsReferenceType, Is.True);
+        Assert.That(typedefs["LRefT"].IsLValueReferenceType, Is.True);
+        Assert.That(typedefs["LRefT"].IsRValueReferenceType, Is.False);
+
+        Assert.That(typedefs["RRefT"].IsReferenceType, Is.True);
+        Assert.That(typedefs["RRefT"].IsRValueReferenceType, Is.True);
+        Assert.That(typedefs["RRefT"].IsLValueReferenceType, Is.False);
+
+        Assert.That(typedefs["ArrT"].IsArrayType, Is.True);
+        Assert.That(typedefs["PtrT"].IsPointerType, Is.True);
+        Assert.That(typedefs["PtrT"].IsAnyPointerType, Is.True);
+        Assert.That(typedefs["RecordT"].IsRecordType, Is.True);
+        Assert.That(typedefs["EnumT"].IsEnumeralType, Is.True);
+        Assert.That(typedefs["FuncT"].IsFunctionType, Is.True);
+        Assert.That(typedefs["MemPtrT"].IsMemberPointerType, Is.True);
+        Assert.That(typedefs["VecT"].IsVectorType, Is.True);
+    }
+
+    [Test]
+    public void MemberPointerClassTypeTest()
+    {
+        var inputContents = """
+struct S { int field; };
+using MemPtrT = int S::*;
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var memPtr = translationUnit.TranslationUnitDecl.Decls.OfType<TypedefNameDecl>().Single((typedef) => typedef.Name.Equals("MemPtrT", StringComparison.Ordinal));
+        var memberPointerType = (MemberPointerType)memPtr.UnderlyingType.CanonicalType;
+
+        Assert.That(memberPointerType.ClassType.AsCXXRecordDecl, Is.Not.Null);
+        Assert.That(memberPointerType.ClassType.AsCXXRecordDecl!.Name, Is.EqualTo("S"));
+    }
+
+    [Test]
+    public void TemplateNameTest()
+    {
+        var inputContents = """
+template <typename T> struct Tmpl { T value; };
+using SpecT = Tmpl<int>;
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var spec = translationUnit.TranslationUnitDecl.Decls.OfType<TypedefNameDecl>().Single((typedef) => typedef.Name.Equals("SpecT", StringComparison.Ordinal));
+        var templateSpecializationType = (TemplateSpecializationType)spec.UnderlyingType.Desugar;
+        var templateName = templateSpecializationType.TemplateName;
+
+        Assert.That(templateName.IsNull, Is.False);
+        Assert.That(templateName.Kind, Is.EqualTo(CX_TemplateNameKind.CX_TNK_QualifiedTemplate));
+    }
+
+    [Test]
+    public void NonReferenceTypeTest()
+    {
+        var inputContents = """
+using LRefT = int&;
+using RRefT = int&&;
+using ValT = int;
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var typedefs = translationUnit.TranslationUnitDecl.Decls.OfType<TypedefNameDecl>().ToDictionary((typedef) => typedef.Name, StringComparer.Ordinal);
+
+        Assert.That(typedefs["LRefT"].UnderlyingType.NonReferenceType.AsString, Is.EqualTo("int"));
+        Assert.That(typedefs["RRefT"].UnderlyingType.NonReferenceType.AsString, Is.EqualTo("int"));
+        Assert.That(typedefs["ValT"].UnderlyingType.NonReferenceType.AsString, Is.EqualTo("int"));
+
+        Assert.That(typedefs["ValT"].UnderlyingType.AddressSpace, Is.EqualTo(0u));
     }
 }


### PR DESCRIPTION
Surfaces a set of Clang C++ API members on the high-level managed layer that were already bridged through libclang / libClangSharp but not yet exposed. Each addition maps to a faithful Clang C++ method and is purely managed-side (no native `libClangSharp` changes), so it needs no native rebuild.

`Type`
- `AddressSpace` -- `QualType::getAddressSpace()`
- `NonReferenceType` -- `QualType::getNonReferenceType()`
- Structural / single-builtin predicates (`IsArrayType`, `IsRecordType`, `IsEnumeralType`, `IsFunctionType`, `IsReferenceType`, `IsLValueReferenceType`, `IsRValueReferenceType`, `IsMemberPointerType`, `IsBlockPointerType`, `IsVectorType`, `IsAtomicType`, `IsVoidType`, `IsBooleanType`, `IsNullPtrType`, `IsPODType`, ...) and `SizeOf` / `AlignOf` / `Nullability` conveniences

`MemberPointerType`
- `ClassType` -- `MemberPointerType::getClass()`

`CXXMethodDecl`
- `IsPureVirtual` -- `CXXMethodDecl::isPureVirtual()`

`FieldDecl`
- `OffsetOfField` -- field offset (bits)

`TemplateName`
- `Kind` / `IsNull`

----------

Only trivially-correct predicates are done managed-side; multi-kind / subtle predicates (e.g. `isScalarType`, `isArithmeticType`) and entirely-unbridged concepts (`NestedNameSpecifier`, `DeclarationName`, `Designator`, `LambdaCapture`, `CXXCtorInitializer`, `LambdaExpr` surfacing) are deferred to a follow-up that adds the native bridges first.

Regression tests added in `TypeTest` and `DeclTest`. Builds clean (0 warnings); all `ClangSharp.UnitTests` pass.