### PR TITLE
Fix Type keyword bridge for the LLVM 22 ElaboratedType removal

### DIFF
--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -7289,16 +7289,28 @@ CX_ElaboratedTypeKeyword clangsharp_Type_getKeyword(CXType CT) {
     QualType T = GetQualType(CT);
     const Type* TP = T.getTypePtrOrNull();
 
-    if (const ElaboratedType* ET = dyn_cast<ElaboratedType>(TP)) {
-        return static_cast<CX_ElaboratedTypeKeyword>(static_cast<int>(ET->getKeyword()) + 1);
+    if (const TagType* TT = dyn_cast<TagType>(TP)) {
+        return static_cast<CX_ElaboratedTypeKeyword>(static_cast<int>(TT->getKeyword()) + 1);
+    }
+
+    if (const TypedefType* TDT = dyn_cast<TypedefType>(TP)) {
+        return static_cast<CX_ElaboratedTypeKeyword>(static_cast<int>(TDT->getKeyword()) + 1);
+    }
+
+    if (const UsingType* UT = dyn_cast<UsingType>(TP)) {
+        return static_cast<CX_ElaboratedTypeKeyword>(static_cast<int>(UT->getKeyword()) + 1);
+    }
+
+    if (const UnresolvedUsingType* UUT = dyn_cast<UnresolvedUsingType>(TP)) {
+        return static_cast<CX_ElaboratedTypeKeyword>(static_cast<int>(UUT->getKeyword()) + 1);
+    }
+
+    if (const TemplateSpecializationType* TST = dyn_cast<TemplateSpecializationType>(TP)) {
+        return static_cast<CX_ElaboratedTypeKeyword>(static_cast<int>(TST->getKeyword()) + 1);
     }
 
     if (const DependentNameType* DNT = dyn_cast<DependentNameType>(TP)) {
         return static_cast<CX_ElaboratedTypeKeyword>(static_cast<int>(DNT->getKeyword()) + 1);
-    }
-
-    if (const DependentTemplateSpecializationType* DTST = dyn_cast<DependentTemplateSpecializationType>(TP)) {
-        return static_cast<CX_ElaboratedTypeKeyword>(static_cast<int>(DTST->getKeyword()) + 1);
     }
 
     return CX_ETK_Invalid;


### PR DESCRIPTION
Fixes the `regenerate-native` build failure introduced when #797 (authored against clang 21.1.8) landed on top of the native base that is now on clang 22.1.8.

clang 22 removed the `ElaboratedType` and `DependentTemplateSpecializationType` `Type` classes: the elaborated-type keyword now lives directly on each `TypeWithKeyword`-derived type, and the dependent template-specialization case folded into `TemplateSpecializationType` via a dependent `TemplateName`. The `clangsharp_Type_getKeyword` bridge added in #797 was the only code still `dyn_cast`ing those removed classes, so the native library failed to compile on every platform:

```
ClangSharp.cpp:7292:15: error: ISO C++ forbids declaration of 'ElaboratedType' with no type
ClangSharp.cpp:7300:15: error: ... 'DependentTemplateSpecializationType' with no type
```

`getKeyword` now dispatches over the concrete keyword-bearing types (`TagType`, `TypedefType`, `UsingType`, `UnresolvedUsingType`, `TemplateSpecializationType`, `DependentNameType`). `dyn_cast<TypeWithKeyword>` is deliberately blocked by `KeywordWrapper::classof`, so per-type dispatch is the correct route. This is also more faithful than the 21.x wrapper -- the keyword is now observable for the non-elaborated cases the old `ElaboratedType` used to cover (a plain tag/typedef/using type now reports `ETK_None` rather than falling through to `Invalid`).

----------

I also re-audited every other bridge #797 added against the clang 22.1.8 headers (`TypeBase.h`/`Type.h`/`Expr.h`/`ExprCXX.h`/`ExprObjC.h`/`Decl.h`/`DeclCXX.h`/`DeclObjC.h`/`StmtCXX.h`/`StmtObjC.h`/`DeclTemplate.h`/`MacroInfo.h`): every other `dyn_cast` target class and method call exists unchanged in v22. `getKeyword` was the sole break.

> [!NOTE]
> Authored with Copilot. Verified against the clang 22.1.8 headers; I can't build LLVM locally, so the actual compile/link is confirmed by the `regenerate-native` workflow.
