### PR TITLE
Fix stale libClangSharp version string and republish as 22.1.8.2

### DIFF
--- a/packages/libClangSharp/libClangSharp.runtime.linux-arm64/libClangSharp.runtime.linux-arm64.nuspec
+++ b/packages/libClangSharp/libClangSharp.runtime.linux-arm64/libClangSharp.runtime.linux-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libClangSharp.runtime.linux-arm64</id>
-    <version>22.1.8.1</version>
+    <version>22.1.8.2</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libClangSharp/libClangSharp.runtime.linux-x64/libClangSharp.runtime.linux-x64.nuspec
+++ b/packages/libClangSharp/libClangSharp.runtime.linux-x64/libClangSharp.runtime.linux-x64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libClangSharp.runtime.linux-x64</id>
-    <version>22.1.8.1</version>
+    <version>22.1.8.2</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libClangSharp/libClangSharp.runtime.osx-arm64/libClangSharp.runtime.osx-arm64.nuspec
+++ b/packages/libClangSharp/libClangSharp.runtime.osx-arm64/libClangSharp.runtime.osx-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libClangSharp.runtime.osx-arm64</id>
-    <version>22.1.8.1</version>
+    <version>22.1.8.2</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libClangSharp/libClangSharp.runtime.win-arm64/libClangSharp.runtime.win-arm64.nuspec
+++ b/packages/libClangSharp/libClangSharp.runtime.win-arm64/libClangSharp.runtime.win-arm64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libClangSharp.runtime.win-arm64</id>
-    <version>22.1.8.1</version>
+    <version>22.1.8.2</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libClangSharp/libClangSharp.runtime.win-x64/libClangSharp.runtime.win-x64.nuspec
+++ b/packages/libClangSharp/libClangSharp.runtime.win-x64/libClangSharp.runtime.win-x64.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libClangSharp.runtime.win-x64</id>
-    <version>22.1.8.1</version>
+    <version>22.1.8.2</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libClangSharp/libClangSharp/libClangSharp.nuspec
+++ b/packages/libClangSharp/libClangSharp/libClangSharp.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>libClangSharp</id>
-    <version>22.1.8.1</version>
+    <version>22.1.8.2</version>
     <authors>.NET Foundation and Contributors</authors>
     <owners>.NET Foundation and Contributors</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/packages/libClangSharp/libClangSharp/runtime.json
+++ b/packages/libClangSharp/libClangSharp/runtime.json
@@ -2,27 +2,27 @@
   "runtimes": {
     "linux-arm64": {
       "libClangSharp": {
-        "libClangSharp.runtime.linux-arm64": "22.1.8.1"
+        "libClangSharp.runtime.linux-arm64": "22.1.8.2"
       }
     },
     "linux-x64": {
       "libClangSharp": {
-        "libClangSharp.runtime.linux-x64": "22.1.8.1"
+        "libClangSharp.runtime.linux-x64": "22.1.8.2"
       }
     },
     "osx-arm64": {
       "libClangSharp": {
-        "libClangSharp.runtime.osx-arm64": "22.1.8.1"
+        "libClangSharp.runtime.osx-arm64": "22.1.8.2"
       }
     },
     "win-arm64": {
       "libClangSharp": {
-        "libClangSharp.runtime.win-arm64": "22.1.8.1"
+        "libClangSharp.runtime.win-arm64": "22.1.8.2"
       }
     },
     "win-x64": {
       "libClangSharp": {
-        "libClangSharp.runtime.win-x64": "22.1.8.1"
+        "libClangSharp.runtime.win-x64": "22.1.8.2"
       }
     }
   }

--- a/sources/libClangSharp/ClangSharp.cpp
+++ b/sources/libClangSharp/ClangSharp.cpp
@@ -6461,7 +6461,7 @@ CXString clangsharp_Cursor_prettyPrintAttribute(CXCursor C) {
 }
 
 CXString clangsharp_getVersion() {
-    return cxstring::createDup("clangsharp version 21.1.8");
+    return cxstring::createDup("clangsharp version 22.1.8");
 }
 
 void clangsharp_TemplateArgument_dispose(CX_TemplateArgument T) {


### PR DESCRIPTION
The native clangsharp_getVersion() still returned `clangsharp version 21.1.8`, even though the CMake project and the `libClangSharp` package were already bumped to 22.1.8. The `PInvokeGenerator` version guard checks this string, so the `22.1.8.x` native package is rejected when the generator is run against libClang 22 -- `Invalid libClang version. Returned string 'clangsharp version 21.1.8' does not contain 'version 22.1'`.

Fix the string and, because `22.1.8.1` was already published carrying the stale value, republish the corrected native package as `22.1.8.2` (nuspecs + `runtime.json`).

----------

Consumer pins in `Directory.Packages.props` are intentionally left lagging at `21.1.8` here; they move to the `22.1.8.2` native package as part of the separate managed-regen change.

> [!NOTE]
> This PR body was drafted by Copilot.