### PR TITLE
Build win-arm64 libClangSharp with clang-cl to match the LLVM release ABI

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ The change-detection and version-verification the workflow gates on live in the 
 
 The staged binary is written to `artifacts/native/<rid>/`. The LLVM release distribution bundles both the prebuilt `libclang` and the `lib/cmake/{llvm,clang}` config, headers, and import libraries used as `PATH_TO_LLVM` when building `libClangSharp`, so no from-source LLVM build is required (the manual [Building Native](#building-native) steps remain the way to reproduce a build locally). Because lifting `libclang` is just unpacking prebuilt binaries, the workflow does all five runtimes on a single Windows runner (its bundled `bsdtar` handles `.tar.xz`); `libClangSharp` is compiled per-runtime on native runners.
 
+The `win-arm64` runtime is compiled with the LLVM release's own `clang-cl` (via `-G Ninja`) rather than MSVC. The official LLVM binaries are clang-built, and on Arm64 clang and MSVC disagree on the record layout of over-aligned non-POD base classes (e.g. `clang::TemplateSpecializationType`), so an MSVC-built shim reads members of clang-built types at the wrong offset. The other runtimes are unaffected (`win-x64` layouts agree between the two, and the Unix runtimes already use clang).
+
 The jobs run when:
 
 * **libclang** — the tracked LLVM major/minor version changes, or the workflow is dispatched manually with the `libclang` input set.

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -162,17 +162,72 @@ function Extract-Libclang([string] $runtime, [string] $source, [string] $destina
   Copy-Item -Path $lib.FullName -Destination (Join-Path -Path $destination -ChildPath $name)
 }
 
-function Build-Libclangsharp([string] $runtime, [string] $source, [string] $destination) {
-  $arch = switch ($runtime) {
-    "win-x64"   { "x64" }
-    "win-arm64" { "ARM64" }
-    default     { throw "'$runtime' cannot build libClangSharp on Windows; use build.sh on the matching runner" }
+function Get-VisualStudioInstallPath() {
+  $vswhere = Join-Path -Path ${env:ProgramFiles(x86)} -ChildPath "Microsoft Visual Studio\Installer\vswhere.exe"
+
+  if (-not (Test-Path -Path $vswhere)) {
+    throw "'vswhere.exe' was not found; a Visual Studio installation is required to build libClangSharp on Windows"
   }
 
+  $vsPath = & $vswhere -latest -prerelease -products * -property installationPath | Select-Object -First 1
+
+  if (-not $vsPath) {
+    throw "No Visual Studio installation was found via 'vswhere.exe'"
+  }
+
+  return $vsPath
+}
+
+function Import-VisualStudioEnvironment([string] $vsPath, [string] $arch) {
+  $vcvars = Join-Path -Path $vsPath -ChildPath "VC\Auxiliary\Build\vcvarsall.bat"
+
+  if (-not (Test-Path -Path $vcvars)) {
+    throw "'vcvarsall.bat' was not found under '$vsPath'"
+  }
+
+  # clang-cl relies on the MSVC toolchain, Windows SDK, and linker being on
+  # INCLUDE/LIB/PATH; import the developer environment into this process so the
+  # subsequent cmake invocation inherits it.
+  & cmd /c "call `"$vcvars`" $arch > nul && set" | ForEach-Object {
+    $pair = $_ -split "=", 2
+    if ($pair.Count -eq 2) {
+      [System.Environment]::SetEnvironmentVariable($pair[0], $pair[1])
+    }
+  }
+}
+
+function Build-Libclangsharp([string] $runtime, [string] $source, [string] $destination) {
   $nativeBuildDir = Join-Path -Path $ArtifactsDir -ChildPath "bin\native\$runtime"
   $pathToLlvm = (Resolve-Path -Path $source).Path
 
-  & cmake -B "$nativeBuildDir" -S "$RepoRoot" -A "$arch" "-Thost=$arch" "-DPATH_TO_LLVM=$pathToLlvm"
+  if ($runtime -eq "win-arm64") {
+    # The official LLVM release binaries are built with clang. On win-arm64,
+    # clang and MSVC disagree on the record layout of over-aligned non-POD base
+    # classes (e.g. clang::TemplateSpecializationType), so an MSVC-built shim
+    # reads members of clang-built types at the wrong offset and returns garbage.
+    # Build the shim with the release's own clang-cl so the layouts match.
+    # win-x64 layouts agree between the two, so it keeps using MSVC.
+    $vsPath = Get-VisualStudioInstallPath
+    $hostArch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) { "arm64" } else { "amd64_arm64" }
+    Import-VisualStudioEnvironment -vsPath $vsPath -arch $hostArch
+
+    $env:PATH = "$pathToLlvm\bin;$env:PATH"
+
+    $ninja = (Get-Command -Name "ninja" -ErrorAction SilentlyContinue).Source
+    if (-not $ninja) {
+      $ninja = Join-Path -Path $vsPath -ChildPath "Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.exe"
+    }
+
+    & cmake -G Ninja -B "$nativeBuildDir" -S "$RepoRoot" "-DCMAKE_MAKE_PROGRAM=$ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl "-DPATH_TO_LLVM=$pathToLlvm"
+  }
+  else {
+    $arch = switch ($runtime) {
+      "win-x64" { "x64" }
+      default   { throw "'$runtime' cannot build libClangSharp on Windows; use build.sh on the matching runner" }
+    }
+
+    & cmake -B "$nativeBuildDir" -S "$RepoRoot" -A "$arch" "-Thost=$arch" "-DPATH_TO_LLVM=$pathToLlvm"
+  }
 
   if ($LastExitCode -ne 0) {
     throw "'cmake' configure failed for '$runtime'"

--- a/sources/libClangSharp/CMakeLists.txt
+++ b/sources/libClangSharp/CMakeLists.txt
@@ -42,20 +42,37 @@ find_package(Clang REQUIRED CONFIG
 # into the imported LLVMDebugInfoPDB target in LLVMExports.cmake. That path
 # won't exist on another machine (or a CI runner) with a different Visual
 # Studio, causing LNK1181. Repoint it at the DIA SDK of the Visual Studio
-# actually being used for this build.
-if(MSVC AND CMAKE_GENERATOR_INSTANCE AND TARGET LLVMDebugInfoPDB)
-  if(CMAKE_GENERATOR_PLATFORM MATCHES "[Aa][Rr][Mm]64")
-    set(_clangsharp_diaguids "${CMAKE_GENERATOR_INSTANCE}/DIA SDK/lib/arm64/diaguids.lib")
-  elseif(CMAKE_GENERATOR_PLATFORM MATCHES "[Ww]in32")
-    set(_clangsharp_diaguids "${CMAKE_GENERATOR_INSTANCE}/DIA SDK/lib/diaguids.lib")
+# actually being used for this build. The Visual Studio generator (win-x64)
+# exposes its root and target as CMAKE_GENERATOR_INSTANCE/PLATFORM; Ninja +
+# clang-cl (win-arm64) gets them from VSINSTALLDIR and the compiler arch id.
+if(MSVC AND TARGET LLVMDebugInfoPDB)
+  if(CMAKE_GENERATOR_INSTANCE)
+    set(_clangsharp_vs "${CMAKE_GENERATOR_INSTANCE}")
   else()
-    set(_clangsharp_diaguids "${CMAKE_GENERATOR_INSTANCE}/DIA SDK/lib/amd64/diaguids.lib")
+    file(TO_CMAKE_PATH "$ENV{VSINSTALLDIR}" _clangsharp_vs)
+  endif()
+  string(REGEX REPLACE "/+$" "" _clangsharp_vs "${_clangsharp_vs}")
+
+  if(CMAKE_GENERATOR_PLATFORM)
+    set(_clangsharp_arch "${CMAKE_GENERATOR_PLATFORM}")
+  else()
+    set(_clangsharp_arch "${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}")
   endif()
 
-  get_target_property(_clangsharp_pdb_libs LLVMDebugInfoPDB INTERFACE_LINK_LIBRARIES)
-  if(EXISTS "${_clangsharp_diaguids}")
-    string(REGEX REPLACE "[^;]*[Dd][Ii][Aa] SDK[^;]*diaguids\\.lib" "${_clangsharp_diaguids}" _clangsharp_pdb_libs "${_clangsharp_pdb_libs}")
-    set_target_properties(LLVMDebugInfoPDB PROPERTIES INTERFACE_LINK_LIBRARIES "${_clangsharp_pdb_libs}")
+  if(_clangsharp_vs)
+    if(_clangsharp_arch MATCHES "[Aa][Rr][Mm]64")
+      set(_clangsharp_diaguids "${_clangsharp_vs}/DIA SDK/lib/arm64/diaguids.lib")
+    elseif(_clangsharp_arch MATCHES "[Ww]in32|[Xx]86")
+      set(_clangsharp_diaguids "${_clangsharp_vs}/DIA SDK/lib/diaguids.lib")
+    else()
+      set(_clangsharp_diaguids "${_clangsharp_vs}/DIA SDK/lib/amd64/diaguids.lib")
+    endif()
+
+    get_target_property(_clangsharp_pdb_libs LLVMDebugInfoPDB INTERFACE_LINK_LIBRARIES)
+    if(EXISTS "${_clangsharp_diaguids}")
+      string(REGEX REPLACE "[^;]*[Dd][Ii][Aa] SDK[^;]*diaguids\\.lib" "${_clangsharp_diaguids}" _clangsharp_pdb_libs "${_clangsharp_pdb_libs}")
+      set_target_properties(LLVMDebugInfoPDB PROPERTIES INTERFACE_LINK_LIBRARIES "${_clangsharp_pdb_libs}")
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
## What

Builds the `win-arm64` `libClangSharp` shim with the LLVM release's own `clang-cl` (via `-G Ninja`) instead of MSVC, so the shim's C++ record layouts match the clang-built LLVM binaries it links against.

## Why

The official LLVM release binaries are clang-built. On Arm64, clang and MSVC disagree on the record layout of over-aligned non-POD base classes — e.g. `clang::TemplateSpecializationType` (`TypeWithKeyword` + `FoldingSetNode`, where the `Type` base is `alignas(16)`):

- **clang** rounds the over-aligned base up to a full slot → later base at offset 32, `Template` at 40.
- **MSVC-Arm64** packs the next base into the over-aligned base's tail padding → later base at 24, `Template` at 32.

So an MSVC-built shim reads members of clang-built types at the wrong offset and returns garbage — `clangsharp_Type_getTemplateName` yields `CX_TNK_Invalid`, which surfaces as the `windows-arm64` CI failures on `TemplateNameTest` / `DependentTemplateBaseTest`. This is a long-standing MSVC-vs-clang ABI disagreement specific to the `aarch64-pc-windows-msvc` triple (reproduces across every MSVC Arm64 and clang version tested); `win-x64` layouts agree, so only `win-arm64` needs the change.

## Changes

- `scripts/build.ps1` — route `win-arm64` `libClangSharp` through Ninja + the release's `clang-cl` (imports the VS dev environment via `vcvarsall`, puts the LLVM `bin` on `PATH`). `win-x64` keeps using MSVC.
- `sources/libClangSharp/CMakeLists.txt` — generalize the `diaguids.lib` repoint (which works around the absolute path LLVM bakes into `LLVMExports.cmake`) to also apply under Ninja + clang-cl, sourcing the VS root/arch from `VSINSTALLDIR` and the compiler arch id when the VS-generator variables are absent.
- `README.md` — document the `win-arm64` clang-cl special-casing.

The interim skip guards for `TemplateNameTest` / `DependentTemplateBaseTest` (issue #806) stay until the native package is regenerated and republished with this fix.

## Validation

Built the shim locally on an Arm64 box via the real `scripts/build.ps1 -regeneratenative` path (fresh build dir, simulated the LLVM build-machine `diaguids` path to confirm the repoint), binplaced the result, and ran both previously-failing tests: `TemplateNameTest` passes and `DependentTemplateBaseTest` is 8 passed / 0 failed (was 8× `Debug.Fail`).
