### PR TITLE
Expose additional managed C++ API for exprs, lambdas, and types

### DIFF
--- a/sources/ClangSharp.Interop/Extensions/CXCursor.cs
+++ b/sources/ClangSharp.Interop/Extensions/CXCursor.cs
@@ -1178,6 +1178,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly bool IsResultDependent => clangsharp.Cursor_getIsResultDependent(this) != 0;
 
+    public readonly bool IsReversed => clangsharp.Cursor_getIsReversed(this) != 0;
+
     public readonly bool IsStdInitListInitialization => clangsharp.Cursor_getIsStdInitListInitialization(this) != 0;
 
     public readonly bool IsSigned => clangsharp.Cursor_getIsSigned(this) != 0;

--- a/sources/ClangSharp/Cursors/Exprs/CXXRewrittenBinaryOperator.cs
+++ b/sources/ClangSharp/Cursors/Exprs/CXXRewrittenBinaryOperator.cs
@@ -26,6 +26,8 @@ public sealed class CXXRewrittenBinaryOperator : Expr
 
     public static bool IsComparisonOp => true;
 
+    public bool IsReversed => Handle.IsReversed;
+
     public CXBinaryOperatorKind Opcode => Operator;
 
     public CXBinaryOperatorKind Operator => Handle.BinaryOperatorKind;

--- a/sources/ClangSharp/Cursors/Exprs/Expr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/Expr.cs
@@ -14,12 +14,41 @@ public class Expr : ValueStmt
 {
     private static readonly Func<Expr, Expr> s_ignoreImplicitCastsSingleStep = (e) => e is ImplicitCastExpr ice ? ice.SubExpr : e is FullExpr fe ? fe.SubExpr : e;
 
+    private static readonly Func<Expr, Expr> s_ignoreImplicitCastsExtraSingleStep = (e) =>
+    {
+        var subE = s_ignoreImplicitCastsSingleStep(e);
+
+        return subE != e ? subE : e is MaterializeTemporaryExpr mte ? mte.SubExpr : e is SubstNonTypeTemplateParmExpr nttp ? nttp.Replacement : e;
+    };
+
+    private static readonly Func<Expr, Expr> s_ignoreCastsSingleStep = (e) => e switch {
+        CastExpr ce => ce.SubExpr,
+        FullExpr fe => fe.SubExpr,
+        MaterializeTemporaryExpr mte => mte.SubExpr,
+        SubstNonTypeTemplateParmExpr nttp => nttp.Replacement,
+        _ => e,
+    };
+
+    private static readonly Func<Expr, Expr> s_ignoreLValueCastsSingleStep = (e) =>
+    {
+        if (e is CastExpr ce && ce.CastKind != CX_CK_LValueToRValue)
+        {
+            return e;
+        }
+
+        return s_ignoreCastsSingleStep(e);
+    };
+
+    private static readonly Func<Expr, Expr> s_ignoreBaseCastsSingleStep = (e) => e is CastExpr ce && ce.CastKind is CX_CK_DerivedToBase or CX_CK_UncheckedDerivedToBase or CX_CK_NoOp ? ce.SubExpr : e;
+
     private static readonly Func<Expr, Expr> s_ignoreImplicitSingleStep = (e) =>
     {
         var subE = s_ignoreImplicitCastsSingleStep(e);
 
         return subE != e ? subE : e is MaterializeTemporaryExpr mte ? mte.SubExpr : e is CXXBindTemporaryExpr bte ? bte.SubExpr : e;
     };
+
+    private static readonly Func<Expr, Expr> s_ignoreImplicitAsWrittenSingleStep = (e) => e is ImplicitCastExpr ice ? ice.SubExprAsWritten : s_ignoreImplicitSingleStep(e);
 
     private static readonly Func<Expr, Expr> s_ignoreParensSingleStep = (e) =>
     {
@@ -75,9 +104,23 @@ public class Expr : ValueStmt
 
     public CX_ExprDependence Dependence => Handle.ExprDependence;
 
+    public Expr IgnoreCasts => IgnoreExprNodes(this, s_ignoreCastsSingleStep);
+
+    public Expr IgnoreImpCasts => IgnoreExprNodes(this, s_ignoreImplicitCastsSingleStep);
+
     public Expr IgnoreImplicit => IgnoreExprNodes(this, s_ignoreImplicitSingleStep);
 
+    public Expr IgnoreImplicitAsWritten => IgnoreExprNodes(this, s_ignoreImplicitAsWrittenSingleStep);
+
     public Expr IgnoreParens => IgnoreExprNodes(this, s_ignoreParensSingleStep);
+
+    public Expr IgnoreParenBaseCasts => IgnoreExprNodes(this, s_ignoreParensSingleStep, s_ignoreBaseCastsSingleStep);
+
+    public Expr IgnoreParenCasts => IgnoreExprNodes(this, s_ignoreParensSingleStep, s_ignoreCastsSingleStep);
+
+    public Expr IgnoreParenImpCasts => IgnoreExprNodes(this, s_ignoreParensSingleStep, s_ignoreImplicitCastsExtraSingleStep);
+
+    public Expr IgnoreParenLValueCasts => IgnoreExprNodes(this, s_ignoreParensSingleStep, s_ignoreLValueCastsSingleStep);
 
     public bool IsImplicitCXXThis
     {
@@ -140,6 +183,19 @@ public class Expr : ValueStmt
         {
             lastE = e;
             e = fn(e);
+        }
+
+        return e;
+    }
+
+    private static Expr IgnoreExprNodes(Expr e, Func<Expr, Expr> fn1, Func<Expr, Expr> fn2)
+    {
+        Expr? lastE = null;
+
+        while (e != lastE)
+        {
+            lastE = e;
+            e = fn2(fn1(e));
         }
 
         return e;

--- a/sources/ClangSharp/Cursors/Exprs/LambdaExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/LambdaExpr.cs
@@ -8,7 +8,16 @@ namespace ClangSharp;
 
 public sealed class LambdaExpr : Expr
 {
-    internal LambdaExpr(CXCursor handle) : base(handle, CXCursor_LambdaExpr, CX_StmtClass_LambdaExpr)
+    private ValueLazy<LambdaExpr, CXXMethodDecl> _callOperator;
+
+    internal unsafe LambdaExpr(CXCursor handle) : base(handle, CXCursor_LambdaExpr, CX_StmtClass_LambdaExpr)
     {
+        _callOperator = new ValueLazy<LambdaExpr, CXXMethodDecl>(&CallOperatorFactory);
     }
+
+    public CXXMethodDecl CallOperator => _callOperator.GetValue(this);
+
+    public bool IsMutable => !CallOperator.IsConst;
+
+    private static unsafe CXXMethodDecl CallOperatorFactory(LambdaExpr self) => self.TranslationUnit.GetOrCreate<CXXMethodDecl>(self.Type.AsCXXRecordDecl!.Handle.LambdaCallOperator);
 }

--- a/sources/ClangSharp/Types/MemberPointerType.cs
+++ b/sources/ClangSharp/Types/MemberPointerType.cs
@@ -17,5 +17,9 @@ public sealed class MemberPointerType : Type
 
     public Type ClassType => _classType.GetValue(this);
 
+    public bool IsMemberDataPointer => !IsMemberFunctionPointer;
+
+    public bool IsMemberFunctionPointer => PointeeType.CanonicalType is FunctionProtoType;
+
     private static unsafe Type ClassTypeFactory(MemberPointerType self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.ClassType);
 }

--- a/sources/ClangSharp/Types/Type.cs
+++ b/sources/ClangSharp/Types/Type.cs
@@ -107,6 +107,8 @@ public unsafe class Type : IEquatable<Type>
 
     public bool IsBooleanType => (CanonicalType is BuiltinType builtinType) && builtinType.Kind == CXType_Bool;
 
+    public bool IsCharType => (CanonicalType is BuiltinType builtinType) && builtinType.Kind is CXType_Char_U or CXType_UChar or CXType_Char_S or CXType_SChar;
+
     public bool IsEnumeralType => CanonicalType is EnumType;
 
     public bool IsFunctionType => CanonicalType is FunctionType;
@@ -130,6 +132,8 @@ public unsafe class Type : IEquatable<Type>
     public bool IsLocalRestrictQualified => Handle.IsRestrictQualified;
 
     public bool IsLocalVolatileQualified => Handle.IsVolatileQualified;
+
+    public bool IsMatrixType => CanonicalType is MatrixType;
 
     public bool IsMemberPointerType => CanonicalType is MemberPointerType;
 

--- a/tests/ClangSharp.UnitTests/ExprTest.cs
+++ b/tests/ClangSharp.UnitTests/ExprTest.cs
@@ -1,0 +1,122 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+public sealed class ExprTest : TranslationUnitTest
+{
+    private static readonly string[] Cpp20CommandLineArgs = ["-std=c++20", "-Wno-pragma-once-outside-header"];
+
+    private static T? FindDescendant<T>(Cursor cursor)
+        where T : Cursor
+    {
+        if (cursor is T match)
+        {
+            return match;
+        }
+
+        foreach (var child in cursor.CursorChildren)
+        {
+            if (FindDescendant<T>(child) is T found)
+            {
+                return found;
+            }
+        }
+
+        return null;
+    }
+
+    [Test]
+    public void LambdaExprTest()
+    {
+        var inputContents = """
+auto mutableLambda = [](int x) mutable { return x; };
+auto constLambda = [](int x) { return x; };
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents, commandLineArgs: Cpp20CommandLineArgs);
+
+        var vars = translationUnit.TranslationUnitDecl.Decls.OfType<VarDecl>()
+                                  .ToDictionary((varDecl) => varDecl.Name, StringComparer.Ordinal);
+
+        var mutableLambda = FindDescendant<LambdaExpr>(vars["mutableLambda"].Init);
+        var constLambda = FindDescendant<LambdaExpr>(vars["constLambda"].Init);
+
+        Assert.That(mutableLambda, Is.Not.Null);
+        Assert.That(constLambda, Is.Not.Null);
+
+        Assert.That(mutableLambda!.CallOperator, Is.Not.Null);
+        Assert.That(mutableLambda.CallOperator.Name, Is.EqualTo("operator()"));
+
+        Assert.That(mutableLambda.IsMutable, Is.True);
+        Assert.That(constLambda!.IsMutable, Is.False);
+    }
+
+    [Test]
+    public void IgnoreExprTest()
+    {
+        // `int gVar = (gInt);` produces ImplicitCastExpr(LValueToRValue) -> ParenExpr -> DeclRefExpr.
+        var inputContents = """
+int gInt;
+int gVar = (gInt);
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var gVar = translationUnit.TranslationUnitDecl.Decls.OfType<VarDecl>().Single((varDecl) => varDecl.Name.Equals("gVar", StringComparison.Ordinal));
+        var init = gVar.Init;
+
+        Assert.That(init, Is.InstanceOf<ImplicitCastExpr>(), "init should be an implicit LValueToRValue cast");
+
+        // IgnoreParens leaves the outer implicit cast in place.
+        Assert.That(init.IgnoreParens, Is.InstanceOf<ImplicitCastExpr>());
+
+        // IgnoreImpCasts / IgnoreImplicit / IgnoreCasts strip the cast but stop at the ParenExpr.
+        Assert.That(init.IgnoreImpCasts, Is.InstanceOf<ParenExpr>());
+        Assert.That(init.IgnoreImplicit, Is.InstanceOf<ParenExpr>());
+        Assert.That(init.IgnoreCasts, Is.InstanceOf<ParenExpr>());
+
+        // The paren-aware variants strip both the cast and the parens.
+        Assert.That(init.IgnoreParenCasts, Is.InstanceOf<DeclRefExpr>());
+        Assert.That(init.IgnoreParenImpCasts, Is.InstanceOf<DeclRefExpr>());
+        Assert.That(init.IgnoreParenLValueCasts, Is.InstanceOf<DeclRefExpr>());
+
+        // IgnoreParenBaseCasts only strips base casts, so the LValueToRValue cast remains.
+        Assert.That(init.IgnoreParenBaseCasts, Is.InstanceOf<ImplicitCastExpr>());
+
+        // IgnoreImplicitAsWritten walks through the implicit cast as written.
+        Assert.That(init.IgnoreImplicitAsWritten, Is.Not.InstanceOf<ImplicitCastExpr>());
+    }
+
+    [Test]
+    public void RewrittenBinaryOperatorIsReversedTest()
+    {
+        var inputContents = """
+struct S { int v; };
+bool operator==(const S& lhs, int rhs);
+
+struct T { int v; };
+int operator<=>(const T& lhs, const T& rhs);
+
+bool reversedEquals(S s) { return 1 == s; }
+bool spaceshipLess(T a, T b) { return a < b; }
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents, commandLineArgs: Cpp20CommandLineArgs);
+
+        var functions = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>()
+                                       .ToDictionary((functionDecl) => functionDecl.Name, StringComparer.Ordinal);
+
+        var reversed = FindDescendant<CXXRewrittenBinaryOperator>(functions["reversedEquals"]);
+        var forward = FindDescendant<CXXRewrittenBinaryOperator>(functions["spaceshipLess"]);
+
+        Assert.That(reversed, Is.Not.Null, "`1 == s` should be a reversed rewritten operator");
+        Assert.That(reversed!.IsReversed, Is.True);
+
+        Assert.That(forward, Is.Not.Null, "`a < b` should be a rewritten operator from <=>");
+        Assert.That(forward!.IsReversed, Is.False);
+    }
+}

--- a/tests/ClangSharp.UnitTests/TypeTest.cs
+++ b/tests/ClangSharp.UnitTests/TypeTest.cs
@@ -102,6 +102,72 @@ using MemPtrT = int S::*;
     }
 
     [Test]
+    public void CharTypeTest()
+    {
+        var inputContents = """
+using CharT = char;
+using UCharT = unsigned char;
+using SCharT = signed char;
+using WCharT = wchar_t;
+using IntT = int;
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var typedefs = translationUnit.TranslationUnitDecl.Decls.OfType<TypedefNameDecl>()
+                                      .ToDictionary((typedef) => typedef.Name, (typedef) => typedef.UnderlyingType, StringComparer.Ordinal);
+
+        Assert.That(typedefs["CharT"].IsCharType, Is.True);
+        Assert.That(typedefs["UCharT"].IsCharType, Is.True);
+        Assert.That(typedefs["SCharT"].IsCharType, Is.True);
+        Assert.That(typedefs["WCharT"].IsCharType, Is.False);
+        Assert.That(typedefs["IntT"].IsCharType, Is.False);
+    }
+
+    [Test]
+    public void MatrixTypeTest()
+    {
+        var inputContents = """
+typedef float Matrix4x4 __attribute__((matrix_type(4, 4)));
+using IntT = int;
+""";
+
+        string[] commandLineArgs = ["-std=c++17", "-Wno-pragma-once-outside-header", "-fenable-matrix"];
+
+        using var translationUnit = CreateTranslationUnit(inputContents, commandLineArgs: commandLineArgs);
+
+        var typedefs = translationUnit.TranslationUnitDecl.Decls.OfType<TypedefNameDecl>()
+                                      .ToDictionary((typedef) => typedef.Name, (typedef) => typedef.UnderlyingType, StringComparer.Ordinal);
+
+        Assert.That(typedefs["Matrix4x4"].IsMatrixType, Is.True);
+        Assert.That(typedefs["IntT"].IsMatrixType, Is.False);
+    }
+
+    [Test]
+    public void MemberPointerKindTest()
+    {
+        var inputContents = """
+struct S { int field; void method(); };
+using MemDataT = int S::*;
+using MemFuncT = void (S::*)();
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var memDataT = translationUnit.TranslationUnitDecl.Decls.OfType<TypedefNameDecl>().Single((typedef) => typedef.Name.Equals("MemDataT", StringComparison.Ordinal));
+        var memFuncT = translationUnit.TranslationUnitDecl.Decls.OfType<TypedefNameDecl>().Single((typedef) => typedef.Name.Equals("MemFuncT", StringComparison.Ordinal));
+
+        var memberDataPointer = (MemberPointerType)memDataT.UnderlyingType.CanonicalType;
+        var memberFunctionPointer = (MemberPointerType)memFuncT.UnderlyingType.CanonicalType;
+
+        Assert.That(memberDataPointer.IsMemberDataPointer, Is.True);
+        Assert.That(memberDataPointer.IsMemberFunctionPointer, Is.False);
+
+        Assert.That(memberFunctionPointer.IsMemberFunctionPointer, Is.True);
+        Assert.That(memberFunctionPointer.IsMemberDataPointer, Is.False);
+    }
+
+    [Test]
     public void TemplateNameTest()
     {
         var inputContents = """


### PR DESCRIPTION
A managed-only follow-up to #794 that surfaces additional Clang C++ AST API on the high-level managed layer (`sources/ClangSharp/`) using only interop bridges already present in the released package. No `sources/libClangSharp/` changes. Every addition mirrors clang 21.1.8 (`llvmorg-21.1.8`) exactly.

----------

### `Expr` (`Cursors/Exprs/Expr.cs`)
Adds the remaining `Ignore*` accessors, composing single-step funcs that mirror `IgnoreExpr.h` and the composition in `Expr.cpp`:
- `IgnoreImpCasts` — `IgnoreExprNodes(IgnoreImplicitCastsSingleStep)`
- `IgnoreCasts` — `IgnoreExprNodes(IgnoreCastsSingleStep)`
- `IgnoreImplicitAsWritten` — `IgnoreExprNodes(IgnoreImplicitAsWrittenSingleStep)`
- `IgnoreParenImpCasts` — `IgnoreExprNodes(IgnoreParensSingleStep, IgnoreImplicitCastsExtraSingleStep)`
- `IgnoreParenCasts` — `IgnoreExprNodes(IgnoreParensSingleStep, IgnoreCastsSingleStep)`
- `IgnoreParenLValueCasts` — `IgnoreExprNodes(IgnoreParensSingleStep, IgnoreLValueCastsSingleStep)`
- `IgnoreParenBaseCasts` — `IgnoreExprNodes(IgnoreParensSingleStep, IgnoreBaseCastsSingleStep)`

Adds the matching single-step funcs and a two-func `IgnoreExprNodes` overload that applies `fn1` then `fn2` per fixed-point step (mirroring `detail::IgnoreExprNodesImpl`).

### `LambdaExpr` (`Cursors/Exprs/LambdaExpr.cs`)
- `CallOperator` — mirrors `LambdaExpr::getCallOperator()` (`getLambdaClass()->getLambdaCallOperator()`). The released `Cursor_getLambdaCallOperator` dispatches on the closure `CXXRecordDecl`, not the `LambdaExpr` cursor, so this routes through `Type.AsCXXRecordDecl`.
- `IsMutable` — mirrors `LambdaExpr::isMutable()` (`!getCallOperator()->isConst()`).

### `CXXRewrittenBinaryOperator` (`Cursors/Exprs/CXXRewrittenBinaryOperator.cs`)
- `IsReversed` — mirrors `CXXRewrittenBinaryOperator::isReversed()`, via a new `CXCursor.IsReversed` interop helper over the already-released `clangsharp_Cursor_getIsReversed` bridge.

### `Type` (`Types/Type.cs`)
- `IsCharType` — mirrors `Type::isCharType()` (`BuiltinType` of `Char_U`/`UChar`/`Char_S`/`SChar`).
- `IsMatrixType` — mirrors `Type::isMatrixType()` (`CanonicalType is MatrixType`).

### `MemberPointerType` (`Types/MemberPointerType.cs`)
- `IsMemberFunctionPointer` — mirrors `MemberPointerType::isMemberFunctionPointer()` (`PointeeType->isFunctionProtoType()`).
- `IsMemberDataPointer` — mirrors `MemberPointerType::isMemberDataPointer()` (negation).

----------

### Tests
- New `ExprTest.cs` covering `LambdaExpr.CallOperator`/`IsMutable`, the `Ignore*` family, and reversed vs. spaceship-rewritten `CXXRewrittenBinaryOperator.IsReversed` (`-std=c++20`).
- New `TypeTest.cs` cases for `IsCharType`, `IsMatrixType` (`-fenable-matrix`), and `IsMemberFunctionPointer`/`IsMemberDataPointer`.

----------

### Deferred to a native change
- Subtle multi-category `Type` predicates (`isScalarType`, `isArithmeticType`, `isFloatingType`, `isRealFloatingType`, `isAggregateType`, `isObjectType`, `hasPointerRepresentation`, `hasIntegerRepresentation`, `hasFloatingRepresentation`) — spec-faithfulness needs data not cleanly available managed-side.
- `LambdaExpr.CaptureDefault` — `getLambdaCaptureDefault` isn't in the released package.
- `Expr.IgnoreParenNoopCasts` — requires `ASTContext`.
- The transparent-`PredefinedExpr` sub-step of `IgnoreParensSingleStep` — the released `Cursor_getIsTransparent` only covers `TypedefNameDecl`/`InitListExpr`, not `PredefinedExpr::isTransparent()`. The existing shipped `IgnoreParens` already omits it; the new `IgnoreParen*` accessors reuse the same single-step and inherit that one pre-existing divergence.
