### PR TITLE
Add libClangSharp bridges for C++ AST gaps

### DIFF
--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -5811,6 +5811,139 @@ CXCursor clangsharp_Cursor_getTypedefNameForAnonDecl(CXCursor C) {
     return clang_getNullCursor();
 }
 
+static const MacroInfo* getMacroInfoForCursor(CXCursor C) {
+    if (C.kind != CXCursor_MacroDefinition) {
+        return nullptr;
+    }
+
+    const MacroDefinitionRecord* MDR = getCursorMacroDefinition(C);
+
+    if (!MDR) {
+        return nullptr;
+    }
+
+    ASTUnit* AU = getCursorASTUnit(C);
+
+    if (!AU) {
+        return nullptr;
+    }
+
+    return AU->getPreprocessor().getMacroInfo(MDR->getName());
+}
+
+unsigned clangsharp_Cursor_getIsMacroVariadic(CXCursor C) {
+    if (const MacroInfo* MI = getMacroInfoForCursor(C)) {
+        return MI->isVariadic();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsMacroC99Varargs(CXCursor C) {
+    if (const MacroInfo* MI = getMacroInfoForCursor(C)) {
+        return MI->isC99Varargs();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsMacroGNUVarargs(CXCursor C) {
+    if (const MacroInfo* MI = getMacroInfoForCursor(C)) {
+        return MI->isGNUVarargs();
+    }
+
+    return 0;
+}
+
+int clangsharp_Cursor_getNumMacroParams(CXCursor C) {
+    if (const MacroInfo* MI = getMacroInfoForCursor(C)) {
+        return MI->getNumParams();
+    }
+
+    return -1;
+}
+
+CXString clangsharp_Cursor_getMacroParamName(CXCursor C, unsigned i) {
+    if (const MacroInfo* MI = getMacroInfoForCursor(C)) {
+        if (i < MI->getNumParams()) {
+            return createDup(MI->params()[i]->getName());
+        }
+    }
+
+    return createEmpty();
+}
+
+int clangsharp_Cursor_getNumMacroTokens(CXCursor C) {
+    if (const MacroInfo* MI = getMacroInfoForCursor(C)) {
+        return MI->getNumTokens();
+    }
+
+    return -1;
+}
+
+CXString clangsharp_Cursor_getMacroTokenSpelling(CXCursor C, unsigned i) {
+    if (const MacroInfo* MI = getMacroInfoForCursor(C)) {
+        if (i < MI->getNumTokens()) {
+            ASTUnit* AU = getCursorASTUnit(C);
+            std::string spelling = AU->getPreprocessor().getSpelling(MI->getReplacementToken(i));
+            return createDup(spelling);
+        }
+    }
+
+    return createEmpty();
+}
+
+unsigned clangsharp_Cursor_getMacroTokenKind(CXCursor C, unsigned i) {
+    if (const MacroInfo* MI = getMacroInfoForCursor(C)) {
+        if (i < MI->getNumTokens()) {
+            return static_cast<unsigned>(MI->getReplacementToken(i).getKind());
+        }
+    }
+
+    return 0;
+}
+
+CXCursor clangsharp_Cursor_getMacroExpansionDefinition(CXCursor C) {
+    if (C.kind == CXCursor_MacroExpansion) {
+        MacroExpansionCursor MEC = getCursorMacroExpansion(C);
+        const MacroDefinitionRecord* MDR = MEC.getDefinition();
+
+        if (MDR) {
+            CXCursor Def = { CXCursor_MacroDefinition, 0, { MDR, nullptr, C.data[2] } };
+            return Def;
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CX_InclusionDirectiveKind clangsharp_Cursor_getInclusionDirectiveKind(CXCursor C) {
+    if (C.kind == CXCursor_InclusionDirective) {
+        const InclusionDirective* ID = getCursorInclusionDirective(C);
+        return static_cast<CX_InclusionDirectiveKind>(ID->getKind() + 1);
+    }
+
+    return CX_IDK_Invalid;
+}
+
+unsigned clangsharp_Cursor_getInclusionDirectiveWasInQuotes(CXCursor C) {
+    if (C.kind == CXCursor_InclusionDirective) {
+        const InclusionDirective* ID = getCursorInclusionDirective(C);
+        return ID->wasInQuotes();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getInclusionDirectiveImportedModule(CXCursor C) {
+    if (C.kind == CXCursor_InclusionDirective) {
+        const InclusionDirective* ID = getCursorInclusionDirective(C);
+        return ID->importedModule();
+    }
+
+    return 0;
+}
+
 CX_ObjCMessageReceiverKind clangsharp_Cursor_getObjCMessageReceiverKind(CXCursor C) {
     if (isStmtOrExpr(C.kind)) {
         const Stmt* S = getCursorStmt(C);

--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -1039,9 +1039,25 @@ unsigned clangsharp_Cursor_getBoolLiteralValue(CXCursor C) {
         if (const ObjCBoolLiteralExpr* OCBLE = dyn_cast<ObjCBoolLiteralExpr>(S)) {
             return OCBLE->getValue();
         }
+
+        if (const TypeTraitExpr* TTE = dyn_cast<TypeTraitExpr>(S)) {
+            return TTE->getBoolValue();
+        }
     }
 
     return 0;
+}
+
+CXCursor clangsharp_Cursor_getCookedLiteral(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const UserDefinedLiteral* UDL = dyn_cast<UserDefinedLiteral>(S)) {
+            return MakeCXCursor(UDL->getCookedLiteral(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
 }
 
 CXType clangsharp_Cursor_getDeclaredReturnType(CXCursor C) {
@@ -1617,6 +1633,18 @@ unsigned clangsharp_Cursor_getHadMultipleCandidates(CXCursor C) {
     return 0;
 }
 
+unsigned clangsharp_Cursor_getHasAPValueResult(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ConstantExpr* CE = dyn_cast<ConstantExpr>(S)) {
+            return CE->hasAPValueResult();
+        }
+    }
+
+    return 0;
+}
+
 unsigned clangsharp_Cursor_getHasBody(CXCursor C) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
@@ -2107,6 +2135,18 @@ unsigned clangsharp_Cursor_getInheritedFromVBase(CXCursor C) {
     }
 
     return 0;
+}
+
+CX_PredefinedIdentKind clangsharp_Cursor_getIdentKind(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const PredefinedExpr* PE = dyn_cast<PredefinedExpr>(S)) {
+            return static_cast<CX_PredefinedIdentKind>(static_cast<int>(PE->getIdentKind()) + 1);
+        }
+    }
+
+    return CX_PIK_Invalid;
 }
 
 CXCursor clangsharp_Cursor_getInitExpr(CXCursor C) {
@@ -3222,6 +3262,19 @@ unsigned clangsharp_Cursor_getIsThrownVariableInScope(CXCursor C) {
     return 0;
 }
 
+CXCursor clangsharp_Cursor_getIgnoreParenNoopCasts(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const Expr* E = dyn_cast<Expr>(S)) {
+            const ASTContext& Ctx = getCursorASTUnit(C)->getASTContext();
+            return MakeCXCursor(E->IgnoreParenNoopCasts(Ctx), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
 unsigned clangsharp_Cursor_getIsTransparent(CXCursor C) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
@@ -3236,6 +3289,10 @@ unsigned clangsharp_Cursor_getIsTransparent(CXCursor C) {
 
         if (const InitListExpr* ILE = dyn_cast<InitListExpr>(S)) {
             return ILE->isTransparent();
+        }
+
+        if (const PredefinedExpr* PE = dyn_cast<PredefinedExpr>(S)) {
+            return PE->isTransparent();
         }
     }
 
@@ -3411,6 +3468,18 @@ CXCursor clangsharp_Cursor_getLhsExpr(CXCursor C) {
     }
 
     return clang_getNullCursor();
+}
+
+CX_LiteralOperatorKind clangsharp_Cursor_getLiteralOperatorKind(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const UserDefinedLiteral* UDL = dyn_cast<UserDefinedLiteral>(S)) {
+            return static_cast<CX_LiteralOperatorKind>(UDL->getLiteralOperatorKind() + 1);
+        }
+    }
+
+    return CX_LOK_Invalid;
 }
 
 unsigned clangsharp_Cursor_getMaxAlignment(CXCursor C) {
@@ -4182,6 +4251,18 @@ CLANGSHARP_LINKAGE CXString clangsharp_Cursor_getObjCRuntimeNameAttrMetadataName
     return createEmpty();
 }
 
+CX_ExprObjectKind clangsharp_Cursor_getObjectKind(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const Expr* E = dyn_cast<Expr>(S)) {
+            return static_cast<CX_ExprObjectKind>(E->getObjectKind() + 1);
+        }
+    }
+
+    return CX_OK_Invalid;
+}
+
 CXCursor clangsharp_Cursor_getOpaqueValue(CXCursor C) {
     if (isStmtOrExpr(C.kind)) {
         const Stmt* S = getCursorStmt(C);
@@ -4483,6 +4564,20 @@ unsigned clangsharp_Cursor_getRequiresZeroInitialization(CXCursor C) {
 
         if (const CXXConstructExpr* CXXCE = dyn_cast<CXXConstructExpr>(S)) {
             return CXXCE->requiresZeroInitialization();
+        }
+    }
+
+    return 0;
+}
+
+int64_t clangsharp_Cursor_getResultAsAPSInt(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ConstantExpr* CE = dyn_cast<ConstantExpr>(S)) {
+            if (CE->hasAPValueResult() && CE->getResultAPValueKind() == APValue::Int) {
+                return CE->getResultAsAPSInt().getSExtValue();
+            }
         }
     }
 
@@ -5459,6 +5554,30 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getTypeParamVariance(CXCursor C)
     }
 
     return 0 /* ObjCTypeParamVariance::Invariant */;
+}
+
+CX_TypeTrait clangsharp_Cursor_getTypeTrait(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const TypeTraitExpr* TTE = dyn_cast<TypeTraitExpr>(S)) {
+            return static_cast<CX_TypeTrait>(TTE->getTrait() + 1);
+        }
+    }
+
+    return CX_TT_Invalid;
+}
+
+CX_ExprValueKind clangsharp_Cursor_getValueKind(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const Expr* E = dyn_cast<Expr>(S)) {
+            return static_cast<CX_ExprValueKind>(E->getValueKind() + 1);
+        }
+    }
+
+    return CX_VK_Invalid;
 }
 
 CXCursor clangsharp_Cursor_getVBase(CXCursor C, unsigned i) {

--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -120,6 +120,46 @@ int64_t getVtblIdx(const GlobalDecl& d)
     return -1;
 }
 
+CXCursor clangsharp_Cursor_getAllocate(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return MakeCXCursor(CBS->getAllocate(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXString clangsharp_Cursor_getAsmString(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const GCCAsmStmt* GAS = dyn_cast<GCCAsmStmt>(S)) {
+            return createDup(GAS->getAsmString());
+        }
+
+        if (const MSAsmStmt* MAS = dyn_cast<MSAsmStmt>(S)) {
+            return createDup(MAS->getAsmString());
+        }
+    }
+
+    return createEmpty();
+}
+
+CXCursor clangsharp_Cursor_getAsmStringExpr(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const GCCAsmStmt* GAS = dyn_cast<GCCAsmStmt>(S)) {
+            return MakeCXCursor(GAS->getAsmStringExpr(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
 CXCursor clangsharp_Cursor_getArgument(CXCursor C, unsigned i) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
@@ -528,7 +568,29 @@ CXCursor clangsharp_Cursor_getBody(CXCursor C) {
         return MakeCXCursor(D->getBody(), D, getCursorTU(C));
     }
 
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return MakeCXCursor(CBS->getBody(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
     return clang_getNullCursor();
+}
+
+CXString clangsharp_Cursor_getClobber(CXCursor C, unsigned i) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const AsmStmt* AS = dyn_cast<AsmStmt>(S)) {
+            if (i < AS->getNumClobbers()) {
+                return createDup(AS->getClobber(i));
+            }
+        }
+    }
+
+    return createEmpty();
 }
 
 CXType clangsharp_Cursor_getCallResultType(CXCursor C) {
@@ -1054,6 +1116,54 @@ CXCursor clangsharp_Cursor_getCookedLiteral(CXCursor C) {
 
         if (const UserDefinedLiteral* UDL = dyn_cast<UserDefinedLiteral>(S)) {
             return MakeCXCursor(UDL->getCookedLiteral(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXCursor clangsharp_Cursor_getDeallocate(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return MakeCXCursor(CBS->getDeallocate(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXCursor clangsharp_Cursor_getExceptionHandler(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return MakeCXCursor(CBS->getExceptionHandler(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXCursor clangsharp_Cursor_getFallthroughHandler(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return MakeCXCursor(CBS->getFallthroughHandler(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXCursor clangsharp_Cursor_getFinalSuspendStmt(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return MakeCXCursor(CBS->getFinalSuspendStmt(), getCursorDecl(C), getCursorTU(C));
         }
     }
 
@@ -1645,6 +1755,30 @@ unsigned clangsharp_Cursor_getHasAPValueResult(CXCursor C) {
     return 0;
 }
 
+unsigned clangsharp_Cursor_getHasBraces(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const MSAsmStmt* MAS = dyn_cast<MSAsmStmt>(S)) {
+            return MAS->hasBraces();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getHasDependentPromiseType(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return CBS->hasDependentPromiseType();
+        }
+    }
+
+    return 0;
+}
+
 unsigned clangsharp_Cursor_getHasBody(CXCursor C) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
@@ -2149,6 +2283,72 @@ CX_PredefinedIdentKind clangsharp_Cursor_getIdentKind(CXCursor C) {
     return CX_PIK_Invalid;
 }
 
+CX_IfStatementKind clangsharp_Cursor_getIfStatementKind(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const IfStmt* IS = dyn_cast<IfStmt>(S)) {
+            return static_cast<CX_IfStatementKind>(static_cast<int>(IS->getStatementKind()) + 1);
+        }
+    }
+
+    return CX_ISK_Invalid;
+}
+
+CXCursor clangsharp_Cursor_getInitSuspendStmt(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return MakeCXCursor(CBS->getInitSuspendStmt(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXString clangsharp_Cursor_getInputConstraint(CXCursor C, unsigned i) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const AsmStmt* AS = dyn_cast<AsmStmt>(S)) {
+            if (i < AS->getNumInputs()) {
+                return createDup(AS->getInputConstraint(i));
+            }
+        }
+    }
+
+    return createEmpty();
+}
+
+CXCursor clangsharp_Cursor_getInputExpr(CXCursor C, unsigned i) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const GCCAsmStmt* GAS = dyn_cast<GCCAsmStmt>(S)) {
+            if (i < GAS->getNumInputs()) {
+                return MakeCXCursor(GAS->getInputExpr(i), getCursorDecl(C), getCursorTU(C));
+            }
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXString clangsharp_Cursor_getInputName(CXCursor C, unsigned i) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const GCCAsmStmt* GAS = dyn_cast<GCCAsmStmt>(S)) {
+            if (i < GAS->getNumInputs()) {
+                return createDup(GAS->getInputName(i));
+            }
+        }
+    }
+
+    return createEmpty();
+}
+
 CXCursor clangsharp_Cursor_getInitExpr(CXCursor C) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
@@ -2632,6 +2832,42 @@ unsigned clangsharp_Cursor_getIsIfExists(CXCursor C) {
     return 0;
 }
 
+unsigned clangsharp_Cursor_getIsAsmGoto(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const GCCAsmStmt* GAS = dyn_cast<GCCAsmStmt>(S)) {
+            return GAS->isAsmGoto();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsSimple(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const AsmStmt* AS = dyn_cast<AsmStmt>(S)) {
+            return AS->isSimple();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsVolatile(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const AsmStmt* AS = dyn_cast<AsmStmt>(S)) {
+            return AS->isVolatile();
+        }
+    }
+
+    return 0;
+}
+
 unsigned clangsharp_Cursor_getIsImplicit(CXCursor C) {
     if (clang_isAttribute(C.kind)) {
         const Attr* A = getCursorAttr(C);
@@ -2659,6 +2895,10 @@ unsigned clangsharp_Cursor_getIsImplicit(CXCursor C) {
 
         if (const CXXThisExpr* CXXTE = dyn_cast<CXXThisExpr>(S)) {
             return CXXTE->isImplicit();
+        }
+
+        if (const CoreturnStmt* CRS = dyn_cast<CoreturnStmt>(S)) {
+            return CRS->isImplicit();
         }
 
         if (const ImplicitCastExpr* ICE = dyn_cast<ImplicitCastExpr>(S)) {
@@ -3441,6 +3681,34 @@ CXCursor clangsharp_Cursor_getLambdaContextDecl(CXCursor C) {
     return clang_getNullCursor();
 }
 
+CXCursor clangsharp_Cursor_getLabelExpr(CXCursor C, unsigned i) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const GCCAsmStmt* GAS = dyn_cast<GCCAsmStmt>(S)) {
+            if (i < GAS->getNumLabels()) {
+                return MakeCXCursor(GAS->getLabelExpr(i), getCursorDecl(C), getCursorTU(C));
+            }
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXString clangsharp_Cursor_getLabelName(CXCursor C, unsigned i) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const GCCAsmStmt* GAS = dyn_cast<GCCAsmStmt>(S)) {
+            if (i < GAS->getNumLabels()) {
+                return createDup(GAS->getLabelName(i));
+            }
+        }
+    }
+
+    return createEmpty();
+}
+
 CXCursor clangsharp_Cursor_getLambdaStaticInvoker(CXCursor C) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
@@ -3643,6 +3911,54 @@ CXCursor clangsharp_Cursor_getNonClosureContext(CXCursor C) {
     }
 
     return clang_getNullCursor();
+}
+
+unsigned clangsharp_Cursor_getNumClobbers(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const AsmStmt* AS = dyn_cast<AsmStmt>(S)) {
+            return AS->getNumClobbers();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getNumInputs(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const AsmStmt* AS = dyn_cast<AsmStmt>(S)) {
+            return AS->getNumInputs();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getNumLabels(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const GCCAsmStmt* GAS = dyn_cast<GCCAsmStmt>(S)) {
+            return GAS->getNumLabels();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getNumOutputs(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const AsmStmt* AS = dyn_cast<AsmStmt>(S)) {
+            return AS->getNumOutputs();
+        }
+    }
+
+    return 0;
 }
 
 int clangsharp_Cursor_getNumArguments(CXCursor C) {
@@ -4263,6 +4579,60 @@ CX_ExprObjectKind clangsharp_Cursor_getObjectKind(CXCursor C) {
     return CX_OK_Invalid;
 }
 
+CXCursor clangsharp_Cursor_getOperand(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoreturnStmt* CRS = dyn_cast<CoreturnStmt>(S)) {
+            return MakeCXCursor(CRS->getOperand(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXString clangsharp_Cursor_getOutputConstraint(CXCursor C, unsigned i) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const AsmStmt* AS = dyn_cast<AsmStmt>(S)) {
+            if (i < AS->getNumOutputs()) {
+                return createDup(AS->getOutputConstraint(i));
+            }
+        }
+    }
+
+    return createEmpty();
+}
+
+CXCursor clangsharp_Cursor_getOutputExpr(CXCursor C, unsigned i) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const GCCAsmStmt* GAS = dyn_cast<GCCAsmStmt>(S)) {
+            if (i < GAS->getNumOutputs()) {
+                return MakeCXCursor(GAS->getOutputExpr(i), getCursorDecl(C), getCursorTU(C));
+            }
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXString clangsharp_Cursor_getOutputName(CXCursor C, unsigned i) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const GCCAsmStmt* GAS = dyn_cast<GCCAsmStmt>(S)) {
+            if (i < GAS->getNumOutputs()) {
+                return createDup(GAS->getOutputName(i));
+            }
+        }
+    }
+
+    return createEmpty();
+}
+
 CXCursor clangsharp_Cursor_getOpaqueValue(CXCursor C) {
     if (isStmtOrExpr(C.kind)) {
         const Stmt* S = getCursorStmt(C);
@@ -4317,6 +4687,30 @@ int clangsharp_Cursor_getPackLength(CXCursor C) {
     }
 
     return -1;
+}
+
+CXCursor clangsharp_Cursor_getPromiseCall(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoreturnStmt* CRS = dyn_cast<CoreturnStmt>(S)) {
+            return MakeCXCursor(CRS->getPromiseCall(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXCursor clangsharp_Cursor_getPromiseDecl(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return MakeCXCursor(CBS->getPromiseDecl(), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
 }
 
 CXCursor clangsharp_Cursor_getParentFunctionOrMethod(CXCursor C) {
@@ -4582,6 +4976,66 @@ int64_t clangsharp_Cursor_getResultAsAPSInt(CXCursor C) {
     }
 
     return 0;
+}
+
+CXCursor clangsharp_Cursor_getResultDecl(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return MakeCXCursor(CBS->getResultDecl(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXCursor clangsharp_Cursor_getReturnStmt(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return MakeCXCursor(CBS->getReturnStmt(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXCursor clangsharp_Cursor_getReturnStmtOnAllocFailure(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return MakeCXCursor(CBS->getReturnStmtOnAllocFailure(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXCursor clangsharp_Cursor_getReturnValue(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return MakeCXCursor(CBS->getReturnValue(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXCursor clangsharp_Cursor_getReturnValueInit(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const CoroutineBodyStmt* CBS = dyn_cast<CoroutineBodyStmt>(S)) {
+            return MakeCXCursor(CBS->getReturnValueInit(), getCursorDecl(C), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
 }
 
 int clangsharp_Cursor_getResultIndex(CXCursor C) {

--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -937,6 +937,18 @@ CX_ConstructionKind clangsharp_Cursor_getConstructionKind(CXCursor C) {
     return _CX_CK_Invalid;
 }
 
+CX_ConstexprSpecKind clangsharp_Cursor_getConstexprKind(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const FunctionDecl* FD = dyn_cast<FunctionDecl>(D)) {
+            return static_cast<CX_ConstexprSpecKind>(static_cast<int>(FD->getConstexprKind()) + 1);
+        }
+    }
+
+    return CX_CSK_Invalid;
+}
+
 unsigned clangsharp_Cursor_getConstructsVirtualBase(CXCursor C) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
@@ -1921,6 +1933,126 @@ unsigned clangsharp_Cursor_getHasUserDeclaredMoveOperation(CXCursor C) {
     return 0;
 }
 
+unsigned clangsharp_Cursor_getHasDeletedDestructor(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->hasDeletedDestructor();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getHasInClassInitializer(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->hasInClassInitializer();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getHasMutableFields(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->hasMutableFields();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getHasNonTrivialDefaultConstructor(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->hasNonTrivialDefaultConstructor();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getHasNonTrivialDestructor(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->hasNonTrivialDestructor();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getHasPrivateFields(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->hasPrivateFields();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getHasProtectedFields(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->hasProtectedFields();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getHasTrivialCopyConstructor(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->hasTrivialCopyConstructor();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getHasTrivialDefaultConstructor(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->hasTrivialDefaultConstructor();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getHasTrivialDestructor(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->hasTrivialDestructor();
+        }
+    }
+
+    return 0;
+}
+
 unsigned clangsharp_Cursor_getHasVarStorage(CXCursor C) {
     if (isStmtOrExpr(C.kind)) {
         const Stmt* S = getCursorStmt(C);
@@ -1991,6 +2123,18 @@ CXCursor clangsharp_Cursor_getInitExpr(CXCursor C) {
     }
 
     return clang_getNullCursor();
+}
+
+CX_InitializationStyle clangsharp_Cursor_getInitStyle(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const VarDecl* VD = dyn_cast<VarDecl>(D)) {
+            return static_cast<CX_InitializationStyle>(VD->getInitStyle() + 1);
+        }
+    }
+
+    return CX_IS_Invalid;
 }
 
 CXType clangsharp_Cursor_getInjectedSpecializationType(CXCursor C) {
@@ -2388,6 +2532,18 @@ unsigned clangsharp_Cursor_getIsFileScope(CXCursor C) {
     return 0;
 }
 
+unsigned clangsharp_Cursor_getIsFixed(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const EnumDecl* ED = dyn_cast<EnumDecl>(D)) {
+            return ED->isFixed();
+        }
+    }
+
+    return 0;
+}
+
 unsigned clangsharp_Cursor_getIsGlobal(CXCursor C) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
@@ -2501,6 +2657,166 @@ unsigned clangsharp_Cursor_getIsIncomplete(CXCursor C) {
     return 0;
 }
 
+unsigned clangsharp_Cursor_getIsAggregate(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->isAggregate();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsCapturelessLambda(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->isCapturelessLambda();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsCXX11StandardLayout(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->isCXX11StandardLayout();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsDynamicClass(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->isDynamicClass();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsEffectivelyFinal(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->isEffectivelyFinal();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsEmpty(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->isEmpty();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsGenericLambda(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->isLambda() && CXXRD->isGenericLambda();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsLambda(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->isLambda();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsLiteral(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->isLiteral();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsPolymorphic(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->isPolymorphic();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsStandardLayout(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->isStandardLayout();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsTrivial(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->isTrivial();
+        }
+
+        if (const FunctionDecl* FD = dyn_cast<FunctionDecl>(D)) {
+            return FD->isTrivial();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsTriviallyCopyable(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CXXRD = dyn_cast<CXXRecordDecl>(D)) {
+            return CXXRD->getDefinition() && CXXRD->isTriviallyCopyable();
+        }
+    }
+
+    return 0;
+}
+
 unsigned clangsharp_Cursor_getIsInheritingConstructor(CXCursor C) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
@@ -2587,6 +2903,18 @@ unsigned clangsharp_Cursor_getIsNegative(CXCursor C) {
 
         if (const IntegerLiteral* IL = dyn_cast<IntegerLiteral>(S)) {
             return IL->getValue().isNegative();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsNested(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const NamespaceDecl* ND = dyn_cast<NamespaceDecl>(D)) {
+            return ND->isNested();
         }
     }
 
@@ -3004,6 +3332,18 @@ unsigned clangsharp_Cursor_getIsVariadic(CXCursor C) {
     return clang_Cursor_isVariadic(C);
 }
 
+unsigned clangsharp_Cursor_getIsZeroLengthBitField(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const FieldDecl* FD = dyn_cast<FieldDecl>(D)) {
+            return FD->isZeroLengthBitField();
+        }
+    }
+
+    return 0;
+}
+
 CXCursor clangsharp_Cursor_getLambdaCallOperator(CXCursor C) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
@@ -3014,6 +3354,20 @@ CXCursor clangsharp_Cursor_getLambdaCallOperator(CXCursor C) {
     }
 
     return clang_getNullCursor();
+}
+
+CX_LambdaCaptureDefault clangsharp_Cursor_getLambdaCaptureDefault(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXRecordDecl* CRD = dyn_cast<CXXRecordDecl>(D)) {
+            if (CRD->isLambda()) {
+                return static_cast<CX_LambdaCaptureDefault>(CRD->getLambdaCaptureDefault() + 1);
+            }
+        }
+    }
+
+    return CX_LCD_Invalid;
 }
 
 CXCursor clangsharp_Cursor_getLambdaContextDecl(CXCursor C) {
@@ -4151,6 +4505,18 @@ int clangsharp_Cursor_getResultIndex(CXCursor C) {
     }
 
     return -1;
+}
+
+CXRefQualifierKind clangsharp_Cursor_getRefQualifier(CXCursor C) {
+    if (isDeclOrTU(C.kind)) {
+        const Decl* D = getCursorDecl(C);
+
+        if (const CXXMethodDecl* MD = dyn_cast<CXXMethodDecl>(D)) {
+            return static_cast<CXRefQualifierKind>(MD->getRefQualifier());
+        }
+    }
+
+    return CXRefQualifier_None;
 }
 
 CXType clangsharp_Cursor_getReturnType(CXCursor C) {

--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -5811,6 +5811,207 @@ CXCursor clangsharp_Cursor_getTypedefNameForAnonDecl(CXCursor C) {
     return clang_getNullCursor();
 }
 
+CX_ObjCMessageReceiverKind clangsharp_Cursor_getObjCMessageReceiverKind(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCMessageExpr* OCME = dyn_cast<ObjCMessageExpr>(S)) {
+            return static_cast<CX_ObjCMessageReceiverKind>(OCME->getReceiverKind() + 1);
+        }
+    }
+
+    return CX_OMRK_Invalid;
+}
+
+CXType clangsharp_Cursor_getObjCMessageReceiverType(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCMessageExpr* OCME = dyn_cast<ObjCMessageExpr>(S)) {
+            return MakeCXType(OCME->getReceiverType(), getCursorTU(C));
+        }
+    }
+
+    return MakeCXType(QualType(), getCursorTU(C));
+}
+
+unsigned clangsharp_Cursor_getIsDelegateInitCall(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCMessageExpr* OCME = dyn_cast<ObjCMessageExpr>(S)) {
+            return OCME->isDelegateInitCall();
+        }
+    }
+
+    return 0;
+}
+
+int clangsharp_Cursor_getNumObjCLiteralElements(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCArrayLiteral* OCAL = dyn_cast<ObjCArrayLiteral>(S)) {
+            return OCAL->getNumElements();
+        }
+
+        if (const ObjCDictionaryLiteral* OCDL = dyn_cast<ObjCDictionaryLiteral>(S)) {
+            return OCDL->getNumElements();
+        }
+    }
+
+    return -1;
+}
+
+CXCursor clangsharp_Cursor_getObjCDictionaryKey(CXCursor C, unsigned i) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCDictionaryLiteral* OCDL = dyn_cast<ObjCDictionaryLiteral>(S)) {
+            if (i < OCDL->getNumElements()) {
+                return MakeCXCursor(OCDL->getKeyValueElement(i).Key, getCursorDecl(C), getCursorTU(C));
+            }
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXCursor clangsharp_Cursor_getObjCDictionaryValue(CXCursor C, unsigned i) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCDictionaryLiteral* OCDL = dyn_cast<ObjCDictionaryLiteral>(S)) {
+            if (i < OCDL->getNumElements()) {
+                return MakeCXCursor(OCDL->getKeyValueElement(i).Value, getCursorDecl(C), getCursorTU(C));
+            }
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+unsigned clangsharp_Cursor_getIsMessagingGetter(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCPropertyRefExpr* OCPRE = dyn_cast<ObjCPropertyRefExpr>(S)) {
+            return OCPRE->isMessagingGetter();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsMessagingSetter(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCPropertyRefExpr* OCPRE = dyn_cast<ObjCPropertyRefExpr>(S)) {
+            return OCPRE->isMessagingSetter();
+        }
+    }
+
+    return 0;
+}
+
+CX_ObjCPropertyRefReceiverKind clangsharp_Cursor_getObjCPropertyRefReceiverKind(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCPropertyRefExpr* OCPRE = dyn_cast<ObjCPropertyRefExpr>(S)) {
+            if (OCPRE->isObjectReceiver()) {
+                return CX_OPRK_Object;
+            }
+
+            if (OCPRE->isSuperReceiver()) {
+                return CX_OPRK_Super;
+            }
+
+            if (OCPRE->isClassReceiver()) {
+                return CX_OPRK_Class;
+            }
+        }
+    }
+
+    return CX_OPRK_Invalid;
+}
+
+CXCursor clangsharp_Cursor_getObjCPropertyRefClassReceiver(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCPropertyRefExpr* OCPRE = dyn_cast<ObjCPropertyRefExpr>(S)) {
+            if (OCPRE->isClassReceiver()) {
+                return MakeCXCursor(OCPRE->getClassReceiver(), getCursorTU(C));
+            }
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+CXCursor clangsharp_Cursor_getSetAtIndexMethodDecl(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCSubscriptRefExpr* OCSRE = dyn_cast<ObjCSubscriptRefExpr>(S)) {
+            return MakeCXCursor(OCSRE->setAtIndexMethodDecl(), getCursorTU(C));
+        }
+    }
+
+    return clang_getNullCursor();
+}
+
+unsigned clangsharp_Cursor_getHasObjCAvailabilityVersion(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCAvailabilityCheckExpr* OCACE = dyn_cast<ObjCAvailabilityCheckExpr>(S)) {
+            return OCACE->hasVersion();
+        }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getObjCAvailabilityVersion(CXCursor C, llvm::VersionTuple* version) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCAvailabilityCheckExpr* OCACE = dyn_cast<ObjCAvailabilityCheckExpr>(S)) {
+            *version = OCACE->getVersion();
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+int clangsharp_Cursor_getNumCatchStmts(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCAtTryStmt* OCATS = dyn_cast<ObjCAtTryStmt>(S)) {
+            return OCATS->getNumCatchStmts();
+        }
+    }
+
+    return -1;
+}
+
+unsigned clangsharp_Cursor_getHasCatchAll(CXCursor C) {
+    if (isStmtOrExpr(C.kind)) {
+        const Stmt* S = getCursorStmt(C);
+
+        if (const ObjCAtCatchStmt* OCACS = dyn_cast<ObjCAtCatchStmt>(S)) {
+            return OCACS->hasEllipsis();
+        }
+    }
+
+    return 0;
+}
+
 CXType clangsharp_Cursor_getTypeOperand(CXCursor C) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
@@ -7240,6 +7441,141 @@ CXCursor clangsharp_Type_getUnderlyingExpr(CXType CT) {
     if (const TypeOfExprType* TOET = dyn_cast<TypeOfExprType>(TP)) {
         CXCursor C = clang_getTypeDeclaration(CT);
         return MakeCXCursor(TOET->getUnderlyingExpr(), getCursorDecl(C), GetTypeTU(CT));
+    }
+
+    return clang_getNullCursor();
+}
+
+unsigned clangsharp_Type_getIsObjCIdType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->isObjCIdType();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsObjCClassType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->isObjCClassType();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsObjCQualifiedIdType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->isObjCQualifiedIdType();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsObjCQualifiedClassType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->isObjCQualifiedClassType();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsObjCKindOfType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const ObjCObjectType* OCOT = dyn_cast<ObjCObjectType>(TP)) {
+        return OCOT->isKindOfType();
+    }
+
+    if (const ObjCObjectPointerType* OCOPT = dyn_cast<ObjCObjectPointerType>(TP)) {
+        return OCOPT->isKindOfType();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsObjCKindOfTypeAsWritten(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const ObjCObjectType* OCOT = dyn_cast<ObjCObjectType>(TP)) {
+        return OCOT->isKindOfTypeAsWritten();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsObjCObjectSpecialized(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const ObjCObjectType* OCOT = dyn_cast<ObjCObjectType>(TP)) {
+        return OCOT->isSpecialized();
+    }
+
+    if (const ObjCObjectPointerType* OCOPT = dyn_cast<ObjCObjectPointerType>(TP)) {
+        return OCOPT->isSpecialized();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsObjCObjectSpecializedAsWritten(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const ObjCObjectType* OCOT = dyn_cast<ObjCObjectType>(TP)) {
+        return OCOT->isSpecializedAsWritten();
+    }
+
+    if (const ObjCObjectPointerType* OCOPT = dyn_cast<ObjCObjectPointerType>(TP)) {
+        return OCOPT->isSpecializedAsWritten();
+    }
+
+    return 0;
+}
+
+CXType clangsharp_Type_getObjCSuperClassType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const ObjCObjectType* OCOT = dyn_cast<ObjCObjectType>(TP)) {
+        return MakeCXType(OCOT->getSuperClassType(), GetTypeTU(CT));
+    }
+
+    return MakeCXType(QualType(), GetTypeTU(CT));
+}
+
+int clangsharp_Type_getNumObjCTypeParamProtocols(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const ObjCTypeParamType* OCTPT = dyn_cast<ObjCTypeParamType>(TP)) {
+        return OCTPT->getNumProtocols();
+    }
+
+    return -1;
+}
+
+CXCursor clangsharp_Type_getObjCTypeParamProtocol(CXType CT, unsigned i) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const ObjCTypeParamType* OCTPT = dyn_cast<ObjCTypeParamType>(TP)) {
+        if (i < OCTPT->getNumProtocols()) {
+            return MakeCXCursor(OCTPT->getProtocol(i), GetTypeTU(CT));
+        }
     }
 
     return clang_getNullCursor();

--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -362,6 +362,15 @@ CX_AttrKind clangsharp_Cursor_getAttrKind(CXCursor C) {
     return CX_AttrKind_Invalid;
 }
 
+CXString clangsharp_Cursor_getAttrSpelling(CXCursor C) {
+    if (clang_isAttribute(C.kind)) {
+        const Attr* A = getCursorAttr(C);
+        return createDup(A->getSpelling());
+    }
+
+    return createEmpty();
+}
+
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getAvailabilityAttributeDeprecated(CXCursor C, llvm::VersionTuple* version)
 {
     if (clang_isAttribute(C.kind)) {
@@ -3097,6 +3106,15 @@ unsigned clangsharp_Cursor_getIsTriviallyCopyable(CXCursor C) {
     return 0;
 }
 
+unsigned clangsharp_Cursor_getIsInherited(CXCursor C) {
+    if (clang_isAttribute(C.kind)) {
+        const Attr* A = getCursorAttr(C);
+        return A->isInherited();
+    }
+
+    return 0;
+}
+
 unsigned clangsharp_Cursor_getIsInheritingConstructor(CXCursor C) {
     if (isDeclOrTU(C.kind)) {
         const Decl* D = getCursorDecl(C);
@@ -3104,6 +3122,15 @@ unsigned clangsharp_Cursor_getIsInheritingConstructor(CXCursor C) {
         if (const CXXConstructorDecl* CXXCD = dyn_cast<CXXConstructorDecl>(D)) {
             return CXXCD->isInheritingConstructor();
         }
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Cursor_getIsLateParsed(CXCursor C) {
+    if (clang_isAttribute(C.kind)) {
+        const Attr* A = getCursorAttr(C);
+        return A->isLateParsed();
     }
 
     return 0;
@@ -6191,6 +6218,26 @@ CXType clangsharp_TemplateArgument_getNullPtrType(CX_TemplateArgument T) {
     return MakeCXType(QualType(), T.tu);
 }
 
+unsigned clangsharp_TemplateArgument_getIsDefaulted(CX_TemplateArgument T) {
+    if (T.value) {
+        return T.value->getIsDefaulted();
+    }
+
+    return 0;
+}
+
+int clangsharp_TemplateArgument_getNumTemplateExpansions(CX_TemplateArgument T) {
+    if (T.value && (T.kind == CXTemplateArgumentKind_TemplateExpansion)) {
+        UnsignedOrNone NumExpansions = T.value->getNumTemplateExpansions();
+
+        if (NumExpansions) {
+            return static_cast<int>(*NumExpansions);
+        }
+    }
+
+    return -1;
+}
+
 int clangsharp_TemplateArgument_getNumPackElements(CX_TemplateArgument T) {
     if (T.kind == CXTemplateArgumentKind_Pack) {
         return T.value->getPackAsArray().size();
@@ -6235,6 +6282,24 @@ CX_TemplateArgument clangsharp_TemplateArgumentLoc_getArgument(CX_TemplateArgume
     }
 
     return MakeCXTemplateArgument(nullptr, T.tu);
+}
+
+CXSourceLocation clangsharp_TemplateArgumentLoc_getTemplateEllipsisLoc(CX_TemplateArgumentLoc T) {
+    if (T.value) {
+        SourceLocation SLoc = T.value->getTemplateEllipsisLoc();
+        return translateSourceLocation(getASTUnit(T.tu)->getASTContext(), SLoc);
+    }
+
+    return clang_getNullLocation();
+}
+
+CXSourceLocation clangsharp_TemplateArgumentLoc_getTemplateNameLoc(CX_TemplateArgumentLoc T) {
+    if (T.value) {
+        SourceLocation SLoc = T.value->getTemplateNameLoc();
+        return translateSourceLocation(getASTUnit(T.tu)->getASTContext(), SLoc);
+    }
+
+    return clang_getNullLocation();
 }
 
 CXSourceLocation clangsharp_TemplateArgumentLoc_getLocation(CX_TemplateArgumentLoc T) {
@@ -6316,6 +6381,42 @@ CXSourceRange clangsharp_TemplateArgumentLoc_getSourceRangeRaw(CX_TemplateArgume
     }
 
     return translateSourceRangeRaw(getASTUnit(T.tu)->getASTContext(), R);
+}
+
+CX_TemplateName clangsharp_TemplateName_getUnderlying(CX_TemplateName T) {
+    if (T.value) {
+        TemplateName TN = TemplateName::getFromVoidPointer(const_cast<void*>(T.value));
+        return MakeCXTemplateName(TN.getUnderlying(), T.tu);
+    }
+
+    return MakeCXTemplateName(TemplateName::getFromVoidPointer(nullptr), T.tu);
+}
+
+unsigned clangsharp_TemplateName_getContainsUnexpandedParameterPack(CX_TemplateName T) {
+    if (T.value) {
+        TemplateName TN = TemplateName::getFromVoidPointer(const_cast<void*>(T.value));
+        return TN.containsUnexpandedParameterPack();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_TemplateName_getIsDependent(CX_TemplateName T) {
+    if (T.value) {
+        TemplateName TN = TemplateName::getFromVoidPointer(const_cast<void*>(T.value));
+        return TN.isDependent();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_TemplateName_getIsInstantiationDependent(CX_TemplateName T) {
+    if (T.value) {
+        TemplateName TN = TemplateName::getFromVoidPointer(const_cast<void*>(T.value));
+        return TN.isInstantiationDependent();
+    }
+
+    return 0;
 }
 
 CXCursor clangsharp_TemplateName_getAsTemplateDecl(CX_TemplateName T) {

--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -6386,6 +6386,17 @@ CXType clangsharp_Type_getBaseType(CXType CT) {
     return MakeCXType(QualType(), GetTypeTU(CT));
 }
 
+CX_AutoTypeKeyword clangsharp_Type_getAutoTypeKeyword(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const AutoType* AT = dyn_cast<AutoType>(TP)) {
+        return static_cast<CX_AutoTypeKeyword>(static_cast<int>(AT->getKeyword()) + 1);
+    }
+
+    return CX_ATK_Invalid;
+}
+
 CXCursor clangsharp_Type_getColumnExpr(CXType CT) {
     QualType T = GetQualType(CT);
     const Type* TP = T.getTypePtrOrNull();
@@ -6440,6 +6451,17 @@ CXCursor clangsharp_Type_getDeclaration(CXType CT) {
     return clang_getTypeDeclaration(CT);
 }
 
+unsigned clangsharp_Type_getContainsUnexpandedParameterPack(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->containsUnexpandedParameterPack();
+    }
+
+    return 0;
+}
+
 CXType clangsharp_Type_getDeducedType(CXType CT) {
     QualType T = GetQualType(CT);
     const Type* TP = T.getTypePtrOrNull();
@@ -6485,6 +6507,17 @@ CXType clangsharp_Type_getElementType(CXType CT) {
     return clang_getElementType(CT);
 }
 
+CX_TypeDependence clangsharp_Type_getDependence(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return static_cast<CX_TypeDependence>(TP->getDependence());
+    }
+
+    return CX_TD_None;
+}
+
 CXType clangsharp_Type_getEquivalentType(CXType CT) {
     QualType T = GetQualType(CT);
     const Type* TP = T.getTypePtrOrNull();
@@ -6520,6 +6553,74 @@ CXType clangsharp_Type_getInjectedSpecializationType(CXType CT) {
     return MakeCXType(QualType(), GetTypeTU(CT));
 }
 
+CX_ExceptionSpecificationType clangsharp_Type_getExceptionSpecType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const FunctionProtoType* FPT = dyn_cast<FunctionProtoType>(TP)) {
+        return static_cast<CX_ExceptionSpecificationType>(FPT->getExceptionSpecType() + 1);
+    }
+
+    return CX_EST_Invalid;
+}
+
+CXType clangsharp_Type_getExceptionType(CXType C, unsigned i) {
+    QualType T = GetQualType(C);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const FunctionProtoType* FPT = dyn_cast<FunctionProtoType>(TP)) {
+        if (i < FPT->getNumExceptions()) {
+            return MakeCXType(FPT->getExceptionType(i), GetTypeTU(C));
+        }
+    }
+
+    return MakeCXType(QualType(), GetTypeTU(C));
+}
+
+unsigned clangsharp_Type_getHasFloatingRepresentation(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->hasFloatingRepresentation();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getHasIntegerRepresentation(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->hasIntegerRepresentation();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getHasPointerRepresentation(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->hasPointerRepresentation();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getHasTrailingReturn(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const FunctionProtoType* FPT = dyn_cast<FunctionProtoType>(TP)) {
+        return FPT->hasTrailingReturn();
+    }
+
+    return 0;
+}
+
 CXType clangsharp_Type_getInjectedTST(CXType CT) {
     QualType T = GetQualType(CT);
     const Type* TP = T.getTypePtrOrNull();
@@ -6531,6 +6632,105 @@ CXType clangsharp_Type_getInjectedTST(CXType CT) {
     }
 
     return MakeCXType(QualType(), GetTypeTU(CT));
+}
+
+unsigned clangsharp_Type_getIsAggregateType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->isAggregateType();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsArithmeticType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->isArithmeticType();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsConst(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const FunctionProtoType* FPT = dyn_cast<FunctionProtoType>(TP)) {
+        return FPT->getMethodQuals().hasConst();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsConstrained(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const AutoType* AT = dyn_cast<AutoType>(TP)) {
+        return AT->isConstrained();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsDecltypeAuto(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const AutoType* AT = dyn_cast<AutoType>(TP)) {
+        return AT->isDecltypeAuto();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsDependentType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->isDependentType();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsFloatingType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->isFloatingType();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsGNUAutoType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const AutoType* AT = dyn_cast<AutoType>(TP)) {
+        return AT->isGNUAutoType();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsInstantiationDependentType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->isInstantiationDependentType();
+    }
+
+    return 0;
 }
 
 unsigned clangsharp_Type_getIsObjCInstanceType(CXType CT) {
@@ -6580,6 +6780,50 @@ unsigned clangsharp_Type_getIsTypeAlias(CXType CT) {
     return 0;
 }
 
+unsigned clangsharp_Type_getIsObjectType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->isObjectType();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsParameterPack(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const TemplateTypeParmType* TTPT = dyn_cast<TemplateTypeParmType>(TP)) {
+        return TTPT->isParameterPack();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsRealFloatingType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->isRealFloatingType();
+    }
+
+    return 0;
+}
+
+unsigned clangsharp_Type_getIsScalarType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->isScalarType();
+    }
+
+    return 0;
+}
+
 unsigned clangsharp_Type_getIsUnsigned(CXType CT) {
     QualType T = GetQualType(CT);
     const Type* TP = T.getTypePtrOrNull();
@@ -6593,6 +6837,36 @@ unsigned clangsharp_Type_getIsUnsigned(CXType CT) {
     }
 
     return 0;
+}
+
+unsigned clangsharp_Type_getIsVariablyModifiedType(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (TP) {
+        return TP->isVariablyModifiedType();
+    }
+
+    return 0;
+}
+
+CX_ElaboratedTypeKeyword clangsharp_Type_getKeyword(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const ElaboratedType* ET = dyn_cast<ElaboratedType>(TP)) {
+        return static_cast<CX_ElaboratedTypeKeyword>(static_cast<int>(ET->getKeyword()) + 1);
+    }
+
+    if (const DependentNameType* DNT = dyn_cast<DependentNameType>(TP)) {
+        return static_cast<CX_ElaboratedTypeKeyword>(static_cast<int>(DNT->getKeyword()) + 1);
+    }
+
+    if (const DependentTemplateSpecializationType* DTST = dyn_cast<DependentTemplateSpecializationType>(TP)) {
+        return static_cast<CX_ElaboratedTypeKeyword>(static_cast<int>(DTST->getKeyword()) + 1);
+    }
+
+    return CX_ETK_Invalid;
 }
 
 CXType clangsharp_Type_getModifiedType(CXType CT) {
@@ -6624,6 +6898,18 @@ CXCursor clangsharp_Type_getNumBitsExpr(CXType CT) {
     if (const DependentBitIntType* DEIT = dyn_cast<DependentBitIntType>(TP)) {
         CXCursor C = clang_getTypeDeclaration(CT);
         return MakeCXCursor(DEIT->getNumBitsExpr(), getCursorDecl(C), GetTypeTU(CT));
+    }
+
+    return clang_getNullCursor();
+}
+
+CXCursor clangsharp_Type_getNoexceptExpr(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const FunctionProtoType* FPT = dyn_cast<FunctionProtoType>(TP)) {
+        CXCursor C = clang_getTypeDeclaration(CT);
+        return MakeCXCursor(FPT->getNoexceptExpr(), getCursorDecl(C), GetTypeTU(CT));
     }
 
     return clang_getNullCursor();
@@ -6856,6 +7142,17 @@ CXCursor clangsharp_Type_getUnderlyingExpr(CXType CT) {
     }
 
     return clang_getNullCursor();
+}
+
+CX_VectorKind clangsharp_Type_getVectorKind(CXType CT) {
+    QualType T = GetQualType(CT);
+    const Type* TP = T.getTypePtrOrNull();
+
+    if (const VectorType* VT = dyn_cast<VectorType>(TP)) {
+        return static_cast<CX_VectorKind>(static_cast<int>(VT->getVectorKind()) + 1);
+    }
+
+    return CX_VECK_Invalid;
 }
 
 CXType clangsharp_Type_getUnderlyingType(CXType CT) {

--- a/sources/libClangSharp/ClangSharp.h
+++ b/sources/libClangSharp/ClangSharp.h
@@ -219,6 +219,21 @@ enum CX_ElaboratedTypeKeyword {
     CX_ETK_None = static_cast<int>(clang::ElaboratedTypeKeyword::None) + 1,
 };
 
+enum CX_ObjCMessageReceiverKind {
+    CX_OMRK_Invalid,
+    CX_OMRK_Class = static_cast<int>(clang::ObjCMessageExpr::Class) + 1,
+    CX_OMRK_Instance = static_cast<int>(clang::ObjCMessageExpr::Instance) + 1,
+    CX_OMRK_SuperClass = static_cast<int>(clang::ObjCMessageExpr::SuperClass) + 1,
+    CX_OMRK_SuperInstance = static_cast<int>(clang::ObjCMessageExpr::SuperInstance) + 1,
+};
+
+enum CX_ObjCPropertyRefReceiverKind {
+    CX_OPRK_Invalid,
+    CX_OPRK_Object,
+    CX_OPRK_Super,
+    CX_OPRK_Class,
+};
+
 enum CX_InitializationStyle {
     CX_IS_Invalid,
     CX_IS_CInit = clang::VarDecl::CInit + 1,
@@ -1065,6 +1080,36 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getTrailingRequiresClause(CXCursor
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getTypedefNameForAnonDecl(CXCursor C);
 
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasCatchAll(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasObjCAvailabilityVersion(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsDelegateInitCall(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsMessagingGetter(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsMessagingSetter(CXCursor C);
+
+CLANGSHARP_LINKAGE int clangsharp_Cursor_getNumCatchStmts(CXCursor C);
+
+CLANGSHARP_LINKAGE int clangsharp_Cursor_getNumObjCLiteralElements(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getObjCAvailabilityVersion(CXCursor C, llvm::VersionTuple* version);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getObjCDictionaryKey(CXCursor C, unsigned i);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getObjCDictionaryValue(CXCursor C, unsigned i);
+
+CLANGSHARP_LINKAGE CX_ObjCMessageReceiverKind clangsharp_Cursor_getObjCMessageReceiverKind(CXCursor C);
+
+CLANGSHARP_LINKAGE CXType clangsharp_Cursor_getObjCMessageReceiverType(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getObjCPropertyRefClassReceiver(CXCursor C);
+
+CLANGSHARP_LINKAGE CX_ObjCPropertyRefReceiverKind clangsharp_Cursor_getObjCPropertyRefReceiverKind(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getSetAtIndexMethodDecl(CXCursor C);
+
 CLANGSHARP_LINKAGE CXType clangsharp_Cursor_getTypeOperand(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getTypeParam(CXCursor C, unsigned i);
@@ -1282,6 +1327,28 @@ CLANGSHARP_LINKAGE CX_TemplateName clangsharp_Type_getTemplateName(CXType C);
 CLANGSHARP_LINKAGE CX_TypeClass clangsharp_Type_getTypeClass(CXType CT);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Type_getUnderlyingExpr(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsObjCClassType(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsObjCIdType(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsObjCKindOfType(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsObjCKindOfTypeAsWritten(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsObjCObjectSpecialized(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsObjCObjectSpecializedAsWritten(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsObjCQualifiedClassType(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsObjCQualifiedIdType(CXType CT);
+
+CLANGSHARP_LINKAGE int clangsharp_Type_getNumObjCTypeParamProtocols(CXType CT);
+
+CLANGSHARP_LINKAGE CXType clangsharp_Type_getObjCSuperClassType(CXType CT);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Type_getObjCTypeParamProtocol(CXType CT, unsigned i);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Type_getUnderlyingType(CXType CT);
 

--- a/sources/libClangSharp/ClangSharp.h
+++ b/sources/libClangSharp/ClangSharp.h
@@ -19,6 +19,9 @@
 #include <clang/AST/StmtObjC.h>
 #include <clang/AST/VTableBuilder.h>
 #include <clang/Basic/Specifiers.h>
+#include <clang/Lex/MacroInfo.h>
+#include <clang/Lex/Preprocessor.h>
+#include <clang/Lex/PreprocessingRecord.h>
 #include <clang-c/ExternC.h>
 #include <clang-c/Index.h>
 
@@ -240,6 +243,14 @@ enum CX_InitializationStyle {
     CX_IS_CallInit = clang::VarDecl::CallInit + 1,
     CX_IS_ListInit = clang::VarDecl::ListInit + 1,
     CX_IS_ParenListInit = clang::VarDecl::ParenListInit + 1,
+};
+
+enum CX_InclusionDirectiveKind {
+    CX_IDK_Invalid,
+    CX_IDK_Include = static_cast<int>(clang::InclusionDirective::Include) + 1,
+    CX_IDK_Import = static_cast<int>(clang::InclusionDirective::Import) + 1,
+    CX_IDK_IncludeNext = static_cast<int>(clang::InclusionDirective::IncludeNext) + 1,
+    CX_IDK_IncludeMacros = static_cast<int>(clang::InclusionDirective::IncludeMacros) + 1,
 };
 
 enum CX_LambdaCaptureDefault {
@@ -1079,6 +1090,30 @@ CLANGSHARP_LINKAGE CXType clangsharp_Cursor_getThisType(CXCursor C);
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getTrailingRequiresClause(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getTypedefNameForAnonDecl(CXCursor C);
+
+CLANGSHARP_LINKAGE CX_InclusionDirectiveKind clangsharp_Cursor_getInclusionDirectiveKind(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getInclusionDirectiveImportedModule(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getInclusionDirectiveWasInQuotes(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsMacroC99Varargs(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsMacroGNUVarargs(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsMacroVariadic(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getMacroExpansionDefinition(CXCursor C);
+
+CLANGSHARP_LINKAGE CXString clangsharp_Cursor_getMacroParamName(CXCursor C, unsigned i);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getMacroTokenKind(CXCursor C, unsigned i);
+
+CLANGSHARP_LINKAGE CXString clangsharp_Cursor_getMacroTokenSpelling(CXCursor C, unsigned i);
+
+CLANGSHARP_LINKAGE int clangsharp_Cursor_getNumMacroParams(CXCursor C);
+
+CLANGSHARP_LINKAGE int clangsharp_Cursor_getNumMacroTokens(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasCatchAll(CXCursor C);
 

--- a/sources/libClangSharp/ClangSharp.h
+++ b/sources/libClangSharp/ClangSharp.h
@@ -156,6 +156,69 @@ enum CX_IfStatementKind {
     CX_ISK_ConstevalNegated = static_cast<int>(clang::IfStatementKind::ConstevalNegated) + 1,
 };
 
+enum CX_TypeDependence {
+    CX_TD_None = clang::TypeDependenceScope::None,
+    CX_TD_UnexpandedPack = clang::TypeDependenceScope::UnexpandedPack,
+    CX_TD_Instantiation = clang::TypeDependenceScope::Instantiation,
+    CX_TD_Dependent = clang::TypeDependenceScope::Dependent,
+    CX_TD_VariablyModified = clang::TypeDependenceScope::VariablyModified,
+    CX_TD_Error = clang::TypeDependenceScope::Error,
+    CX_TD_All = clang::TypeDependenceScope::All,
+
+    CX_TD_DependentInstantiation = clang::TypeDependenceScope::DependentInstantiation,
+};
+
+enum CX_ExceptionSpecificationType {
+    CX_EST_Invalid,
+    CX_EST_None = clang::EST_None + 1,
+    CX_EST_DynamicNone = clang::EST_DynamicNone + 1,
+    CX_EST_Dynamic = clang::EST_Dynamic + 1,
+    CX_EST_MSAny = clang::EST_MSAny + 1,
+    CX_EST_NoThrow = clang::EST_NoThrow + 1,
+    CX_EST_BasicNoexcept = clang::EST_BasicNoexcept + 1,
+    CX_EST_DependentNoexcept = clang::EST_DependentNoexcept + 1,
+    CX_EST_NoexceptFalse = clang::EST_NoexceptFalse + 1,
+    CX_EST_NoexceptTrue = clang::EST_NoexceptTrue + 1,
+    CX_EST_Unevaluated = clang::EST_Unevaluated + 1,
+    CX_EST_Uninstantiated = clang::EST_Uninstantiated + 1,
+    CX_EST_Unparsed = clang::EST_Unparsed + 1,
+};
+
+enum CX_VectorKind {
+    CX_VECK_Invalid,
+    CX_VECK_Generic = static_cast<int>(clang::VectorKind::Generic) + 1,
+    CX_VECK_AltiVecVector = static_cast<int>(clang::VectorKind::AltiVecVector) + 1,
+    CX_VECK_AltiVecPixel = static_cast<int>(clang::VectorKind::AltiVecPixel) + 1,
+    CX_VECK_AltiVecBool = static_cast<int>(clang::VectorKind::AltiVecBool) + 1,
+    CX_VECK_Neon = static_cast<int>(clang::VectorKind::Neon) + 1,
+    CX_VECK_NeonPoly = static_cast<int>(clang::VectorKind::NeonPoly) + 1,
+    CX_VECK_SveFixedLengthData = static_cast<int>(clang::VectorKind::SveFixedLengthData) + 1,
+    CX_VECK_SveFixedLengthPredicate = static_cast<int>(clang::VectorKind::SveFixedLengthPredicate) + 1,
+    CX_VECK_RVVFixedLengthData = static_cast<int>(clang::VectorKind::RVVFixedLengthData) + 1,
+    CX_VECK_RVVFixedLengthMask = static_cast<int>(clang::VectorKind::RVVFixedLengthMask) + 1,
+    CX_VECK_RVVFixedLengthMask_1 = static_cast<int>(clang::VectorKind::RVVFixedLengthMask_1) + 1,
+    CX_VECK_RVVFixedLengthMask_2 = static_cast<int>(clang::VectorKind::RVVFixedLengthMask_2) + 1,
+    CX_VECK_RVVFixedLengthMask_4 = static_cast<int>(clang::VectorKind::RVVFixedLengthMask_4) + 1,
+};
+
+enum CX_AutoTypeKeyword {
+    CX_ATK_Invalid,
+    CX_ATK_Auto = static_cast<int>(clang::AutoTypeKeyword::Auto) + 1,
+    CX_ATK_DecltypeAuto = static_cast<int>(clang::AutoTypeKeyword::DecltypeAuto) + 1,
+    CX_ATK_GNUAutoType = static_cast<int>(clang::AutoTypeKeyword::GNUAutoType) + 1,
+};
+
+enum CX_ElaboratedTypeKeyword {
+    CX_ETK_Invalid,
+    CX_ETK_Struct = static_cast<int>(clang::ElaboratedTypeKeyword::Struct) + 1,
+    CX_ETK_Interface = static_cast<int>(clang::ElaboratedTypeKeyword::Interface) + 1,
+    CX_ETK_Union = static_cast<int>(clang::ElaboratedTypeKeyword::Union) + 1,
+    CX_ETK_Class = static_cast<int>(clang::ElaboratedTypeKeyword::Class) + 1,
+    CX_ETK_Enum = static_cast<int>(clang::ElaboratedTypeKeyword::Enum) + 1,
+    CX_ETK_Typename = static_cast<int>(clang::ElaboratedTypeKeyword::Typename) + 1,
+    CX_ETK_None = static_cast<int>(clang::ElaboratedTypeKeyword::None) + 1,
+};
+
 enum CX_InitializationStyle {
     CX_IS_Invalid,
     CX_IS_CInit = clang::VarDecl::CInit + 1,
@@ -1084,9 +1147,13 @@ CLANGSHARP_LINKAGE CXType clangsharp_Type_getAdjustedType(CXType CT);
 
 CLANGSHARP_LINKAGE CX_AttrKind clangsharp_Type_getAttrKind(CXType CT);
 
+CLANGSHARP_LINKAGE CX_AutoTypeKeyword clangsharp_Type_getAutoTypeKeyword(CXType CT);
+
 CLANGSHARP_LINKAGE CXType clangsharp_Type_getBaseType(CXType CT);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Type_getColumnExpr(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getContainsUnexpandedParameterPack(CXType CT);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Type_getDecayedType(CXType CT);
 
@@ -1094,11 +1161,25 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Type_getDeclaration(CXType CT);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Type_getDeducedType(CXType CT);
 
+CLANGSHARP_LINKAGE CX_TypeDependence clangsharp_Type_getDependence(CXType CT);
+
 CLANGSHARP_LINKAGE int clangsharp_Type_getDepth(CXType CT);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Type_getElementType(CXType CT);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Type_getEquivalentType(CXType CT);
+
+CLANGSHARP_LINKAGE CX_ExceptionSpecificationType clangsharp_Type_getExceptionSpecType(CXType CT);
+
+CLANGSHARP_LINKAGE CXType clangsharp_Type_getExceptionType(CXType C, unsigned i);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getHasFloatingRepresentation(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getHasIntegerRepresentation(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getHasPointerRepresentation(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getHasTrailingReturn(CXType CT);
 
 CLANGSHARP_LINKAGE int clangsharp_Type_getIndex(CXType CT);
 
@@ -1106,7 +1187,33 @@ CLANGSHARP_LINKAGE CXType clangsharp_Type_getInjectedSpecializationType(CXType C
 
 CLANGSHARP_LINKAGE CXType clangsharp_Type_getInjectedTST(CXType CT);
 
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsAggregateType(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsArithmeticType(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsConst(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsConstrained(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsDecltypeAuto(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsDependentType(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsFloatingType(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsGNUAutoType(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsInstantiationDependentType(CXType CT);
+
 CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsObjCInstanceType(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsObjectType(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsParameterPack(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsRealFloatingType(CXType CT);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsScalarType(CXType CT);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsSigned(CXType CT);
 
@@ -1116,7 +1223,13 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsTypeAlias(CXType CT);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsUnsigned(CXType CT);
 
+CLANGSHARP_LINKAGE unsigned clangsharp_Type_getIsVariablyModifiedType(CXType CT);
+
+CLANGSHARP_LINKAGE CX_ElaboratedTypeKeyword clangsharp_Type_getKeyword(CXType CT);
+
 CLANGSHARP_LINKAGE CXType clangsharp_Type_getModifiedType(CXType CT);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Type_getNoexceptExpr(CXType CT);
 
 CLANGSHARP_LINKAGE int clangsharp_Type_getNumBits(CXType CT);
 
@@ -1149,6 +1262,8 @@ CLANGSHARP_LINKAGE CX_TypeClass clangsharp_Type_getTypeClass(CXType CT);
 CLANGSHARP_LINKAGE CXCursor clangsharp_Type_getUnderlyingExpr(CXType CT);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Type_getUnderlyingType(CXType CT);
+
+CLANGSHARP_LINKAGE CX_VectorKind clangsharp_Type_getVectorKind(CXType CT);
 LLVM_CLANG_C_EXTERN_C_END
 
 #endif

--- a/sources/libClangSharp/ClangSharp.h
+++ b/sources/libClangSharp/ClangSharp.h
@@ -148,6 +148,14 @@ enum CX_FloatingSemantics {
     CX_FLK_MaxSemantics = llvm::APFloatBase::S_MaxSemantics + 1,
 };
 
+enum CX_IfStatementKind {
+    CX_ISK_Invalid,
+    CX_ISK_Ordinary = static_cast<int>(clang::IfStatementKind::Ordinary) + 1,
+    CX_ISK_Constexpr = static_cast<int>(clang::IfStatementKind::Constexpr) + 1,
+    CX_ISK_ConstevalNonNegated = static_cast<int>(clang::IfStatementKind::ConstevalNonNegated) + 1,
+    CX_ISK_ConstevalNegated = static_cast<int>(clang::IfStatementKind::ConstevalNegated) + 1,
+};
+
 enum CX_InitializationStyle {
     CX_IS_Invalid,
     CX_IS_CInit = clang::VarDecl::CInit + 1,
@@ -320,6 +328,12 @@ struct CX_TemplateName {
 LLVM_CLANG_C_EXTERN_C_BEGIN
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getArgument(CXCursor C, unsigned i);
 
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getAllocate(CXCursor C);
+
+CLANGSHARP_LINKAGE CXString clangsharp_Cursor_getAsmString(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getAsmStringExpr(CXCursor C);
+
 CLANGSHARP_LINKAGE CXType clangsharp_Cursor_getArgumentType(CXCursor C);
 
 CLANGSHARP_LINKAGE int64_t clangsharp_Cursor_getArraySize(CXCursor C);
@@ -365,6 +379,8 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getBlockMissingReturnType(CXCursor
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getBody(CXCursor C);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Cursor_getCallResultType(CXCursor C);
+
+CLANGSHARP_LINKAGE CXString clangsharp_Cursor_getClobber(CXCursor C, unsigned i);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getCanAvoidCopyToHeap(CXCursor C);
 
@@ -438,6 +454,14 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getCookedLiteral(CXCursor C);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Cursor_getDeclaredReturnType(CXCursor C);
 
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getDeallocate(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getExceptionHandler(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getFallthroughHandler(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getFinalSuspendStmt(CXCursor C);
+
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getDecl(CXCursor C, unsigned i);
 
 CLANGSHARP_LINKAGE CX_DeclKind clangsharp_Cursor_getDeclKind(CXCursor C);
@@ -497,6 +521,10 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHadMultipleCandidates(CXCursor 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasAPValueResult(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasBody(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasBraces(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasDependentPromiseType(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasDefaultArg(CXCursor C);
 
@@ -566,6 +594,8 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getInClassInitializer(CXCursor C);
 
 CLANGSHARP_LINKAGE CX_PredefinedIdentKind clangsharp_Cursor_getIdentKind(CXCursor C);
 
+CLANGSHARP_LINKAGE CX_IfStatementKind clangsharp_Cursor_getIfStatementKind(CXCursor C);
+
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getIgnoreParenNoopCasts(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getInheritedConstructor(CXCursor C);
@@ -573,6 +603,14 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getInheritedConstructor(CXCursor C
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getInheritedFromVBase(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getInitExpr(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getInitSuspendStmt(CXCursor C);
+
+CLANGSHARP_LINKAGE CXString clangsharp_Cursor_getInputConstraint(CXCursor C, unsigned i);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getInputExpr(CXCursor C, unsigned i);
+
+CLANGSHARP_LINKAGE CXString clangsharp_Cursor_getInputName(CXCursor C, unsigned i);
 
 CLANGSHARP_LINKAGE CX_InitializationStyle clangsharp_Cursor_getInitStyle(CXCursor C);
 
@@ -641,6 +679,12 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsInjectedClassName(CXCursor C)
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsIfExists(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsImplicit(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsAsmGoto(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsSimple(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsVolatile(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsIncomplete(CXCursor C);
 
@@ -752,6 +796,10 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getLambdaContextDecl(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getLambdaStaticInvoker(CXCursor C);
 
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getLabelExpr(CXCursor C, unsigned i);
+
+CLANGSHARP_LINKAGE CXString clangsharp_Cursor_getLabelName(CXCursor C, unsigned i);
+
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getLhsExpr(CXCursor C);
 
 CLANGSHARP_LINKAGE CX_LiteralOperatorKind clangsharp_Cursor_getLiteralOperatorKind(CXCursor C);
@@ -777,6 +825,14 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getNominatedBaseClassShadowDecl(CX
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getNonClosureContext(CXCursor C);
 
 CLANGSHARP_LINKAGE int clangsharp_Cursor_getNumArguments(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getNumClobbers(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getNumInputs(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getNumLabels(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getNumOutputs(CXCursor C);
 
 CLANGSHARP_LINKAGE int clangsharp_Cursor_getNumAssocs(CXCursor C);
 
@@ -830,6 +886,14 @@ CLANGSHARP_LINKAGE CX_ExprObjectKind clangsharp_Cursor_getObjectKind(CXCursor C)
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getOpaqueValue(CXCursor C);
 
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getOperand(CXCursor C);
+
+CLANGSHARP_LINKAGE CXString clangsharp_Cursor_getOutputConstraint(CXCursor C, unsigned i);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getOutputExpr(CXCursor C, unsigned i);
+
+CLANGSHARP_LINKAGE CXString clangsharp_Cursor_getOutputName(CXCursor C, unsigned i);
+
 CLANGSHARP_LINKAGE CXType clangsharp_Cursor_getOriginalType(CXCursor C);
 
 CLANGSHARP_LINKAGE CX_OverloadedOperatorKind clangsharp_Cursor_getOverloadedOperatorKind(CXCursor C);
@@ -837,6 +901,10 @@ CLANGSHARP_LINKAGE CX_OverloadedOperatorKind clangsharp_Cursor_getOverloadedOper
 CLANGSHARP_LINKAGE int clangsharp_Cursor_getPackLength(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getParentFunctionOrMethod(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getPromiseCall(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getPromiseDecl(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getPlaceholderTypeConstraint(CXCursor C);
 
@@ -861,6 +929,16 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getRequiresZeroInitialization(CXCu
 CLANGSHARP_LINKAGE int64_t clangsharp_Cursor_getResultAsAPSInt(CXCursor C);
 
 CLANGSHARP_LINKAGE int clangsharp_Cursor_getResultIndex(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getResultDecl(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getReturnStmt(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getReturnStmtOnAllocFailure(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getReturnValue(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getReturnValueInit(CXCursor C);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Cursor_getReturnType(CXCursor C);
 

--- a/sources/libClangSharp/ClangSharp.h
+++ b/sources/libClangSharp/ClangSharp.h
@@ -411,6 +411,8 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getAttr(CXCursor C, unsigned i);
 
 CLANGSHARP_LINKAGE CX_AttrKind clangsharp_Cursor_getAttrKind(CXCursor C);
 
+CLANGSHARP_LINKAGE CXString clangsharp_Cursor_getAttrSpelling(CXCursor C);
+
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getAvailabilityAttributeDeprecated(CXCursor, llvm::VersionTuple* version);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getAvailabilityAttributeIntroduced(CXCursor, llvm::VersionTuple* version);
@@ -751,6 +753,8 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsVolatile(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsIncomplete(CXCursor C);
 
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsInherited(CXCursor C);
+
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsInheritingConstructor(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsAggregate(CXCursor C);
@@ -778,6 +782,8 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsStandardLayout(CXCursor C);
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsTrivial(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsTriviallyCopyable(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsLateParsed(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsListInitialization(CXCursor C);
 
@@ -1109,11 +1115,15 @@ CLANGSHARP_LINKAGE CX_TemplateArgumentDependence clangsharp_TemplateArgument_get
 
 CLANGSHARP_LINKAGE CXType clangsharp_TemplateArgument_getIntegralType(CX_TemplateArgument T);
 
+CLANGSHARP_LINKAGE unsigned clangsharp_TemplateArgument_getIsDefaulted(CX_TemplateArgument T);
+
 CLANGSHARP_LINKAGE CXType clangsharp_TemplateArgument_getNonTypeTemplateArgumentType(CX_TemplateArgument T);
 
 CLANGSHARP_LINKAGE CXType clangsharp_TemplateArgument_getNullPtrType(CX_TemplateArgument T);
 
 CLANGSHARP_LINKAGE int clangsharp_TemplateArgument_getNumPackElements(CX_TemplateArgument T);
+
+CLANGSHARP_LINKAGE int clangsharp_TemplateArgument_getNumTemplateExpansions(CX_TemplateArgument T);
 
 CLANGSHARP_LINKAGE CX_TemplateArgument clangsharp_TemplateArgument_getPackElement(CX_TemplateArgument T, unsigned i);
 
@@ -1137,7 +1147,19 @@ CLANGSHARP_LINKAGE CXSourceRange clangsharp_TemplateArgumentLoc_getSourceRange(C
 
 CLANGSHARP_LINKAGE CXSourceRange clangsharp_TemplateArgumentLoc_getSourceRangeRaw(CX_TemplateArgumentLoc T);
 
+CLANGSHARP_LINKAGE CXSourceLocation clangsharp_TemplateArgumentLoc_getTemplateEllipsisLoc(CX_TemplateArgumentLoc T);
+
+CLANGSHARP_LINKAGE CXSourceLocation clangsharp_TemplateArgumentLoc_getTemplateNameLoc(CX_TemplateArgumentLoc T);
+
 CLANGSHARP_LINKAGE CXCursor clangsharp_TemplateName_getAsTemplateDecl(CX_TemplateName T);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_TemplateName_getContainsUnexpandedParameterPack(CX_TemplateName T);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_TemplateName_getIsDependent(CX_TemplateName T);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_TemplateName_getIsInstantiationDependent(CX_TemplateName T);
+
+CLANGSHARP_LINKAGE CX_TemplateName clangsharp_TemplateName_getUnderlying(CX_TemplateName T);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Type_desugar(CXType CT);
 

--- a/sources/libClangSharp/ClangSharp.h
+++ b/sources/libClangSharp/ClangSharp.h
@@ -65,6 +65,14 @@ enum CX_CharacterKind {
     CX_CLK_UTF32 = static_cast<int>(clang::CharacterLiteralKind::UTF32) + 1,
 };
 
+enum CX_ConstexprSpecKind {
+    CX_CSK_Invalid,
+    CX_CSK_Unspecified = static_cast<int>(clang::ConstexprSpecKind::Unspecified) + 1,
+    CX_CSK_Constexpr = static_cast<int>(clang::ConstexprSpecKind::Constexpr) + 1,
+    CX_CSK_Consteval = static_cast<int>(clang::ConstexprSpecKind::Consteval) + 1,
+    CX_CSK_Constinit = static_cast<int>(clang::ConstexprSpecKind::Constinit) + 1,
+};
+
 enum CX_ConstructionKind {
     _CX_CK_Invalid,
     CX_CK_Complete = static_cast<int>(clang::CXXConstructionKind::Complete) + 1,
@@ -121,6 +129,21 @@ enum CX_FloatingSemantics {
     CX_FLK_Float4E2M1FN = llvm::APFloatBase::S_Float4E2M1FN + 1,
     CX_FLK_x87DoubleExtended = llvm::APFloatBase::S_x87DoubleExtended + 1,
     CX_FLK_MaxSemantics = llvm::APFloatBase::S_MaxSemantics + 1,
+};
+
+enum CX_InitializationStyle {
+    CX_IS_Invalid,
+    CX_IS_CInit = clang::VarDecl::CInit + 1,
+    CX_IS_CallInit = clang::VarDecl::CallInit + 1,
+    CX_IS_ListInit = clang::VarDecl::ListInit + 1,
+    CX_IS_ParenListInit = clang::VarDecl::ParenListInit + 1,
+};
+
+enum CX_LambdaCaptureDefault {
+    CX_LCD_Invalid,
+    CX_LCD_None = clang::LCD_None + 1,
+    CX_LCD_ByCopy = clang::LCD_ByCopy + 1,
+    CX_LCD_ByRef = clang::LCD_ByRef + 1,
 };
 
 enum CX_OverloadedOperatorKind {
@@ -337,6 +360,8 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getConstructedBaseClassShadowDecl(
 
 CLANGSHARP_LINKAGE CX_ConstructionKind clangsharp_Cursor_getConstructionKind(CXCursor C);
 
+CLANGSHARP_LINKAGE CX_ConstexprSpecKind clangsharp_Cursor_getConstexprKind(CXCursor C);
+
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getConstructsVirtualBase(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getContextParam(CXCursor C);
@@ -449,6 +474,26 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasUserDeclaredMoveConstructor(
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasUserDeclaredMoveOperation(CXCursor C);
 
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasDeletedDestructor(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasInClassInitializer(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasMutableFields(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasNonTrivialDefaultConstructor(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasNonTrivialDestructor(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasPrivateFields(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasProtectedFields(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasTrivialCopyConstructor(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasTrivialDefaultConstructor(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasTrivialDestructor(CXCursor C);
+
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasVarStorage(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getHoldingVar(CXCursor C);
@@ -460,6 +505,8 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getInheritedConstructor(CXCursor C
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getInheritedFromVBase(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getInitExpr(CXCursor C);
+
+CLANGSHARP_LINKAGE CX_InitializationStyle clangsharp_Cursor_getInitStyle(CXCursor C);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Cursor_getInjectedSpecializationType(CXCursor C);
 
@@ -517,6 +564,8 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsExternC(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsFileScope(CXCursor C);
 
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsFixed(CXCursor C);
+
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsGlobal(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsInjectedClassName(CXCursor C);
@@ -529,6 +578,32 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsIncomplete(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsInheritingConstructor(CXCursor C);
 
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsAggregate(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsCapturelessLambda(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsCXX11StandardLayout(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsDynamicClass(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsEffectivelyFinal(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsEmpty(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsGenericLambda(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsLambda(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsLiteral(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsPolymorphic(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsStandardLayout(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsTrivial(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsTriviallyCopyable(CXCursor C);
+
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsListInitialization(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsLocalVarDecl(CXCursor C);
@@ -538,6 +613,8 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsLocalVarDeclOrParm(CXCursor C
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsMemberSpecialization(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsNegative(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsNested(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsNonNegative(CXCursor C);
 
@@ -597,7 +674,11 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsUserProvided(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsVariadic(CXCursor C);
 
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getIsZeroLengthBitField(CXCursor C);
+
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getLambdaCallOperator(CXCursor C);
+
+CLANGSHARP_LINKAGE CX_LambdaCaptureDefault clangsharp_Cursor_getLambdaCaptureDefault(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getLambdaContextDecl(CXCursor C);
 
@@ -700,6 +781,8 @@ CLANGSHARP_LINKAGE CXString clangsharp_Cursor_getQualifiedName(CXCursor C);
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getRedeclContext(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getReferenced(CXCursor C);
+
+CLANGSHARP_LINKAGE CXRefQualifierKind clangsharp_Cursor_getRefQualifier(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getRequiresZeroInitialization(CXCursor C);
 

--- a/sources/libClangSharp/ClangSharp.h
+++ b/sources/libClangSharp/ClangSharp.h
@@ -106,6 +106,23 @@ enum CX_ExprDependence {
     CX_ED_ErrorDependent = clang::ExprDependenceScope::ErrorDependent,
 };
 
+enum CX_ExprObjectKind {
+    CX_OK_Invalid,
+    CX_OK_Ordinary = clang::OK_Ordinary + 1,
+    CX_OK_BitField = clang::OK_BitField + 1,
+    CX_OK_VectorComponent = clang::OK_VectorComponent + 1,
+    CX_OK_ObjCProperty = clang::OK_ObjCProperty + 1,
+    CX_OK_ObjCSubscript = clang::OK_ObjCSubscript + 1,
+    CX_OK_MatrixComponent = clang::OK_MatrixComponent + 1,
+};
+
+enum CX_ExprValueKind {
+    CX_VK_Invalid,
+    CX_VK_PRValue = clang::VK_PRValue + 1,
+    CX_VK_LValue = clang::VK_LValue + 1,
+    CX_VK_XValue = clang::VK_XValue + 1,
+};
+
 enum CX_FloatingSemantics {
     CX_FLK_Invalid,
     CX_FLK_IEEEhalf = llvm::APFloatBase::S_IEEEhalf + 1,
@@ -146,11 +163,33 @@ enum CX_LambdaCaptureDefault {
     CX_LCD_ByRef = clang::LCD_ByRef + 1,
 };
 
+enum CX_LiteralOperatorKind {
+    CX_LOK_Invalid,
+    CX_LOK_Raw = clang::UserDefinedLiteral::LOK_Raw + 1,
+    CX_LOK_Template = clang::UserDefinedLiteral::LOK_Template + 1,
+    CX_LOK_Integer = clang::UserDefinedLiteral::LOK_Integer + 1,
+    CX_LOK_Floating = clang::UserDefinedLiteral::LOK_Floating + 1,
+    CX_LOK_String = clang::UserDefinedLiteral::LOK_String + 1,
+    CX_LOK_Character = clang::UserDefinedLiteral::LOK_Character + 1,
+};
+
 enum CX_OverloadedOperatorKind {
     CX_OO_Invalid = clang::OO_None,
 #define OVERLOADED_OPERATOR(Name,Spelling,Token,Unary,Binary,MemberOnly) \
     CX_OO_##Name = clang::OO_##Name,
 #include "clang/Basic/OperatorKinds.def"
+};
+
+enum CX_PredefinedIdentKind {
+    CX_PIK_Invalid,
+    CX_PIK_Func = static_cast<int>(clang::PredefinedIdentKind::Func) + 1,
+    CX_PIK_Function = static_cast<int>(clang::PredefinedIdentKind::Function) + 1,
+    CX_PIK_LFunction = static_cast<int>(clang::PredefinedIdentKind::LFunction) + 1,
+    CX_PIK_FuncDName = static_cast<int>(clang::PredefinedIdentKind::FuncDName) + 1,
+    CX_PIK_FuncSig = static_cast<int>(clang::PredefinedIdentKind::FuncSig) + 1,
+    CX_PIK_LFuncSig = static_cast<int>(clang::PredefinedIdentKind::LFuncSig) + 1,
+    CX_PIK_PrettyFunction = static_cast<int>(clang::PredefinedIdentKind::PrettyFunction) + 1,
+    CX_PIK_PrettyFunctionNoVirtual = static_cast<int>(clang::PredefinedIdentKind::PrettyFunctionNoVirtual) + 1,
 };
 
 enum CX_StmtClass {
@@ -211,6 +250,27 @@ enum CX_TypeClass {
 #define ABSTRACT_TYPE(Class, Base)
 #include <clang/AST/TypeNodes.inc>
     CX_TypeClass_TagFirst = CX_TypeClass_Record, CX_TypeClass_TagLast = CX_TypeClass_Enum
+};
+
+enum CX_TypeTrait {
+    CX_TT_Invalid,
+#define TYPE_TRAIT_1(Spelling, Name, Key) CX_UTT_##Name,
+#include "clang/Basic/TokenKinds.def"
+    CX_UTT_Last = 0 // CX_UTT_Last == last CX_UTT_XX in the enum.
+#define TYPE_TRAIT_1(Spelling, Name, Key) +1
+#include "clang/Basic/TokenKinds.def"
+    ,
+#define TYPE_TRAIT_2(Spelling, Name, Key) CX_BTT_##Name,
+#include "clang/Basic/TokenKinds.def"
+    CX_BTT_Last = CX_UTT_Last // CX_BTT_Last == last CX_BTT_XX in the enum.
+#define TYPE_TRAIT_2(Spelling, Name, Key) +1
+#include "clang/Basic/TokenKinds.def"
+    ,
+#define TYPE_TRAIT_N(Spelling, Name, Key) CX_TT_##Name,
+#include "clang/Basic/TokenKinds.def"
+    CX_TT_Last = CX_BTT_Last // CX_TT_Last == last CX_TT_XX in the enum.
+#define TYPE_TRAIT_N(Spelling, Name, Key) +1
+#include "clang/Basic/TokenKinds.def"
 };
 
 enum CX_UnaryExprOrTypeTrait {
@@ -374,6 +434,8 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getCXXRecord_IsPOD(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getBoolLiteralValue(CXCursor C);
 
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getCookedLiteral(CXCursor C);
+
 CLANGSHARP_LINKAGE CXType clangsharp_Cursor_getDeclaredReturnType(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getDecl(CXCursor C, unsigned i);
@@ -431,6 +493,8 @@ CLANGSHARP_LINKAGE int clangsharp_Cursor_getFunctionScopeIndex(CXCursor C);
 CLANGSHARP_LINKAGE clang::MSGuidDeclParts clangsharp_Cursor_getGuidValue(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHadMultipleCandidates(CXCursor C);
+
+CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasAPValueResult(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasBody(CXCursor C);
 
@@ -499,6 +563,10 @@ CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getHasVarStorage(CXCursor C);
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getHoldingVar(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getInClassInitializer(CXCursor C);
+
+CLANGSHARP_LINKAGE CX_PredefinedIdentKind clangsharp_Cursor_getIdentKind(CXCursor C);
+
+CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getIgnoreParenNoopCasts(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getInheritedConstructor(CXCursor C);
 
@@ -686,6 +754,8 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getLambdaStaticInvoker(CXCursor C)
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getLhsExpr(CXCursor C);
 
+CLANGSHARP_LINKAGE CX_LiteralOperatorKind clangsharp_Cursor_getLiteralOperatorKind(CXCursor C);
+
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getMaxAlignment(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getMethod(CXCursor C, unsigned i);
@@ -756,6 +826,8 @@ CLANGSHARP_LINKAGE int clangsharp_Cursor_getNumVBases(CXCursor C);
 
 CLANGSHARP_LINKAGE CXString clangsharp_Cursor_getObjCRuntimeNameAttrMetadataName(CXCursor C);
 
+CLANGSHARP_LINKAGE CX_ExprObjectKind clangsharp_Cursor_getObjectKind(CXCursor C);
+
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getOpaqueValue(CXCursor C);
 
 CLANGSHARP_LINKAGE CXType clangsharp_Cursor_getOriginalType(CXCursor C);
@@ -785,6 +857,8 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getReferenced(CXCursor C);
 CLANGSHARP_LINKAGE CXRefQualifierKind clangsharp_Cursor_getRefQualifier(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getRequiresZeroInitialization(CXCursor C);
+
+CLANGSHARP_LINKAGE int64_t clangsharp_Cursor_getResultAsAPSInt(CXCursor C);
 
 CLANGSHARP_LINKAGE int clangsharp_Cursor_getResultIndex(CXCursor C);
 
@@ -861,6 +935,10 @@ CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getUsingEnumDeclEnumDecl(CXCursor 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getTypeParamHasExplicitBound(CXCursor C);
 
 CLANGSHARP_LINKAGE unsigned clangsharp_Cursor_getTypeParamVariance(CXCursor C);
+
+CLANGSHARP_LINKAGE CX_TypeTrait clangsharp_Cursor_getTypeTrait(CXCursor C);
+
+CLANGSHARP_LINKAGE CX_ExprValueKind clangsharp_Cursor_getValueKind(CXCursor C);
 
 CLANGSHARP_LINKAGE CXCursor clangsharp_Cursor_getVBase(CXCursor C, unsigned i);
 


### PR DESCRIPTION
Adds the native `libClangSharp` bridges needed to faithfully reproduce the Clang C++ AST where the C API falls short, so ClangSharp can parse the constructs found across most real-world headers/SDKs. Each commit is one logical family; every bridge was verified against clang 21.1.8 sources. This is the native half — the managed accessors that surface these will follow once the package is rebuilt and interop is regenerated.

Authored against `llvmorg-21.1.8`. Requires a native rebuild + interop regen before the managed surface can consume them.

----------

### Decls (`af0f2cbf`)
CXXRecordDecl predicates, constexpr/consteval, ref-qualifier, and namespace/enum/field accessors that had no C-API equivalent.

### Exprs (`a2094cad`)
Expression value/object kind, `PredefinedExpr`, `UserDefinedLiteral`, `TypeTrait`, `ConstantExpr`, plus:
- `getIgnoreParenNoopCasts` — `Expr::IgnoreParenNoopCasts(const ASTContext&)` (uses the cursor's `ASTContext`).
- `getIsTransparent` extended to `PredefinedExpr::isTransparent()` (previously only `TypedefNameDecl`/`InitListExpr`).

### Stmts (`768ce317`)
`IfStmt::getStatementKind` (+`CX_IfStatementKind`), the GCC/MS asm family, and coroutine statements.

### Types (`ee6145ec`)
Type dependence bits (+`CX_TypeDependence`), `FunctionProtoType` exception-spec/cv (+`CX_ExceptionSpecificationType`), `VectorType` kind (+`CX_VectorKind`), `AutoType` keyword (+`CX_AutoTypeKeyword`), `TypeWithKeyword` (+`CX_ElaboratedTypeKeyword`), and the multi-category predicates (`isScalarType`/`isArithmeticType`/`isFloatingType`/`isRealFloatingType`/`isAggregateType`/`isObjectType`/`hasPointerRepresentation`/`hasIntegerRepresentation`/`hasFloatingRepresentation`).

### Templates / Attr (`21cdea35`)
`TemplateName` dependence/instantiation/unexpanded-pack/underlying; `TemplateArgument` isDefaulted/numTemplateExpansions; `TemplateArgumentLoc` name/ellipsis locations; `Attr` isInherited/isLateParsed/spelling.

### ObjC (`290fe9dd`)
`ObjCMessageExpr` receiverKind/receiverType/isDelegateInitCall (+`CX_ObjCMessageReceiverKind`), array/dictionary literal counts, `ObjCPropertyRefExpr` messaging/receiver predicates (+`CX_ObjCPropertyRefReceiverKind`), `ObjCSubscriptRefExpr` set-method, `ObjCAvailabilityCheckExpr` hasVersion/getVersion, `ObjCAtTryStmt`/`ObjCAtCatchStmt`, the Type-level ObjC id/class predicates, and `ObjCObjectType`/`ObjCObjectPointerType`/`ObjCTypeParamType`.

### Macros / preprocessing (`c964693d`)
`MacroInfo` isVariadic/isC99Varargs/isGNUVarargs, param count/name, token count/spelling/kind, the `MacroExpansion` definition cursor, and `InclusionDirective` kind (+`CX_InclusionDirectiveKind`)/wasInQuotes/importedModule.

----------

### Notes
- `CX_TypeTrait` faithfully replicates clang's `BTT`/`TT` value overlap, so the regenerated managed enum will contain duplicate-valued members (valid in C#).
- `MacroDefinitionRecord` stores only the identifier, so the macro→`MacroInfo` route resolves the **current active** definition via the `Preprocessor`; a macro that was `#undef`'d or redefined resolves to its last active definition. This is acceptable for SDK headers.

Nothing is deferred — all High/Med/Low native gaps identified in the sweep are included.
