### PR TITLE
Surface newly-reachable clang 22 lambda, record, and constexpr accessors

### DIFF
--- a/sources/ClangSharp.Interop/Extensions/CXCursor.cs
+++ b/sources/ClangSharp.Interop/Extensions/CXCursor.cs
@@ -1087,6 +1087,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly bool IsCanonical => Equals(CanonicalCursor);
 
+    public readonly bool IsCapturelessLambda => clangsharp.Cursor_getIsCapturelessLambda(this) != 0;
+
     public readonly bool IsCBuffer => clangsharp.Cursor_getIsCBuffer(this) != 0;
 
     public readonly bool IsClassExtension => clangsharp.Cursor_getIsClassExtension(this) != 0;
@@ -1130,6 +1132,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly bool IsFileScope => clangsharp.Cursor_getIsFileScope(this) != 0;
 
     public readonly bool IsFunctionInlined => clang.Cursor_isFunctionInlined(this) != 0;
+
+    public readonly bool IsGenericLambda => clangsharp.Cursor_getIsGenericLambda(this) != 0;
 
     public readonly bool IsGlobal => clangsharp.Cursor_getIsGlobal(this) != 0;
 
@@ -1242,6 +1246,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly CXString KindSpelling => (kind != default) ? clang.getCursorKindSpelling(Kind) : default;
 
     public readonly CXCursor LambdaCallOperator => clangsharp.Cursor_getLambdaCallOperator(this);
+
+    public readonly CX_LambdaCaptureDefault LambdaCaptureDefault => clangsharp.Cursor_getLambdaCaptureDefault(this);
 
     public readonly CXCursor LambdaContextDecl => clangsharp.Cursor_getLambdaContextDecl(this);
 

--- a/sources/ClangSharp.Interop/Extensions/CXCursor.cs
+++ b/sources/ClangSharp.Interop/Extensions/CXCursor.cs
@@ -700,6 +700,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly CXType ComputationResultType => clangsharp.Cursor_getComputationResultType(this);
 
+    public readonly CX_ConstexprSpecKind ConstexprKind => clangsharp.Cursor_getConstexprKind(this);
+
     public readonly CXCursor ConstraintExpr => clangsharp.Cursor_getConstraintExpr(this);
 
     public readonly CXCursor ConstructedBaseClass => clangsharp.Cursor_getConstructedBaseClass(this);
@@ -1063,6 +1065,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly CXType IBOutletCollectionType => clang.getIBOutletCollectionType(this);
 
+    public readonly CX_IfStatementKind IfStatementKind => clangsharp.Cursor_getIfStatementKind(this);
+
     public readonly CXFile IncludedFile => (CXFile)clang.getIncludedFile(this);
 
     public readonly CXCursor InClassInitializer => clangsharp.Cursor_getInClassInitializer(this);
@@ -1072,6 +1076,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly bool InheritedFromVBase => clangsharp.Cursor_getInheritedFromVBase(this) != 0;
 
     public readonly CXCursor InitExpr => clangsharp.Cursor_getInitExpr(this);
+
+    public readonly CX_InitializationStyle InitStyle => clangsharp.Cursor_getInitStyle(this);
 
     public readonly CXType InjectedSpecializationType => clangsharp.Cursor_getInjectedSpecializationType(this);
 

--- a/sources/ClangSharp.Interop/Extensions/CXCursor.cs
+++ b/sources/ClangSharp.Interop/Extensions/CXCursor.cs
@@ -997,11 +997,15 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly bool HasDefaultArg => clangsharp.Cursor_getHasDefaultArg(this) != 0;
 
+    public readonly bool HasDeletedDestructor => clangsharp.Cursor_getHasDeletedDestructor(this) != 0;
+
     public readonly bool HasElseStorage => clangsharp.Cursor_getHasElseStorage(this) != 0;
 
     public readonly bool HasExplicitTemplateArgs => clangsharp.Cursor_getHasExplicitTemplateArgs(this) != 0;
 
     public readonly bool HasImplicitReturnZero => clangsharp.Cursor_getHasImplicitReturnZero(this) != 0;
+
+    public readonly bool HasInClassInitializer => clangsharp.Cursor_getHasInClassInitializer(this) != 0;
 
     public readonly bool HasInheritedDefaultArg => clangsharp.Cursor_getHasInheritedDefaultArg(this) != 0;
 
@@ -1013,11 +1017,25 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly bool HasLocalStorage => clangsharp.Cursor_getHasLocalStorage(this) != 0;
 
+    public readonly bool HasMutableFields => clangsharp.Cursor_getHasMutableFields(this) != 0;
+
+    public readonly bool HasNonTrivialDefaultConstructor => clangsharp.Cursor_getHasNonTrivialDefaultConstructor(this) != 0;
+
+    public readonly bool HasNonTrivialDestructor => clangsharp.Cursor_getHasNonTrivialDestructor(this) != 0;
+
     public readonly bool HasPlaceholderTypeConstraint => clangsharp.Cursor_getHasPlaceholderTypeConstraint(this) != 0;
+
+    public readonly bool HasPrivateFields => clangsharp.Cursor_getHasPrivateFields(this) != 0;
+
+    public readonly bool HasProtectedFields => clangsharp.Cursor_getHasProtectedFields(this) != 0;
 
     public readonly uint Hash => clang.hashCursor(this);
 
     public readonly bool HasTemplateKeyword => clangsharp.Cursor_getHasTemplateKeyword(this) != 0;
+
+    public readonly bool HasTrivialCopyConstructor => clangsharp.Cursor_getHasTrivialCopyConstructor(this) != 0;
+
+    public readonly bool HasTrivialDefaultConstructor => clangsharp.Cursor_getHasTrivialDefaultConstructor(this) != 0;
 
     public readonly bool HasUninstantiatedDefaultArg => clangsharp.Cursor_getHasUninstantiatedDefaultArg(this) != 0;
 
@@ -1063,6 +1081,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly ulong UnsignedIntegerLiteralValue => clangsharp.Cursor_getUnsignedIntegerLiteralValue(this);
 
+    public readonly bool IsAggregate => clangsharp.Cursor_getIsAggregate(this) != 0;
+
     public readonly bool IsAllEnumCasesCovered => clangsharp.Cursor_getIsAllEnumCasesCovered(this) != 0;
 
     public readonly bool IsAlwaysNull => clangsharp.Cursor_getIsAlwaysNull(this) != 0;
@@ -1103,6 +1123,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly bool IsCopyOrMoveConstructor => clangsharp.Cursor_getIsCopyOrMoveConstructor(this) != 0;
 
+    public readonly bool IsCXX11StandardLayout => clangsharp.Cursor_getIsCXX11StandardLayout(this) != 0;
+
     public readonly bool IsCXXTry => clangsharp.Cursor_getIsCXXTry(this) != 0;
 
     public readonly bool IsDeclaration => clang.isDeclaration(Kind) != 0;
@@ -1119,7 +1141,13 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly bool IsDynamicCall => clang.Cursor_isDynamicCall(this) != 0;
 
+    public readonly bool IsDynamicClass => clangsharp.Cursor_getIsDynamicClass(this) != 0;
+
+    public readonly bool IsEffectivelyFinal => clangsharp.Cursor_getIsEffectivelyFinal(this) != 0;
+
     public readonly bool IsElidable => clangsharp.Cursor_getIsElidable(this) != 0;
+
+    public readonly bool IsEmpty => clangsharp.Cursor_getIsEmpty(this) != 0;
 
     public readonly bool IsExplicitlyDefaulted => clangsharp.Cursor_getIsExplicitlyDefaulted(this) != 0;
 
@@ -1155,6 +1183,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly bool IsListInitialization => clangsharp.Cursor_getIsListInitialization(this) != 0;
 
+    public readonly bool IsLiteral => clangsharp.Cursor_getIsLiteral(this) != 0;
+
     public readonly bool IsLocalVarDecl => clangsharp.Cursor_getIsLocalVarDecl(this) != 0;
 
     public readonly bool IsLocalVarDeclOrParm => clangsharp.Cursor_getIsLocalVarDeclOrParm(this) != 0;
@@ -1185,6 +1215,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly bool IsPartiallySubstituted => clangsharp.Cursor_getIsPartiallySubstituted(this) != 0;
 
+    public readonly bool IsPolymorphic => clangsharp.Cursor_getIsPolymorphic(this) != 0;
+
     public readonly bool IsPotentiallyEvaluated => clangsharp.Cursor_getIsPotentiallyEvaluated(this) != 0;
 
     public readonly bool IsPreprocessing => clang.isPreprocessing(Kind) != 0;
@@ -1196,6 +1228,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly bool IsResultDependent => clangsharp.Cursor_getIsResultDependent(this) != 0;
 
     public readonly bool IsReversed => clangsharp.Cursor_getIsReversed(this) != 0;
+
+    public readonly bool IsStandardLayout => clangsharp.Cursor_getIsStandardLayout(this) != 0;
 
     public readonly bool IsStdInitListInitialization => clangsharp.Cursor_getIsStdInitListInitialization(this) != 0;
 
@@ -1220,6 +1254,10 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly bool IsTranslationUnit => clang.isTranslationUnit(Kind) != 0;
 
     public readonly bool IsTransparent => clangsharp.Cursor_getIsTransparent(this) != 0;
+
+    public readonly bool IsTrivial => clangsharp.Cursor_getIsTrivial(this) != 0;
+
+    public readonly bool IsTriviallyCopyable => clangsharp.Cursor_getIsTriviallyCopyable(this) != 0;
 
     public readonly bool IsTypeConcept => clangsharp.Cursor_getIsTypeConcept(this) != 0;
 

--- a/sources/ClangSharp/Cursors/Decls/CXXRecordDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CXXRecordDecl.cs
@@ -52,7 +52,27 @@ public class CXXRecordDecl : RecordDecl
 
     public bool IsAbstract => Handle.CXXRecord_IsAbstract;
 
+    public bool IsAggregate => Handle.IsAggregate;
+
+    public bool IsCXX11StandardLayout => Handle.IsCXX11StandardLayout;
+
+    public bool IsDynamicClass => Handle.IsDynamicClass;
+
+    public bool IsEffectivelyFinal => Handle.IsEffectivelyFinal;
+
+    public bool IsEmpty => Handle.IsEmpty;
+
+    public bool IsLiteral => Handle.IsLiteral;
+
     public bool IsPOD => Handle.CXXRecord_IsPOD;
+
+    public bool IsPolymorphic => Handle.IsPolymorphic;
+
+    public bool IsStandardLayout => Handle.IsStandardLayout;
+
+    public bool IsTrivial => Handle.IsTrivial;
+
+    public bool IsTriviallyCopyable => Handle.IsTriviallyCopyable;
 
     public IReadOnlyList<CXXBaseSpecifier> Bases => _bases;
 
@@ -72,7 +92,25 @@ public class CXXRecordDecl : RecordDecl
 
     public bool HasDefinition => Definition is not null;
 
+    public bool HasDeletedDestructor => Handle.HasDeletedDestructor;
+
     public bool HasFriends => Handle.NumFriends != 0;
+
+    public bool HasInClassInitializer => Handle.HasInClassInitializer;
+
+    public bool HasMutableFields => Handle.HasMutableFields;
+
+    public bool HasNonTrivialDefaultConstructor => Handle.HasNonTrivialDefaultConstructor;
+
+    public bool HasNonTrivialDestructor => Handle.HasNonTrivialDestructor;
+
+    public bool HasPrivateFields => Handle.HasPrivateFields;
+
+    public bool HasProtectedFields => Handle.HasProtectedFields;
+
+    public bool HasTrivialCopyConstructor => Handle.HasTrivialCopyConstructor;
+
+    public bool HasTrivialDefaultConstructor => Handle.HasTrivialDefaultConstructor;
 
     public bool HasUserDeclaredConstructor => Handle.HasUserDeclaredConstructor;
 

--- a/sources/ClangSharp/Cursors/Decls/FunctionDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/FunctionDecl.cs
@@ -48,6 +48,8 @@ public class FunctionDecl : DeclaratorDecl, IDeclContext, IRedeclarable<Function
 
     public new FunctionDecl CanonicalDecl => (FunctionDecl)base.CanonicalDecl;
 
+    public CX_ConstexprSpecKind ConstexprKind => Handle.ConstexprKind;
+
     public Type DeclaredReturnType => _declaredReturnType.GetValue(this);
 
     public FunctionDecl Definition => _definition.GetValue(this);
@@ -61,6 +63,10 @@ public class FunctionDecl : DeclaratorDecl, IDeclContext, IRedeclarable<Function
     public bool HasImplicitReturnZero => Handle.HasImplicitReturnZero;
 
     public FunctionDecl InstantiatedFromMemberFunction => _instantiatedFromMemberFunction.GetValue(this);
+
+    public bool IsConsteval => ConstexprKind == CX_ConstexprSpecKind.CX_CSK_Consteval;
+
+    public bool IsConstexpr => ConstexprKind is CX_ConstexprSpecKind.CX_CSK_Constexpr or CX_ConstexprSpecKind.CX_CSK_Consteval;
 
     public bool IsDefaulted => Handle.CXXMethod_IsDefaulted;
 

--- a/sources/ClangSharp/Cursors/Decls/VarDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/VarDecl.cs
@@ -43,6 +43,8 @@ public class VarDecl : DeclaratorDecl, IRedeclarable<VarDecl>
 
     public Expr Init => _init.GetValue(this);
 
+    public CX_InitializationStyle InitStyle => Handle.InitStyle;
+
     public VarDecl InstantiatedFromStaticDataMember => _instantiatedFromStaticDataMember.GetValue(this);
 
     public bool IsExternC => Handle.IsExternC;

--- a/sources/ClangSharp/Cursors/Exprs/LambdaExpr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/LambdaExpr.cs
@@ -9,15 +9,27 @@ namespace ClangSharp;
 public sealed class LambdaExpr : Expr
 {
     private ValueLazy<LambdaExpr, CXXMethodDecl> _callOperator;
+    private ValueLazy<LambdaExpr, CXXRecordDecl> _lambdaClass;
 
     internal unsafe LambdaExpr(CXCursor handle) : base(handle, CXCursor_LambdaExpr, CX_StmtClass_LambdaExpr)
     {
         _callOperator = new ValueLazy<LambdaExpr, CXXMethodDecl>(&CallOperatorFactory);
+        _lambdaClass = new ValueLazy<LambdaExpr, CXXRecordDecl>(&LambdaClassFactory);
     }
 
     public CXXMethodDecl CallOperator => _callOperator.GetValue(this);
 
+    public CX_LambdaCaptureDefault CaptureDefault => LambdaClass.Handle.LambdaCaptureDefault;
+
+    public bool IsCapturelessLambda => LambdaClass.Handle.IsCapturelessLambda;
+
+    public bool IsGenericLambda => LambdaClass.Handle.IsGenericLambda;
+
     public bool IsMutable => !CallOperator.IsConst;
 
-    private static unsafe CXXMethodDecl CallOperatorFactory(LambdaExpr self) => self.TranslationUnit.GetOrCreate<CXXMethodDecl>(self.Type.AsCXXRecordDecl!.Handle.LambdaCallOperator);
+    public CXXRecordDecl LambdaClass => _lambdaClass.GetValue(this);
+
+    private static unsafe CXXMethodDecl CallOperatorFactory(LambdaExpr self) => self.TranslationUnit.GetOrCreate<CXXMethodDecl>(self.LambdaClass.Handle.LambdaCallOperator);
+
+    private static unsafe CXXRecordDecl LambdaClassFactory(LambdaExpr self) => self.Type.AsCXXRecordDecl!;
 }

--- a/sources/ClangSharp/Cursors/Stmts/IfStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/IfStmt.cs
@@ -34,6 +34,8 @@ public sealed class IfStmt : Stmt
 
     public bool IsObjcAvailabilityCheck => Cond is ObjCAvailabilityCheckExpr;
 
+    public CX_IfStatementKind StatementKind => Handle.IfStatementKind;
+
     public Stmt Then => Children[ThenOffset];
 
     private int CondOffset => VarOffset + (HasVarStorage ? 1 : 0);

--- a/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
@@ -218,6 +218,53 @@ private:
         Assert.That(structB.IsPOD, Is.False, "struct B should be not POD");
     }
 
+    [Test]
+    public void CXXRecordDeclStructuralPredicatesTest()
+    {
+        var inputContents = """
+struct Pod { };
+
+struct Poly
+{
+    Poly();
+    virtual void f();
+    mutable int m;
+private:
+    int p;
+};
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var records = translationUnit.TranslationUnitDecl.Decls.OfType<CXXRecordDecl>()
+                                     .Where((recordDecl) => recordDecl.HasDefinition)
+                                     .ToDictionary((recordDecl) => recordDecl.Name, StringComparer.Ordinal);
+
+        var pod = records["Pod"];
+        var poly = records["Poly"];
+
+        Assert.That(pod.IsAggregate, Is.True);
+        Assert.That(pod.IsEmpty, Is.True);
+        Assert.That(pod.IsPOD, Is.True);
+        Assert.That(pod.IsStandardLayout, Is.True);
+        Assert.That(pod.IsTrivial, Is.True);
+        Assert.That(pod.IsTriviallyCopyable, Is.True);
+        Assert.That(pod.IsPolymorphic, Is.False);
+        Assert.That(pod.IsDynamicClass, Is.False);
+        Assert.That(pod.HasUserDeclaredConstructor, Is.False);
+
+        Assert.That(poly.IsPolymorphic, Is.True);
+        Assert.That(poly.IsDynamicClass, Is.True);
+        Assert.That(poly.IsAggregate, Is.False);
+        Assert.That(poly.IsEmpty, Is.False);
+        Assert.That(poly.IsPOD, Is.False);
+        Assert.That(poly.IsTrivial, Is.False);
+        Assert.That(poly.HasUserDeclaredConstructor, Is.True);
+        Assert.That(poly.HasMutableFields, Is.True);
+        Assert.That(poly.HasPrivateFields, Is.True);
+        Assert.That(poly.HasNonTrivialDestructor, Is.False);
+    }
+
 
     [Test]
     public void QualifiedNameTest()

--- a/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
@@ -265,6 +265,60 @@ private:
         Assert.That(poly.HasNonTrivialDestructor, Is.False);
     }
 
+    [Test]
+    public void FunctionConstexprKindTest()
+    {
+        var inputContents = """
+constexpr int CxFunc() { return 0; }
+consteval int CvFunc() { return 0; }
+int PlainFunc() { return 0; }
+""";
+
+        string[] commandLineArgs = ["-std=c++20", "-Wno-pragma-once-outside-header"];
+        using var translationUnit = CreateTranslationUnit(inputContents, commandLineArgs: commandLineArgs);
+
+        var funcs = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>()
+                                   .ToDictionary((functionDecl) => functionDecl.Name, StringComparer.Ordinal);
+
+        Assert.That(funcs["CxFunc"].ConstexprKind, Is.EqualTo(CX_ConstexprSpecKind.CX_CSK_Constexpr));
+        Assert.That(funcs["CxFunc"].IsConstexpr, Is.True);
+        Assert.That(funcs["CxFunc"].IsConsteval, Is.False);
+
+        Assert.That(funcs["CvFunc"].ConstexprKind, Is.EqualTo(CX_ConstexprSpecKind.CX_CSK_Consteval));
+        Assert.That(funcs["CvFunc"].IsConstexpr, Is.True);
+        Assert.That(funcs["CvFunc"].IsConsteval, Is.True);
+
+        Assert.That(funcs["PlainFunc"].ConstexprKind, Is.EqualTo(CX_ConstexprSpecKind.CX_CSK_Unspecified));
+        Assert.That(funcs["PlainFunc"].IsConstexpr, Is.False);
+        Assert.That(funcs["PlainFunc"].IsConsteval, Is.False);
+    }
+
+    [Test]
+    public void VarInitStyleTest()
+    {
+        var inputContents = """
+void f()
+{
+    int cinit = 0;
+    int listinit{0};
+    int callinit(0);
+}
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var func = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>()
+                                  .Single((functionDecl) => functionDecl.Name.Equals("f", StringComparison.Ordinal));
+        var vars = func.CursorChildren.OfType<CompoundStmt>().Single()
+                       .Children.OfType<DeclStmt>()
+                       .Select((declStmt) => (VarDecl)declStmt.SingleDecl!)
+                       .ToDictionary((varDecl) => varDecl.Name, StringComparer.Ordinal);
+
+        Assert.That(vars["cinit"].InitStyle, Is.EqualTo(CX_InitializationStyle.CX_IS_CInit));
+        Assert.That(vars["listinit"].InitStyle, Is.EqualTo(CX_InitializationStyle.CX_IS_ListInit));
+        Assert.That(vars["callinit"].InitStyle, Is.EqualTo(CX_InitializationStyle.CX_IS_CallInit));
+    }
+
 
     [Test]
     public void QualifiedNameTest()

--- a/tests/ClangSharp.UnitTests/CursorTests/StmtTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/StmtTest.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Linq;
+using ClangSharp.Interop;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+public sealed class StmtTest : TranslationUnitTest
+{
+    [Test]
+    public void IfStmtStatementKindTest()
+    {
+        var inputContents = """
+void f(int x)
+{
+    if (x) { }
+    if constexpr (sizeof(int) == 4) { }
+}
+""";
+
+        string[] commandLineArgs = ["-std=c++20", "-Wno-pragma-once-outside-header"];
+        using var translationUnit = CreateTranslationUnit(inputContents, commandLineArgs: commandLineArgs);
+
+        var func = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>()
+                                  .Single((functionDecl) => functionDecl.Name.Equals("f", StringComparison.Ordinal));
+        var ifStmts = func.CursorChildren.OfType<CompoundStmt>().Single()
+                          .Children.OfType<IfStmt>()
+                          .ToArray();
+
+        Assert.That(ifStmts, Has.Length.EqualTo(2));
+
+        Assert.That(ifStmts[0].StatementKind, Is.EqualTo(CX_IfStatementKind.CX_ISK_Ordinary));
+        Assert.That(ifStmts[0].IsConstexpr, Is.False);
+
+        Assert.That(ifStmts[1].StatementKind, Is.EqualTo(CX_IfStatementKind.CX_ISK_Constexpr));
+        Assert.That(ifStmts[1].IsConstexpr, Is.True);
+    }
+}

--- a/tests/ClangSharp.UnitTests/ExprTest.cs
+++ b/tests/ClangSharp.UnitTests/ExprTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Linq;
+using ClangSharp.Interop;
 using NUnit.Framework;
 
 namespace ClangSharp.UnitTests;
@@ -29,30 +30,73 @@ public sealed class ExprTest : TranslationUnitTest
         return null;
     }
 
+    private static void CollectDescendants<T>(Cursor cursor, System.Collections.Generic.List<T> results)
+        where T : Cursor
+    {
+        if (cursor is T match)
+        {
+            results.Add(match);
+        }
+
+        foreach (var child in cursor.CursorChildren)
+        {
+            CollectDescendants(child, results);
+        }
+    }
+
     [Test]
     public void LambdaExprTest()
     {
         var inputContents = """
-auto mutableLambda = [](int x) mutable { return x; };
-auto constLambda = [](int x) { return x; };
+void f()
+{
+    int gInt = 0;
+    auto mutableLambda = [](int x) mutable { return x; };
+    auto constLambda = [](int x) { return x; };
+    auto genericLambda = [](auto x) { return x; };
+    auto byCopyLambda = [=]() { return gInt; };
+    auto byRefLambda = [&]() { return gInt; };
+}
 """;
 
         using var translationUnit = CreateTranslationUnit(inputContents, commandLineArgs: Cpp20CommandLineArgs);
 
-        var vars = translationUnit.TranslationUnitDecl.Decls.OfType<VarDecl>()
-                                  .ToDictionary((varDecl) => varDecl.Name, StringComparer.Ordinal);
+        var func = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>()
+                                   .Single((functionDecl) => functionDecl.Name.Equals("f", StringComparison.Ordinal));
+
+        var varDecls = new System.Collections.Generic.List<VarDecl>();
+        CollectDescendants(func, varDecls);
+        var vars = varDecls.Where((varDecl) => varDecl is not ParmVarDecl)
+                           .ToDictionary((varDecl) => varDecl.Name, StringComparer.Ordinal);
 
         var mutableLambda = FindDescendant<LambdaExpr>(vars["mutableLambda"].Init);
         var constLambda = FindDescendant<LambdaExpr>(vars["constLambda"].Init);
+        var genericLambda = FindDescendant<LambdaExpr>(vars["genericLambda"].Init);
+        var byCopyLambda = FindDescendant<LambdaExpr>(vars["byCopyLambda"].Init);
+        var byRefLambda = FindDescendant<LambdaExpr>(vars["byRefLambda"].Init);
 
         Assert.That(mutableLambda, Is.Not.Null);
         Assert.That(constLambda, Is.Not.Null);
+        Assert.That(genericLambda, Is.Not.Null);
+        Assert.That(byCopyLambda, Is.Not.Null);
+        Assert.That(byRefLambda, Is.Not.Null);
 
         Assert.That(mutableLambda!.CallOperator, Is.Not.Null);
         Assert.That(mutableLambda.CallOperator.Name, Is.EqualTo("operator()"));
+        Assert.That(mutableLambda.LambdaClass, Is.EqualTo(mutableLambda.Type.AsCXXRecordDecl));
 
         Assert.That(mutableLambda.IsMutable, Is.True);
         Assert.That(constLambda!.IsMutable, Is.False);
+
+        Assert.That(mutableLambda.IsGenericLambda, Is.False);
+        Assert.That(genericLambda!.IsGenericLambda, Is.True);
+
+        Assert.That(mutableLambda.IsCapturelessLambda, Is.True);
+        Assert.That(byCopyLambda!.IsCapturelessLambda, Is.False);
+
+        Assert.That(mutableLambda.CaptureDefault, Is.EqualTo(CX_LambdaCaptureDefault.CX_LCD_None));
+        Assert.That(byCopyLambda.CaptureDefault, Is.EqualTo(CX_LambdaCaptureDefault.CX_LCD_ByCopy));
+        Assert.That(byRefLambda!.CaptureDefault, Is.EqualTo(CX_LambdaCaptureDefault.CX_LCD_ByRef));
     }
 
     [Test]


### PR DESCRIPTION
Surfaces newly-reachable clang 22 AST accessors on the mid- and high-level managed layers now that the v22 libClangSharp port (#805) has landed. Managed-only; no native or generated-binding changes.

----------

**LambdaExpr cluster** -- adds `LambdaClass`, `CaptureDefault`, `IsGenericLambda`, and `IsCapturelessLambda`, all routed through the lambda's `CXXRecordDecl` (where the native predicates dispatch). Capture *enumeration* is intentionally not surfaced: the `getNumCaptures`/`getCapturesCXXThis`/`getCaptureKind`/`getCapturedVar` bridges dispatch only on `BlockDecl`/`CapturedStmt`, never on the `LambdaExpr`, so exposing them would need new native shims.

**CXXRecordDecl structural predicates** -- 10 `Is*` (aggregate, empty, polymorphic, trivial, standard-layout, ...) and 9 `Has*` special-member/field flags. The native shims already guard on `getDefinition()`, so these are well-defined (return `false`) on incomplete types.

**constexpr family** -- `FunctionDecl.ConstexprKind` (plus derived `IsConstexpr`/`IsConsteval`), `VarDecl.InitStyle`, and `IfStmt.StatementKind`. `VarDecl.isConstexpr` has no bridge so it stays unsurfaced; the existing `IfStmt`-scoped `Cursor.IsConstexpr` is unchanged.

Each cluster forwards through a new mid-layer `CXCursor` accessor (25 total). Interop tests cover all three; full suite green, 0 warnings.

> [!NOTE]
> Authored with Copilot.
