### PR TITLE
Fix nullptr macro generating invalid code with GenerateUnmanagedConstants

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -112,7 +112,7 @@ internal partial class CSharpOutputBuilder : IOutputBuilder
             Write(GetAccessSpecifierString(desc.AccessSpecifier, isNested: true));
             Write(" static ");
 
-            if (_generator.Config.GenerateUnmanagedConstants && desc.IsConstant)
+            if (_generator.Config.GenerateUnmanagedConstants && desc.IsConstant && !desc.IsCopy)
             {
                 if (desc.IsArray)
                 {
@@ -132,7 +132,7 @@ internal partial class CSharpOutputBuilder : IOutputBuilder
             }
             else
             {
-                if (desc.IsConstant)
+                if (desc.IsConstant && !(_generator.Config.GenerateUnmanagedConstants && desc.IsCopy))
                 {
                     Write("readonly ");
                 }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
@@ -197,6 +197,12 @@ public partial class PInvokeGenerator
                         }
                         flags |= ValueFlags.Copy;
                     }
+                    else if (IsStmtAsWritten<CXXNullPtrLiteralExpr>(varDecl.Init, out _, removeParens: true))
+                    {
+                        // A null pointer literal has no backing storage to return by
+                        // reference, so emit it as a copied value rather than a ref constant
+                        flags |= ValueFlags.Copy;
+                    }
                 }
 
                 if (IsType<ArrayType>(varDecl, type, out var arrayType))

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NullPtrMacroBinding/NullPtrGenerateUnmanagedConstantsMacroTest.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NullPtrMacroBinding/NullPtrGenerateUnmanagedConstantsMacroTest.CSharp.Latest.Windows.cs
@@ -1,0 +1,8 @@
+namespace ClangSharp.Test
+{
+    public static unsafe partial class Methods
+    {
+        [NativeTypeName("#define MY_NULL_HANDLE nullptr")]
+        public static void* MY_NULL_HANDLE => null;
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/NullPtrMacroBindingTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/NullPtrMacroBindingTest.cs
@@ -18,4 +18,12 @@ public sealed class NullPtrMacroBindingTest : StandaloneBaselineTest
 
         return ValidateGeneratedCSharpLatestWindowsBaselineAsync(inputContents);
     }
+
+    [Test]
+    public Task NullPtrGenerateUnmanagedConstantsMacroTest()
+    {
+        var inputContents = @"#define MY_NULL_HANDLE nullptr";
+
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(inputContents, PInvokeGeneratorConfigurationOptions.GenerateUnmanagedConstants);
+    }
 }


### PR DESCRIPTION
Fixes #803

A `nullptr` macro has pointer type, so it's classified as `ValueKind.Unmanaged`. Under `GenerateUnmanagedConstants` that routed it through the `ref readonly` constant path, but `null` has no backing storage to return by reference -- the getter body emitted a bare, mis-indented `null` and produced uncompilable code:

```cs
public static ref readonly void* MY_NULL_HANDLE
{
    get
    {
null    }
}
```

A null pointer literal is effectively a copied scalar value, so treat it like the primitive-copy constants already do and emit an expression-bodied member instead:

```cs
[NativeTypeName("#define MY_NULL_HANDLE nullptr")]
public static void* MY_NULL_HANDLE => null;
```

----------

- `PInvokeGenerator.VisitVarDecl.cs` -- mark the value `ValueFlags.Copy` when the initializer is a null pointer literal.
- `CSharpOutputBuilder.VisitDecl.cs` -- gate the `ref readonly`/`ReadOnlySpan` type-writing on `!desc.IsCopy` and suppress the `readonly` modifier for the copy-under-unmanaged-constants case, mirroring the existing `Primitive` copy handling.

Adds `NullPtrGenerateUnmanagedConstantsMacroTest` as a regression test with its baseline. This is a separate edge case from the one fixed in #601, which only covered the default (non-unmanaged-constants) path.