### PR TITLE
Surface the clang 22 Type classification and exception-spec accessors

### DIFF
--- a/sources/ClangSharp.Interop/Extensions/CXType.cs
+++ b/sources/ClangSharp.Interop/Extensions/CXType.cs
@@ -57,6 +57,14 @@ public unsafe partial struct CXType : IEquatable<CXType>
 
     public readonly CXCallingConv FunctionTypeCallingConv => clang.getFunctionTypeCallingConv(this);
 
+    public readonly bool HasFloatingRepresentation => clangsharp.Type_getHasFloatingRepresentation(this) != 0;
+
+    public readonly bool HasIntegerRepresentation => clangsharp.Type_getHasIntegerRepresentation(this) != 0;
+
+    public readonly bool HasPointerRepresentation => clangsharp.Type_getHasPointerRepresentation(this) != 0;
+
+    public readonly bool HasTrailingReturn => clangsharp.Type_getHasTrailingReturn(this) != 0;
+
     public readonly int Index => clangsharp.Type_getIndex(this);
 
     public readonly CXType InjectedSpecializationType => (kind != CXType_Invalid) ? clangsharp.Type_getInjectedSpecializationType(this) : default;
@@ -65,15 +73,33 @@ public unsafe partial struct CXType : IEquatable<CXType>
 
     public readonly bool IsCanonical => Equals(CanonicalType);
 
+    public readonly bool IsAggregateType => clangsharp.Type_getIsAggregateType(this) != 0;
+
+    public readonly bool IsArithmeticType => clangsharp.Type_getIsArithmeticType(this) != 0;
+
     public readonly bool IsConstQualified => clang.isConstQualifiedType(this) != 0;
+
+    public readonly bool IsConstrained => clangsharp.Type_getIsConstrained(this) != 0;
+
+    public readonly bool IsDecltypeAuto => clangsharp.Type_getIsDecltypeAuto(this) != 0;
+
+    public readonly bool IsFloatingType => clangsharp.Type_getIsFloatingType(this) != 0;
 
     public readonly bool IsFunctionTypeVariadic => clang.isFunctionTypeVariadic(this) != 0;
 
+    public readonly bool IsGNUAutoType => clangsharp.Type_getIsGNUAutoType(this) != 0;
+
     public readonly bool IsObjCInstanceType => (kind != CXType_Invalid) && clangsharp.Type_getIsObjCInstanceType(this) != 0;
+
+    public readonly bool IsObjectType => clangsharp.Type_getIsObjectType(this) != 0;
 
     public readonly bool IsPODType => clang.isPODType(this) != 0;
 
+    public readonly bool IsRealFloatingType => clangsharp.Type_getIsRealFloatingType(this) != 0;
+
     public readonly bool IsRestrictQualified => clang.isRestrictQualifiedType(this) != 0;
+
+    public readonly bool IsScalarType => clangsharp.Type_getIsScalarType(this) != 0;
 
     public readonly bool IsSigned => clangsharp.Type_getIsSigned(this) != 0;
 
@@ -94,6 +120,8 @@ public unsafe partial struct CXType : IEquatable<CXType>
     public readonly CXType ModifiedType => clangsharp.Type_getModifiedType(this);
 
     public readonly CXType NamedType => clang.Type_getNamedType(this);
+
+    public readonly CXCursor NoexceptExpr => clangsharp.Type_getNoexceptExpr(this);
 
     public readonly CXType NonReferenceType => (kind != CXType_Invalid) ? clang.getNonReferenceType(this) : default;
 
@@ -231,6 +259,8 @@ public unsafe partial struct CXType : IEquatable<CXType>
 
     public readonly CXType ValueType => clang.Type_getValueType(this);
 
+    public readonly CX_VectorKind VectorKind => clangsharp.Type_getVectorKind(this);
+
     internal readonly string DebuggerDisplayString => $"{TypeClassSpelling}: {this}";
 
     public static bool operator ==(CXType left, CXType right) => clang.equalTypes(left, right) != 0;
@@ -242,6 +272,8 @@ public unsafe partial struct CXType : IEquatable<CXType>
     public readonly bool Equals(CXType other) => this == other;
 
     public readonly CXType GetArgType(uint i) => clang.getArgType(this, i);
+
+    public readonly CXType GetExceptionType(uint i) => clangsharp.Type_getExceptionType(this, i);
 
     public override int GetHashCode() => HashCode.Combine(kind, (IntPtr)data[0], (IntPtr)data[1]);
 

--- a/sources/ClangSharp/Types/AutoType.cs
+++ b/sources/ClangSharp/Types/AutoType.cs
@@ -18,6 +18,12 @@ public sealed class AutoType : DeducedType
 
     public IReadOnlyList<TemplateArgument> Args => _templateArgs;
 
+    public bool IsConstrained => Handle.IsConstrained;
+
+    public bool IsDecltypeAuto => Handle.IsDecltypeAuto;
+
+    public bool IsGNUAutoType => Handle.IsGNUAutoType;
+
     public CX_AutoTypeKeyword Keyword => Handle.AutoTypeKeyword;
 
     private static unsafe TemplateArgument TemplateArgsFactory(object self, int i)

--- a/sources/ClangSharp/Types/FunctionProtoType.cs
+++ b/sources/ClangSharp/Types/FunctionProtoType.cs
@@ -10,21 +10,29 @@ namespace ClangSharp;
 public sealed class FunctionProtoType : FunctionType
 {
     private readonly LazyList<Type> _paramTypes;
+    private ValueLazy<FunctionProtoType, Expr> _noexceptExpr;
 
     internal unsafe FunctionProtoType(CXType handle) : base(handle, CXType_FunctionProto, CX_TypeClass_FunctionProto)
     {
         _paramTypes = LazyList.Create<Type>(this, Handle.NumArgTypes, &ParamTypesFactory);
+        _noexceptExpr = new ValueLazy<FunctionProtoType, Expr>(&NoexceptExprFactory);
     }
 
     public CXCursor_ExceptionSpecificationKind ExceptionSpecType => Handle.ExceptionSpecificationType;
 
+    public bool HasTrailingReturn => Handle.HasTrailingReturn;
+
     public bool IsVariadic => Handle.IsFunctionTypeVariadic;
+
+    public Expr? NoexceptExpr => _noexceptExpr.GetValue(this);
 
     public uint NumParams => (uint)Handle.NumArgTypes;
 
     public IReadOnlyList<Type> ParamTypes => _paramTypes;
 
     public CXRefQualifierKind RefQualifier => Handle.CXXRefQualifier;
+
+    private static unsafe Expr NoexceptExprFactory(FunctionProtoType self) => self.TranslationUnit.GetOrCreate<Expr>(self.Handle.NoexceptExpr);
 
     private static unsafe Type ParamTypesFactory(object self, int i)
     {

--- a/sources/ClangSharp/Types/Type.cs
+++ b/sources/ClangSharp/Types/Type.cs
@@ -102,7 +102,17 @@ public unsafe class Type : IEquatable<Type>
 
     public CXType Handle { get; }
 
+    public bool HasFloatingRepresentation => Handle.HasFloatingRepresentation;
+
+    public bool HasIntegerRepresentation => Handle.HasIntegerRepresentation;
+
+    public bool HasPointerRepresentation => Handle.HasPointerRepresentation;
+
+    public bool IsAggregateType => Handle.IsAggregateType;
+
     public bool IsAnyPointerType => IsPointerType || IsObjCObjectPointerType;
+
+    public bool IsArithmeticType => Handle.IsArithmeticType;
 
     public bool IsArrayType => CanonicalType is ArrayType;
 
@@ -119,6 +129,8 @@ public unsafe class Type : IEquatable<Type>
     public bool IsDependentType => (Dependence & CX_TD_Dependent) != 0;
 
     public bool IsEnumeralType => CanonicalType is EnumType;
+
+    public bool IsFloatingType => Handle.IsFloatingType;
 
     public bool IsFunctionType => CanonicalType is FunctionType;
 
@@ -154,15 +166,21 @@ public unsafe class Type : IEquatable<Type>
 
     public bool IsObjCObjectPointerType => CanonicalType is ObjCObjectPointerType;
 
+    public bool IsObjectType => Handle.IsObjectType;
+
     public bool IsPODType => Handle.IsPODType;
 
     public bool IsPointerType => CanonicalType is PointerType;
 
     public bool IsRValueReferenceType => CanonicalType is RValueReferenceType;
 
+    public bool IsRealFloatingType => Handle.IsRealFloatingType;
+
     public bool IsRecordType => CanonicalType is RecordType;
 
     public bool IsReferenceType => CanonicalType is ReferenceType;
+
+    public bool IsScalarType => Handle.IsScalarType;
 
     public bool IsSugared => Handle.IsSugared;
 

--- a/sources/ClangSharp/Types/VectorType.cs
+++ b/sources/ClangSharp/Types/VectorType.cs
@@ -23,5 +23,7 @@ public class VectorType : Type
 
     public long NumElements => Handle.NumElements;
 
+    public CX_VectorKind VectorKind => Handle.VectorKind;
+
     private static unsafe Type ElementTypeFactory(VectorType self) => self.TranslationUnit.GetOrCreate<Type>(self.Handle.ElementType);
 }

--- a/tests/ClangSharp.UnitTests/TypeTest.cs
+++ b/tests/ClangSharp.UnitTests/TypeTest.cs
@@ -272,4 +272,125 @@ template <typename T> auto Deduced(T value);
 
         Assert.That(autoType.Keyword, Is.EqualTo(CX_AutoTypeKeyword.CX_ATK_Auto));
     }
+
+    [Test]
+    public void ClassificationPredicatesTest()
+    {
+        var inputContents = """
+struct S { int field; };
+
+using IntT = int;
+using FloatT = float;
+using PtrT = int*;
+using StructT = S;
+using VoidT = void;
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var typedefs = translationUnit.TranslationUnitDecl.Decls.OfType<TypedefNameDecl>()
+                                      .ToDictionary((typedef) => typedef.Name, (typedef) => typedef.UnderlyingType, StringComparer.Ordinal);
+
+        var intT = typedefs["IntT"];
+        Assert.That(intT.IsScalarType, Is.True);
+        Assert.That(intT.IsArithmeticType, Is.True);
+        Assert.That(intT.IsObjectType, Is.True);
+        Assert.That(intT.IsAggregateType, Is.False);
+        Assert.That(intT.IsFloatingType, Is.False);
+        Assert.That(intT.HasIntegerRepresentation, Is.True);
+        Assert.That(intT.HasPointerRepresentation, Is.False);
+
+        var floatT = typedefs["FloatT"];
+        Assert.That(floatT.IsFloatingType, Is.True);
+        Assert.That(floatT.IsRealFloatingType, Is.True);
+        Assert.That(floatT.IsArithmeticType, Is.True);
+        Assert.That(floatT.HasFloatingRepresentation, Is.True);
+        Assert.That(floatT.HasIntegerRepresentation, Is.False);
+
+        var ptrT = typedefs["PtrT"];
+        Assert.That(ptrT.IsScalarType, Is.True);
+        Assert.That(ptrT.IsArithmeticType, Is.False);
+        Assert.That(ptrT.IsObjectType, Is.True);
+        Assert.That(ptrT.HasPointerRepresentation, Is.True);
+
+        var structT = typedefs["StructT"];
+        Assert.That(structT.IsAggregateType, Is.True);
+        Assert.That(structT.IsScalarType, Is.False);
+        Assert.That(structT.IsObjectType, Is.True);
+
+        var voidT = typedefs["VoidT"];
+        Assert.That(voidT.IsObjectType, Is.False);
+        Assert.That(voidT.IsScalarType, Is.False);
+    }
+
+    [Test]
+    public void VectorKindTest()
+    {
+        var inputContents = """
+using VecT = int __attribute__((vector_size(16)));
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var vecT = translationUnit.TranslationUnitDecl.Decls.OfType<TypedefNameDecl>().Single((typedef) => typedef.Name.Equals("VecT", StringComparison.Ordinal)).UnderlyingType;
+        var vectorType = (VectorType)vecT.CanonicalType;
+
+        Assert.That(vectorType.VectorKind, Is.EqualTo(CX_VectorKind.CX_VECK_Generic));
+    }
+
+    [Test]
+    public void FunctionProtoTypeTest()
+    {
+        var inputContents = """
+int simple();
+auto trailing() -> int;
+void noThrow() noexcept;
+template <typename T> void mayThrow() noexcept(sizeof(T) > 1);
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var functions = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>()
+                                       .ToDictionary((functionDecl) => functionDecl.Name, (functionDecl) => (FunctionProtoType)functionDecl.Type, StringComparer.Ordinal);
+
+        var simple = functions["simple"];
+        Assert.That(simple.HasTrailingReturn, Is.False);
+        Assert.That(simple.ExceptionSpecType, Is.EqualTo(CXCursor_ExceptionSpecificationKind.CXCursor_ExceptionSpecificationKind_None));
+        Assert.That(simple.NoexceptExpr, Is.Null);
+
+        Assert.That(functions["trailing"].HasTrailingReturn, Is.True);
+
+        var noThrow = functions["noThrow"];
+        Assert.That(noThrow.ExceptionSpecType, Is.EqualTo(CXCursor_ExceptionSpecificationKind.CXCursor_ExceptionSpecificationKind_BasicNoexcept));
+        Assert.That(noThrow.NoexceptExpr, Is.Null);
+
+        var mayThrow = (FunctionProtoType)translationUnit.TranslationUnitDecl.Decls.OfType<FunctionTemplateDecl>().Single().TemplatedDecl.Type;
+        Assert.That(mayThrow.NoexceptExpr, Is.Not.Null);
+    }
+
+    [Test]
+    public void AutoTypePredicatesTest()
+    {
+        var inputContents = """
+template <typename T> auto Plain(T value);
+template <typename T> decltype(auto) Decltype(T value);
+template <typename T> concept Small = sizeof(T) > 0;
+template <typename T> Small auto Constrained(T value);
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents, commandLineArgs: Cpp20CommandLineArgs);
+
+        var autoTypes = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionTemplateDecl>()
+                                       .ToDictionary((template) => template.Name, (template) => (AutoType)template.TemplatedDecl.ReturnType, StringComparer.Ordinal);
+
+        var plain = autoTypes["Plain"];
+        Assert.That(plain.IsConstrained, Is.False);
+        Assert.That(plain.IsDecltypeAuto, Is.False);
+        Assert.That(plain.IsGNUAutoType, Is.False);
+
+        Assert.That(autoTypes["Decltype"].IsDecltypeAuto, Is.True);
+        Assert.That(autoTypes["Constrained"].IsConstrained, Is.True);
+    }
+
+    private static readonly string[] Cpp20CommandLineArgs = ["-std=c++20", "-Wno-pragma-once-outside-header"];
 }


### PR DESCRIPTION
Surfaces the clang 22 `Type`-side classification predicates and `FunctionProtoType` exception-spec accessors on the managed AST, now that the v22 libClangSharp port bridges them. Managed-only; no native or generated-binding changes. Complements the cursor-side predicates from #808.

----------

**Type classifiers** -- `IsScalarType`, `IsArithmeticType`, `IsFloatingType`, `IsRealFloatingType`, `IsAggregateType`, `IsObjectType`, plus the `HasPointerRepresentation`/`HasIntegerRepresentation`/`HasFloatingRepresentation` flags. These dispatch on the generic `Type`, so they live on `Type` and forward through new mid-layer `CXType` accessors.

**AutoType** -- `IsConstrained`, `IsDecltypeAuto`, `IsGNUAutoType`.

**VectorType** -- `VectorKind` (`CX_VectorKind`).

**FunctionProtoType** -- `HasTrailingReturn` and `NoexceptExpr`. `ExceptionSpecType` was already surfaced.

The per-exception `getExceptionType(i)` enumeration is intentionally not surfaced: it's guarded natively by `getNumExceptions()`, but no count bridge is exposed today, so a clean list would need a new native shim.

Interop tests cover the classifiers, `AutoType` predicates, `VectorKind`, and the `FunctionProtoType` set; full suite green, 0 warnings.

> [!NOTE]
> Authored with Copilot.
