### PR TITLE
Marshal ReadOnlySpan<byte> file names instead of assuming null termination

### DIFF
--- a/sources/ClangSharp.Interop/Extensions/CXTranslationUnit.cs
+++ b/sources/ClangSharp.Interop/Extensions/CXTranslationUnit.cs
@@ -156,15 +156,13 @@ public unsafe partial struct CXTranslationUnit(IntPtr handle) : IDisposable, IEq
     public readonly CXFile GetFile(string fileName)
     {
         using var marshaledFileName = new MarshaledString(fileName);
-        return GetFile(marshaledFileName.AsSpan());
+        return (CXFile)clang.getFile(this, marshaledFileName);
     }
 
     public readonly CXFile GetFile(ReadOnlySpan<byte> fileName)
     {
-        fixed (byte* pFileName = fileName)
-        {
-            return (CXFile)clang.getFile(this, (sbyte*)pFileName);
-        }
+        using var marshaledFileName = new MarshaledString(fileName);
+        return (CXFile)clang.getFile(this, marshaledFileName);
     }
 
     public readonly ReadOnlySpan<byte> GetFileContents(CXFile file, out UIntPtr size)

--- a/sources/ClangSharp.Interop/Internals/MarshaledString.cs
+++ b/sources/ClangSharp.Interop/Internals/MarshaledString.cs
@@ -44,6 +44,18 @@ public unsafe struct MarshaledString : IDisposable
         Value = pValue;
     }
 
+    public MarshaledString(ReadOnlySpan<byte> input)
+    {
+        var valueLength = input.Length;
+        var pValue = (sbyte*)NativeMemory.Alloc((uint)valueLength + 1);
+
+        input.CopyTo(new Span<byte>(pValue, valueLength));
+        pValue[valueLength] = 0;
+
+        Length = valueLength;
+        Value = pValue;
+    }
+
     public readonly ReadOnlySpan<byte> AsSpan() => new ReadOnlySpan<byte>(Value, Length);
 
     public int Length { get; private set; }


### PR DESCRIPTION
`CXTranslationUnit.GetFile(ReadOnlySpan<byte>)` pinned the incoming span and passed the pointer straight to `clang_getFile`, which expects a null-terminated C string. That silently presumes the span is null-terminated, which isn't a safe guarantee -- most callers pass `u8` literals, whose span excludes the terminator, so the native side would read past the end of the span.

Marshal through a new `MarshaledString(ReadOnlySpan<byte>)` ctor that copies into a freshly allocated buffer and writes the trailing `\0`, matching the existing `string`/`ReadOnlySpan<char>` ctors.

The `GetFile(string)` overload now marshals once directly rather than routing through the span overload (which would otherwise double-marshal).

These are hand-written interop helpers, so no regeneration is needed.