### PR TITLE
Add coverage for the generator's test-generation code paths

### DIFF
--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/PInvokeGeneratorTest.cs
@@ -94,16 +94,30 @@ public abstract class PInvokeGeneratorTest
         Assert.That(actualOutputContents, Is.EqualTo(expectedOutputContents));
     }
 
-    // Shared generator core: produces the actual generated bindings text without asserting against an
-    // expected value, so both the inline-string harness and the checked-in baseline harness can reuse it.
+    // Convenience wrapper over GenerateBindingsWithTestOutputAsync that returns only the primary bindings text,
+    // used by both the inline-string harness and the checked-in baseline harness (neither asserts test output).
     internal static async Task<string> GenerateBindingsAsync(string inputContents, PInvokeGeneratorOutputMode outputMode, PInvokeGeneratorConfigurationOptions configOptions, string[]? excludedNames, IReadOnlyDictionary<string, string>? remappedNames, IReadOnlyDictionary<string, AccessSpecifier>? withAccessSpecifiers, IReadOnlyDictionary<string, IReadOnlyList<string>>? withAttributes, IReadOnlyDictionary<string, string>? withCallConvs, IReadOnlyDictionary<string, string>? withClasses, IReadOnlyDictionary<string, string>? withLibraryPaths, IReadOnlyDictionary<string, string>? withNamespaces, string[]? withSetLastErrors, IReadOnlyDictionary<string, (string, PInvokeGeneratorTransparentStructKind)>? withTransparentStructs, IReadOnlyDictionary<string, string>? withTypes, IReadOnlyDictionary<string, IReadOnlyList<string>>? withUsings, IReadOnlyDictionary<string, string>? withPackings, IEnumerable<Diagnostic>? expectedDiagnostics, string libraryPath, string[]? commandLineArgs, string language, string languageStandard, IReadOnlyDictionary<string, string>? remappedTypeNames = null, IReadOnlyDictionary<string, string>? remappedFieldNames = null, string? typePrefixToStrip = null, IReadOnlyDictionary<string, string>? withEnumMemberStrip = null, string? withConditional = null, string[]? withEqualityMembers = null, IReadOnlyDictionary<string, Guid>? withGuids = null, string[]? withoutSetLastErrors = null, IReadOnlyCollection<string>? withoutCallConvs = null)
+    {
+        var (actualOutputContents, _) = await GenerateBindingsWithTestOutputAsync(inputContents, outputMode, configOptions, excludedNames, remappedNames, withAccessSpecifiers, withAttributes, withCallConvs, withClasses, withLibraryPaths, withNamespaces, withSetLastErrors, withTransparentStructs, withTypes, withUsings, withPackings, expectedDiagnostics, libraryPath, commandLineArgs, language, languageStandard, remappedTypeNames, remappedFieldNames, typePrefixToStrip, withEnumMemberStrip, withConditional, withEqualityMembers, withGuids, withoutSetLastErrors, withoutCallConvs).ConfigureAwait(false);
+        return actualOutputContents;
+    }
+
+    // Same generator core as GenerateBindingsAsync, but additionally captures the auxiliary test output that the
+    // generator emits when GenerateTestsNUnit/GenerateTestsXUnit are set. The regular bindings and the generated
+    // tests are written to separate output streams (keyed off the config's OutputLocation vs TestOutputLocation),
+    // so both can be validated independently. TestOutputContents is the empty string when no test output was
+    // generated (either because tests weren't requested or nothing in the input produced any).
+    internal static async Task<(string OutputContents, string TestOutputContents)> GenerateBindingsWithTestOutputAsync(string inputContents, PInvokeGeneratorOutputMode outputMode, PInvokeGeneratorConfigurationOptions configOptions, string[]? excludedNames, IReadOnlyDictionary<string, string>? remappedNames, IReadOnlyDictionary<string, AccessSpecifier>? withAccessSpecifiers, IReadOnlyDictionary<string, IReadOnlyList<string>>? withAttributes, IReadOnlyDictionary<string, string>? withCallConvs, IReadOnlyDictionary<string, string>? withClasses, IReadOnlyDictionary<string, string>? withLibraryPaths, IReadOnlyDictionary<string, string>? withNamespaces, string[]? withSetLastErrors, IReadOnlyDictionary<string, (string, PInvokeGeneratorTransparentStructKind)>? withTransparentStructs, IReadOnlyDictionary<string, string>? withTypes, IReadOnlyDictionary<string, IReadOnlyList<string>>? withUsings, IReadOnlyDictionary<string, string>? withPackings, IEnumerable<Diagnostic>? expectedDiagnostics, string libraryPath, string[]? commandLineArgs, string language, string languageStandard, IReadOnlyDictionary<string, string>? remappedTypeNames = null, IReadOnlyDictionary<string, string>? remappedFieldNames = null, string? typePrefixToStrip = null, IReadOnlyDictionary<string, string>? withEnumMemberStrip = null, string? withConditional = null, string[]? withEqualityMembers = null, IReadOnlyDictionary<string, Guid>? withGuids = null, string[]? withoutSetLastErrors = null, IReadOnlyCollection<string>? withoutCallConvs = null)
     {
         Assert.That(DefaultInputFileName, Does.Exist);
         commandLineArgs ??= DefaultCppClangCommandLineArgs;
 
         configOptions |= PInvokeGeneratorConfigurationOptions.GenerateMacroBindings;
 
+        var generatesTests = (configOptions & (PInvokeGeneratorConfigurationOptions.GenerateTestsNUnit | PInvokeGeneratorConfigurationOptions.GenerateTestsXUnit)) != 0;
+
         using var outputStream = new MemoryStream();
+        using var testOutputStream = new MemoryStream();
         using var unsavedFile = CXUnsavedFile.Create(DefaultInputFileName, inputContents);
 
         var unsavedFiles = new CXUnsavedFile[] { unsavedFile };
@@ -118,7 +132,7 @@ public abstract class PInvokeGeneratorTest
             RemappedTypeNames = remappedTypeNames,
             RemappedFieldNames = remappedFieldNames,
             TraversalNames = null,
-            TestOutputLocation = null,
+            TestOutputLocation = generatesTests ? Path.GetRandomFileName() : null,
             WithAccessSpecifiers = withAccessSpecifiers,
             WithAttributes = withAttributes,
             WithCallConvs = withCallConvs,
@@ -140,7 +154,14 @@ public abstract class PInvokeGeneratorTest
             WithGuids = withGuids,
         };
 
-        using (var pinvokeGenerator = new PInvokeGenerator(config, (path) => outputStream))
+        var testOutputLocation = config.TestOutputLocation;
+
+        Stream OutputStreamFactory(string path)
+        {
+            return generatesTests && string.Equals(path, testOutputLocation, StringComparison.Ordinal) ? testOutputStream : outputStream;
+        }
+
+        using (var pinvokeGenerator = new PInvokeGenerator(config, OutputStreamFactory))
         {
             var handle = CXTranslationUnit.Parse(pinvokeGenerator.IndexHandle, DefaultInputFileName, commandLineArgs, unsavedFiles, DefaultTranslationUnitFlags);
 
@@ -162,6 +183,11 @@ public abstract class PInvokeGeneratorTest
 
         using var streamReader = new StreamReader(outputStream);
         var actualOutputContents = await streamReader.ReadToEndAsync().ConfigureAwait(false);
-        return actualOutputContents;
+
+        testOutputStream.Position = 0;
+        using var testStreamReader = new StreamReader(testOutputStream);
+        var actualTestOutputContents = await testStreamReader.ReadToEndAsync().ConfigureAwait(false);
+
+        return (actualOutputContents, actualTestOutputContents);
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/TestGenerationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/TestGenerationTest.cs
@@ -1,0 +1,247 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>
+/// Coverage for the generator's test-generation code paths (https://github.com/dotnet/ClangSharp/issues/223).
+/// Passing <c>GenerateTestsNUnit</c>/<c>GenerateTestsXUnit</c> together with a test output location makes the
+/// generator emit a companion validation file (struct size/blittability/layout, GUID checks, ...). None of the
+/// existing fixtures exercised these paths, so this pins the emitted NUnit and xUnit output for the common shapes.
+/// </summary>
+public sealed class TestGenerationTest : PInvokeGeneratorTest
+{
+    private const string StructInputContents = @"struct MyStruct
+{
+    int x;
+    int y;
+};
+";
+
+    // __declspec(uuid(...)) only parses on a Windows target triple, matching the other GUID fixtures.
+    private const string GuidStructInputContents = @"#define DECLSPEC_UUID(x) __declspec(uuid(x))
+
+struct DECLSPEC_UUID(""00000000-0000-0000-C000-000000000046"") MyStruct1
+{
+    int x;
+};
+";
+
+    private static readonly string[] s_declspecExcludedNames = ["DECLSPEC_UUID"];
+
+    [Test]
+    public Task StructTestsNUnit()
+    {
+        var expectedTestOutputContents = @"using NUnit.Framework;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int x;
+
+        public int y;
+    }
+
+    /// <summary>Provides validation of the <see cref=""MyStruct"" /> struct.</summary>
+    public static unsafe partial class MyStructTests
+    {
+        /// <summary>Validates that the <see cref=""MyStruct"" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<MyStruct>(), Is.EqualTo(sizeof(MyStruct)));
+        }
+
+        /// <summary>Validates that the <see cref=""MyStruct"" /> struct has the right <see cref=""LayoutKind"" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(MyStruct).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref=""MyStruct"" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            Assert.That(sizeof(MyStruct), Is.EqualTo(8));
+        }
+    }
+}
+";
+
+        return ValidateGeneratedTestBindingsAsync(StructInputContents, expectedTestOutputContents, PInvokeGeneratorConfigurationOptions.GenerateTestsNUnit);
+    }
+
+    [Test]
+    public Task StructTestsXUnit()
+    {
+        var expectedTestOutputContents = @"using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        public int x;
+
+        public int y;
+    }
+
+    /// <summary>Provides validation of the <see cref=""MyStruct"" /> struct.</summary>
+    public static unsafe partial class MyStructTests
+    {
+        /// <summary>Validates that the <see cref=""MyStruct"" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(MyStruct), Marshal.SizeOf<MyStruct>());
+        }
+
+        /// <summary>Validates that the <see cref=""MyStruct"" /> struct has the right <see cref=""LayoutKind"" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(MyStruct).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref=""MyStruct"" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            Assert.Equal(8, sizeof(MyStruct));
+        }
+    }
+}
+";
+
+        return ValidateGeneratedTestBindingsAsync(StructInputContents, expectedTestOutputContents, PInvokeGeneratorConfigurationOptions.GenerateTestsXUnit);
+    }
+
+    [Test]
+    [Platform("win")]
+    public Task GuidStructTestsNUnit()
+    {
+        var expectedTestOutputContents = @"using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using static ClangSharp.Test.Methods;
+
+namespace ClangSharp.Test
+{
+    [Guid(""00000000-0000-0000-C000-000000000046"")]
+    public partial struct MyStruct1
+    {
+        public int x;
+    }
+
+    /// <summary>Provides validation of the <see cref=""MyStruct1"" /> struct.</summary>
+    public static unsafe partial class MyStruct1Tests
+    {
+        /// <summary>Validates that the <see cref=""Guid"" /> of the <see cref=""MyStruct1"" /> struct is correct.</summary>
+        [Test]
+        public static void GuidOfTest()
+        {
+            Assert.That(typeof(MyStruct1).GUID, Is.EqualTo(IID_MyStruct1));
+        }
+
+        /// <summary>Validates that the <see cref=""MyStruct1"" /> struct is blittable.</summary>
+        [Test]
+        public static void IsBlittableTest()
+        {
+            Assert.That(Marshal.SizeOf<MyStruct1>(), Is.EqualTo(sizeof(MyStruct1)));
+        }
+
+        /// <summary>Validates that the <see cref=""MyStruct1"" /> struct has the right <see cref=""LayoutKind"" />.</summary>
+        [Test]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.That(typeof(MyStruct1).IsLayoutSequential, Is.True);
+        }
+
+        /// <summary>Validates that the <see cref=""MyStruct1"" /> struct has the correct size.</summary>
+        [Test]
+        public static void SizeOfTest()
+        {
+            Assert.That(sizeof(MyStruct1), Is.EqualTo(4));
+        }
+    }
+}
+";
+
+        return ValidateGeneratedTestBindingsAsync(GuidStructInputContents, expectedTestOutputContents, PInvokeGeneratorConfigurationOptions.GenerateTestsNUnit, excludedNames: s_declspecExcludedNames);
+    }
+
+    [Test]
+    [Platform("win")]
+    public Task GuidStructTestsXUnit()
+    {
+        var expectedTestOutputContents = @"using System;
+using System.Runtime.InteropServices;
+using Xunit;
+using static ClangSharp.Test.Methods;
+
+namespace ClangSharp.Test
+{
+    [Guid(""00000000-0000-0000-C000-000000000046"")]
+    public partial struct MyStruct1
+    {
+        public int x;
+    }
+
+    /// <summary>Provides validation of the <see cref=""MyStruct1"" /> struct.</summary>
+    public static unsafe partial class MyStruct1Tests
+    {
+        /// <summary>Validates that the <see cref=""Guid"" /> of the <see cref=""MyStruct1"" /> struct is correct.</summary>
+        [Fact]
+        public static void GuidOfTest()
+        {
+            Assert.Equal(typeof(MyStruct1).GUID, IID_MyStruct1);
+        }
+
+        /// <summary>Validates that the <see cref=""MyStruct1"" /> struct is blittable.</summary>
+        [Fact]
+        public static void IsBlittableTest()
+        {
+            Assert.Equal(sizeof(MyStruct1), Marshal.SizeOf<MyStruct1>());
+        }
+
+        /// <summary>Validates that the <see cref=""MyStruct1"" /> struct has the right <see cref=""LayoutKind"" />.</summary>
+        [Fact]
+        public static void IsLayoutSequentialTest()
+        {
+            Assert.True(typeof(MyStruct1).IsLayoutSequential);
+        }
+
+        /// <summary>Validates that the <see cref=""MyStruct1"" /> struct has the correct size.</summary>
+        [Fact]
+        public static void SizeOfTest()
+        {
+            Assert.Equal(4, sizeof(MyStruct1));
+        }
+    }
+}
+";
+
+        return ValidateGeneratedTestBindingsAsync(GuidStructInputContents, expectedTestOutputContents, PInvokeGeneratorConfigurationOptions.GenerateTestsXUnit, excludedNames: s_declspecExcludedNames);
+    }
+
+    // With neither test-generation option set the generator emits no companion test file, so the captured test
+    // output is empty. This guards the default path and ensures enabling tests is what drives the emission.
+    [Test]
+    public async Task NoTestsGeneratedWhenNotRequested()
+    {
+        var (_, testOutputContents) = await GenerateBindingsWithTestOutputAsync(StructInputContents, PInvokeGeneratorOutputMode.CSharp, PInvokeGeneratorConfigurationOptions.GenerateLatestCode, excludedNames: null, remappedNames: null, withAccessSpecifiers: null, withAttributes: null, withCallConvs: null, withClasses: null, withLibraryPaths: null, withNamespaces: null, withSetLastErrors: null, withTransparentStructs: null, withTypes: null, withUsings: null, withPackings: null, expectedDiagnostics: null, libraryPath: DefaultLibraryPath, commandLineArgs: null, language: "c++", languageStandard: DefaultCppStandard).ConfigureAwait(false);
+        Assert.That(testOutputContents, Is.Empty);
+    }
+
+    private static async Task ValidateGeneratedTestBindingsAsync(string inputContents, string expectedTestOutputContents, PInvokeGeneratorConfigurationOptions additionalConfigOptions, string[]? excludedNames = null)
+    {
+        var configOptions = PInvokeGeneratorConfigurationOptions.GenerateLatestCode | additionalConfigOptions;
+        var (_, testOutputContents) = await GenerateBindingsWithTestOutputAsync(inputContents, PInvokeGeneratorOutputMode.CSharp, configOptions, excludedNames, remappedNames: null, withAccessSpecifiers: null, withAttributes: null, withCallConvs: null, withClasses: null, withLibraryPaths: null, withNamespaces: null, withSetLastErrors: null, withTransparentStructs: null, withTypes: null, withUsings: null, withPackings: null, expectedDiagnostics: null, libraryPath: DefaultLibraryPath, commandLineArgs: null, language: "c++", languageStandard: DefaultCppStandard).ConfigureAwait(false);
+        Assert.That(testOutputContents.ReplaceLineEndings("\n"), Is.EqualTo(expectedTestOutputContents.ReplaceLineEndings("\n")));
+    }
+}


### PR DESCRIPTION
Addresses the premise of #223: the `ClangSharp.PInvokeGenerator.UnitTests` never exercised the generator''s test-generation code paths. Enabling `GenerateTestsNUnit`/`GenerateTestsXUnit` makes the generator emit a companion validation file (struct size/blittability/layout, `GuidOfTest`, ...), but the harness always passed `TestOutputLocation = null`, so `WithTestAttribute`, `WithTestAssertEqual`, `WithTestAssertTrue`, `CreateTestOutputBuilder`, and the `_testOutputBuilder` branches went uncovered.

Rather than the literal suggestion in the issue (passing `Path.GetRandomFileName()` as the location), this captures and asserts the emitted output -- just setting a location isn''t enough, since nothing is emitted unless the test options are set, and the old single-stream factory would have folded the generated tests into the primary-output comparison.

----------

- Split the shared generator harness into `GenerateBindingsWithTestOutputAsync`, which sets `TestOutputLocation` when tests are requested and routes the generated tests to a separate in-memory `MemoryStream` via a path-keyed output factory. `GenerateBindingsAsync` is now a thin wrapper over it, so every existing baseline/inline caller is unchanged. This stays fully in-memory -- the location is just an opaque path key handed to the injected factory; nothing touches disk.
- New `TestGenerationTest` fixture pinning the emitted output for the common shapes:
  - `StructTestsNUnit` / `StructTestsXUnit` -- `SizeOfTest`, `IsBlittableTest`, `IsLayoutSequentialTest` (`[Test]`/`[Fact]`, `Assert.That`/`Assert.Equal`/`Assert.True`).
  - `GuidStructTestsNUnit` / `GuidStructTestsXUnit` -- adds `GuidOfTest`; `[Platform("win")]`, matching the other `__declspec(uuid)` fixtures.
  - `NoTestsGeneratedWhenNotRequested` -- guards the default path: no companion file emitted without the option.

## Validation
- `dotnet build -c Release`: 0 warnings, 0 errors.
- Full generator suite: 4020 passed, 0 failed (Unix variants skipped on the Windows host); new fixture 5/5.