### PR TITLE
Verify the native version string and managed-not-ahead-of-native pins

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -279,6 +279,48 @@ function Verify-Packages() {
     }
   }
 
+  # The native version string reported by clangsharp_getVersion must track the LLVM version exactly.
+  $clangSharpCpp = Join-Path -Path $RepoRoot -ChildPath "sources\libClangSharp\ClangSharp.cpp"
+
+  if ((Get-Content -Path $clangSharpCpp -Raw) -match "clangsharp version ([0-9][0-9.]*)") {
+    if ($Matches[1] -ne $version) {
+      Write-Host -Object "sources\libClangSharp\ClangSharp.cpp: clangsharp_getVersion string '$($Matches[1])' does not match LLVM version '$version'"
+      $failed = $true
+    }
+  }
+  else {
+    Write-Host -Object "sources\libClangSharp\ClangSharp.cpp: could not find the clangsharp_getVersion version string"
+    $failed = $true
+  }
+
+  # The managed package pins consume the native packages. Native may be updated ahead of managed,
+  # but managed must never lead native (managed <= native).
+  $nativeLibClangSharp = $null
+
+  if ((Get-Content -Path (Join-Path -Path $RepoRoot -ChildPath "packages\libClangSharp\libClangSharp\libClangSharp.nuspec") -Raw) -match "<version>([^<]*)</version>") {
+    $nativeLibClangSharp = $Matches[1]
+  }
+
+  $packagesProps = Get-Content -Path (Join-Path -Path $RepoRoot -ChildPath "Directory.Packages.props") -Raw
+
+  if ($packagesProps -match 'Include="libClang"\s+Version="([0-9.]+)"') {
+    $managedLibClang = $Matches[1]
+
+    if ([version]$managedLibClang -gt [version]$version) {
+      Write-Host -Object "Directory.Packages.props: managed libClang pin '$managedLibClang' leads the native libclang version '$version' (managed must be <= native)"
+      $failed = $true
+    }
+  }
+
+  if (($null -ne $nativeLibClangSharp) -and ($packagesProps -match 'Include="libClangSharp"\s+Version="([0-9.]+)"')) {
+    $managedLibClangSharp = $Matches[1]
+
+    if ([version]$managedLibClangSharp -gt [version]$nativeLibClangSharp) {
+      Write-Host -Object "Directory.Packages.props: managed libClangSharp pin '$managedLibClangSharp' leads the native libClangSharp version '$nativeLibClangSharp' (managed must be <= native)"
+      $failed = $true
+    }
+  }
+
   if ($failed) {
     throw "Update the package versions to match the tracked LLVM version ($version) before regenerating."
   }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -453,6 +453,33 @@ function VerifyPackages {
     esac
   done
 
+  # The native version string reported by clangsharp_getVersion must track the LLVM version exactly.
+  cppVersion="$(sed -n 's:.*clangsharp version \([0-9][0-9.]*\).*:\1:p' "$RepoRoot/sources/libClangSharp/ClangSharp.cpp" | head -n1)"
+
+  if [ -z "$cppVersion" ]; then
+    echo "sources/libClangSharp/ClangSharp.cpp: could not find the clangsharp_getVersion version string"
+    rc=1
+  elif [ "$cppVersion" != "$llvm" ]; then
+    echo "sources/libClangSharp/ClangSharp.cpp: clangsharp_getVersion string '$cppVersion' does not match LLVM version '$llvm'"
+    rc=1
+  fi
+
+  # The managed package pins consume the native packages. Native may be updated ahead of managed,
+  # but managed must never lead native (managed <= native).
+  nativeLibClangSharp="$(sed -n 's:.*<version>\([^<]*\)</version>.*:\1:p' "$RepoRoot/packages/libClangSharp/libClangSharp/libClangSharp.nuspec" | head -n1)"
+  managedLibClang="$(sed -n 's:.*Include="libClang"[[:space:]]\{1,\}Version="\([0-9.]*\)".*:\1:p' "$RepoRoot/Directory.Packages.props" | head -n1)"
+  managedLibClangSharp="$(sed -n 's:.*Include="libClangSharp"[[:space:]]\{1,\}Version="\([0-9.]*\)".*:\1:p' "$RepoRoot/Directory.Packages.props" | head -n1)"
+
+  if [ -n "$managedLibClang" ] && [ "$(printf '%s\n%s\n' "$managedLibClang" "$llvm" | sort -V | head -n1)" != "$managedLibClang" ]; then
+    echo "Directory.Packages.props: managed libClang pin '$managedLibClang' leads the native libclang version '$llvm' (managed must be <= native)"
+    rc=1
+  fi
+
+  if [ -n "$managedLibClangSharp" ] && [ -n "$nativeLibClangSharp" ] && [ "$(printf '%s\n%s\n' "$managedLibClangSharp" "$nativeLibClangSharp" | sort -V | head -n1)" != "$managedLibClangSharp" ]; then
+    echo "Directory.Packages.props: managed libClangSharp pin '$managedLibClangSharp' leads the native libClangSharp version '$nativeLibClangSharp' (managed must be <= native)"
+    rc=1
+  fi
+
   if [ "$rc" != 0 ]; then
     echo "Update the package versions to match the tracked LLVM version ($llvm) before regenerating."
     LASTEXITCODE=1


### PR DESCRIPTION
Extends the `Verify-Packages` validation (used by `--verifypackages` in the regenerate-native workflow) to cover two gaps that `#800` exposed:

- **Native version string** -- asserts the `clangsharp_getVersion` string in `sources/libClangSharp/ClangSharp.cpp` matches the tracked LLVM version from `CMakeLists.txt`. This is exactly the stale-string bug fixed in `#800`; the check would have caught it.
- **Managed must not lead native** -- asserts the `Directory.Packages.props` `libClang`/`libClangSharp` pins never exceed the native package versions (libclang tracks the LLVM version; libClangSharp its nuspec version). Native is allowed to update ahead of managed, but managed must always be `<=` native.

Both `scripts/build.ps1` and `scripts/build.sh` are updated so the check stays reproducible locally and matches on Windows/Linux.

----------

Validated locally on both scripts: passes on the current tree (managed still pinned to `21.1.8` while native is `22.1.8`), and fails as expected when the native string is stale or a managed pin is bumped past native.

The monotonic "each change strictly higher than the last" rule is intentionally left out here -- it needs a base ref to diff against, so it belongs in the `--detectchanges --base` path rather than the static verifier. Happy to add it there as a follow-up.
