### PR TITLE
Surface inline-asm statement API on AsmStmt/GCCAsmStmt/MSAsmStmt

### DIFF
--- a/sources/ClangSharp.Interop/Extensions/CXCursor.cs
+++ b/sources/ClangSharp.Interop/Extensions/CXCursor.cs
@@ -23,6 +23,10 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly CXCursor AsFunction => clangsharp.Cursor_getAsFunction(this);
 
+    public readonly CXString AsmString => clangsharp.Cursor_getAsmString(this);
+
+    public readonly CXCursor AsmStringExpr => clangsharp.Cursor_getAsmStringExpr(this);
+
     public readonly CX_AtomicOperatorKind AtomicOperatorKind => clangsharp.Cursor_getAtomicOpcode(this);
 
     public readonly CX_AttrKind AttrKind => clangsharp.Cursor_getAttrKind(this);
@@ -995,6 +999,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly bool HasAttrs => clang.Cursor_hasAttrs(this) != 0;
 
+    public readonly bool HasBraces => clangsharp.Cursor_getHasBraces(this) != 0;
+
     public readonly bool HasBody => clangsharp.Cursor_getHasBody(this) != 0;
 
     public readonly bool HasDefaultArg => clangsharp.Cursor_getHasDefaultArg(this) != 0;
@@ -1106,6 +1112,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly bool IsArrayFormAsWritten => clangsharp.Cursor_getIsArrayFormAsWritten(this) != 0;
 
     public readonly bool IsArrow => clangsharp.Cursor_getIsArrow(this) != 0;
+
+    public readonly bool IsAsmGoto => clangsharp.Cursor_getIsAsmGoto(this) != 0;
 
     public readonly bool IsAttribute => clang.isAttribute(Kind) != 0;
 
@@ -1241,6 +1249,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly bool IsSigned => clangsharp.Cursor_getIsSigned(this) != 0;
 
+    public readonly bool IsSimple => clangsharp.Cursor_getIsSimple(this) != 0;
+
     public readonly bool IsStatement => clang.isStatement(Kind) != 0;
 
     public readonly bool IsStatic => clangsharp.Cursor_getIsStatic(this) != 0;
@@ -1284,6 +1294,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly bool IsVariadic => clangsharp.Cursor_getIsVariadic(this) != 0;
 
     public readonly bool IsVirtualBase => clang.isVirtualBase(this) != 0;
+
+    public readonly bool IsVolatile => clangsharp.Cursor_getIsVolatile(this) != 0;
 
     public readonly CXCursorKind Kind => clang.getCursorKind(this);
 
@@ -1345,6 +1357,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly int NumChildren => clangsharp.Cursor_getNumChildren(this);
 
+    public readonly uint NumClobbers => clangsharp.Cursor_getNumClobbers(this);
+
     public readonly int NumCtors => clangsharp.Cursor_getNumCtors(this);
 
     public readonly int NumDecls => clangsharp.Cursor_getNumDecls(this);
@@ -1361,7 +1375,13 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly int NumFriends => clangsharp.Cursor_getNumFriends(this);
 
+    public readonly uint NumInputs => clangsharp.Cursor_getNumInputs(this);
+
+    public readonly uint NumLabels => clangsharp.Cursor_getNumLabels(this);
+
     public readonly int NumMethods => clangsharp.Cursor_getNumMethods(this);
+
+    public readonly uint NumOutputs => clangsharp.Cursor_getNumOutputs(this);
 
     public readonly uint NumOverloadedDecls => clang.getNumOverloadedDecls(this);
 
@@ -1951,6 +1971,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly CXCursor GetChild(uint index) => clangsharp.Cursor_getChild(this, index);
 
+    public readonly CXString GetClobber(uint index) => clangsharp.Cursor_getClobber(this, index);
+
     public readonly CXCursor GetDecl(uint index) => clangsharp.Cursor_getDecl(this, index);
 
     public readonly void GetDefinitionSpellingAndExtent(out string spelling, out uint startLine, out uint startColumn, out uint endLine, out uint endColumn)
@@ -1977,6 +1999,14 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly CXCursor GetFriend(uint index) => clangsharp.Cursor_getFriend(this, index);
 
+    public readonly CXString GetInputConstraint(uint index) => clangsharp.Cursor_getInputConstraint(this, index);
+
+    public readonly CXCursor GetInputExpr(uint index) => clangsharp.Cursor_getInputExpr(this, index);
+
+    public readonly CXCursor GetLabelExpr(uint index) => clangsharp.Cursor_getLabelExpr(this, index);
+
+    public readonly CXString GetLabelName(uint index) => clangsharp.Cursor_getLabelName(this, index);
+
     public override readonly int GetHashCode() => (int)Hash;
 
     public readonly bool GetIsExternalSymbol(out CXString language, out CXString definedIn, out bool isGenerated)
@@ -2000,6 +2030,10 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly ObjCPropertyAttributeKind GetPropertyAttributes() => (ObjCPropertyAttributeKind)clangsharp.Cursor_getPropertyAttributes(this);
 
     public readonly CXCursor GetOverloadedDecl(uint index) => clang.getOverloadedDecl(this, index);
+
+    public readonly CXString GetOutputConstraint(uint index) => clangsharp.Cursor_getOutputConstraint(this, index);
+
+    public readonly CXCursor GetOutputExpr(uint index) => clangsharp.Cursor_getOutputExpr(this, index);
 
     public readonly int GetPlatformAvailability(out bool alwaysDeprecated, out CXString deprecatedMessage, out bool alwaysUnavailable, out CXString unavailableMessage, Span<CXPlatformAvailability> availability)
     {

--- a/sources/ClangSharp/Cursors/Stmts/AsmStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/AsmStmt.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
 using System;
+using System.Collections.Generic;
 using ClangSharp.Interop;
 using static ClangSharp.Interop.CX_StmtClass;
 
@@ -8,11 +9,41 @@ namespace ClangSharp;
 
 public class AsmStmt : Stmt
 {
-    private protected AsmStmt(CXCursor handle, CXCursorKind expectedCursorKind, CX_StmtClass expectedStmtClass) : base(handle, expectedCursorKind, expectedStmtClass)
+    private readonly LazyList<string> _clobbers;
+    private readonly LazyList<string> _inputConstraints;
+    private readonly LazyList<string> _outputConstraints;
+
+    private protected unsafe AsmStmt(CXCursor handle, CXCursorKind expectedCursorKind, CX_StmtClass expectedStmtClass) : base(handle, expectedCursorKind, expectedStmtClass)
     {
         if (handle.StmtClass is > CX_StmtClass_LastAsmStmt or < CX_StmtClass_FirstAsmStmt)
         {
             throw new ArgumentOutOfRangeException(nameof(handle));
         }
+
+        _clobbers = LazyList.Create<string>(this, (int)Handle.NumClobbers, &ClobbersFactory);
+        _inputConstraints = LazyList.Create<string>(this, (int)Handle.NumInputs, &InputConstraintsFactory);
+        _outputConstraints = LazyList.Create<string>(this, (int)Handle.NumOutputs, &OutputConstraintsFactory);
     }
+
+    public IReadOnlyList<string> Clobbers => _clobbers;
+
+    public IReadOnlyList<string> InputConstraints => _inputConstraints;
+
+    public bool IsSimple => Handle.IsSimple;
+
+    public bool IsVolatile => Handle.IsVolatile;
+
+    public uint NumClobbers => Handle.NumClobbers;
+
+    public uint NumInputs => Handle.NumInputs;
+
+    public uint NumOutputs => Handle.NumOutputs;
+
+    public IReadOnlyList<string> OutputConstraints => _outputConstraints;
+
+    private static string ClobbersFactory(object self, int i) => ((AsmStmt)self).Handle.GetClobber(unchecked((uint)i)).CString;
+
+    private static string InputConstraintsFactory(object self, int i) => ((AsmStmt)self).Handle.GetInputConstraint(unchecked((uint)i)).CString;
+
+    private static string OutputConstraintsFactory(object self, int i) => ((AsmStmt)self).Handle.GetOutputConstraint(unchecked((uint)i)).CString;
 }

--- a/sources/ClangSharp/Cursors/Stmts/GCCAsmStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/GCCAsmStmt.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System.Collections.Generic;
 using ClangSharp.Interop;
 using static ClangSharp.Interop.CXCursorKind;
 using static ClangSharp.Interop.CX_StmtClass;
@@ -8,7 +9,40 @@ namespace ClangSharp;
 
 public sealed class GCCAsmStmt : AsmStmt
 {
-    internal GCCAsmStmt(CXCursor handle) : base(handle, CXCursor_GCCAsmStmt, CX_StmtClass_GCCAsmStmt)
+    private readonly LazyList<Expr> _inputExprs;
+    private readonly LazyList<Expr> _labelExprs;
+    private readonly LazyList<string> _labelNames;
+    private readonly LazyList<Expr> _outputExprs;
+
+    internal unsafe GCCAsmStmt(CXCursor handle) : base(handle, CXCursor_GCCAsmStmt, CX_StmtClass_GCCAsmStmt)
     {
+        _inputExprs = LazyList.Create<Expr>(this, (int)Handle.NumInputs, &InputExprsFactory);
+        _labelExprs = LazyList.Create<Expr>(this, (int)Handle.NumLabels, &LabelExprsFactory);
+        _labelNames = LazyList.Create<string>(this, (int)Handle.NumLabels, &LabelNamesFactory);
+        _outputExprs = LazyList.Create<Expr>(this, (int)Handle.NumOutputs, &OutputExprsFactory);
     }
+
+    public string AsmString => Handle.AsmString.CString;
+
+    public Expr AsmStringExpr => TranslationUnit.GetOrCreate<Expr>(Handle.AsmStringExpr);
+
+    public IReadOnlyList<Expr> InputExprs => _inputExprs;
+
+    public bool IsAsmGoto => Handle.IsAsmGoto;
+
+    public IReadOnlyList<Expr> LabelExprs => _labelExprs;
+
+    public IReadOnlyList<string> LabelNames => _labelNames;
+
+    public uint NumLabels => Handle.NumLabels;
+
+    public IReadOnlyList<Expr> OutputExprs => _outputExprs;
+
+    private static Expr InputExprsFactory(object self, int i) => ((GCCAsmStmt)self).TranslationUnit.GetOrCreate<Expr>(((GCCAsmStmt)self).Handle.GetInputExpr(unchecked((uint)i)));
+
+    private static Expr LabelExprsFactory(object self, int i) => ((GCCAsmStmt)self).TranslationUnit.GetOrCreate<Expr>(((GCCAsmStmt)self).Handle.GetLabelExpr(unchecked((uint)i)));
+
+    private static string LabelNamesFactory(object self, int i) => ((GCCAsmStmt)self).Handle.GetLabelName(unchecked((uint)i)).CString;
+
+    private static Expr OutputExprsFactory(object self, int i) => ((GCCAsmStmt)self).TranslationUnit.GetOrCreate<Expr>(((GCCAsmStmt)self).Handle.GetOutputExpr(unchecked((uint)i)));
 }

--- a/sources/ClangSharp/Cursors/Stmts/MSAsmStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/MSAsmStmt.cs
@@ -11,4 +11,8 @@ public sealed class MSAsmStmt : AsmStmt
     internal MSAsmStmt(CXCursor handle) : base(handle, CXCursor_MSAsmStmt, CX_StmtClass_MSAsmStmt)
     {
     }
+
+    public string AsmString => Handle.AsmString.CString;
+
+    public bool HasBraces => Handle.HasBraces;
 }

--- a/tests/ClangSharp.UnitTests/CursorTests/StmtTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/StmtTest.cs
@@ -37,4 +37,70 @@ void f(int x)
         Assert.That(ifStmts[1].StatementKind, Is.EqualTo(CX_IfStatementKind.CX_ISK_Constexpr));
         Assert.That(ifStmts[1].IsConstexpr, Is.True);
     }
+
+    [Test]
+    public void GCCAsmStmtTest()
+    {
+        var inputContents = """
+void f(int x)
+{
+    int y;
+    asm volatile ("mov %1, %0" : "=r"(y) : "r"(x) : "memory");
+}
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var func = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>()
+                                  .Single((functionDecl) => functionDecl.Name.Equals("f", StringComparison.Ordinal));
+        var asmStmt = func.CursorChildren.OfType<CompoundStmt>().Single()
+                          .Children.OfType<GCCAsmStmt>().Single();
+
+        Assert.That(asmStmt.IsSimple, Is.False);
+        Assert.That(asmStmt.IsVolatile, Is.True);
+        Assert.That(asmStmt.IsAsmGoto, Is.False);
+
+        Assert.That(asmStmt.NumOutputs, Is.EqualTo(1u));
+        Assert.That(asmStmt.OutputConstraints, Has.Count.EqualTo(1));
+        Assert.That(asmStmt.OutputConstraints[0], Is.EqualTo("=r"));
+        Assert.That(asmStmt.OutputExprs, Has.Count.EqualTo(1));
+
+        Assert.That(asmStmt.NumInputs, Is.EqualTo(1u));
+        Assert.That(asmStmt.InputConstraints, Has.Count.EqualTo(1));
+        Assert.That(asmStmt.InputConstraints[0], Is.EqualTo("r"));
+        Assert.That(asmStmt.InputExprs, Has.Count.EqualTo(1));
+
+        Assert.That(asmStmt.NumClobbers, Is.EqualTo(1u));
+        Assert.That(asmStmt.Clobbers, Has.Count.EqualTo(1));
+        Assert.That(asmStmt.Clobbers[0], Is.EqualTo("memory"));
+
+        Assert.That(asmStmt.NumLabels, Is.EqualTo(0u));
+        Assert.That(asmStmt.AsmString, Is.Not.Empty);
+    }
+
+    [Test]
+    public void GCCAsmGotoTest()
+    {
+        var inputContents = """
+void f(int x)
+{
+    asm goto ("" : : "r"(x) : : lbl);
+lbl:
+    ;
+}
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var func = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>()
+                                  .Single((functionDecl) => functionDecl.Name.Equals("f", StringComparison.Ordinal));
+        var asmStmt = func.CursorChildren.OfType<CompoundStmt>().Single()
+                          .Children.OfType<GCCAsmStmt>().Single();
+
+        Assert.That(asmStmt.IsAsmGoto, Is.True);
+        Assert.That(asmStmt.NumLabels, Is.EqualTo(1u));
+        Assert.That(asmStmt.LabelNames, Has.Count.EqualTo(1));
+        Assert.That(asmStmt.LabelNames[0], Is.EqualTo("lbl"));
+        Assert.That(asmStmt.LabelExprs, Has.Count.EqualTo(1));
+    }
 }


### PR DESCRIPTION
Surfaces the inline-asm statement API now reachable through the v22 raw-interop regen. The `AsmStmt`/`GCCAsmStmt`/`MSAsmStmt` managed classes were empty validation shells; this wires them up over the mid-layer `CXCursor` asm accessors (also added here) so the high-level layer mirrors the clang C++ AST.

- `AsmStmt` (base): `IsSimple`, `IsVolatile`, `NumInputs`/`NumOutputs`/`NumClobbers`, and the `InputConstraints`/`OutputConstraints`/`Clobbers` string lists.
- `GCCAsmStmt`: `AsmString`, `AsmStringExpr`, `IsAsmGoto`, `NumLabels`, the `InputExprs`/`OutputExprs`/`LabelExprs` operand lists, and `LabelNames`.
- `MSAsmStmt`: `AsmString`, `HasBraces`.

----------

The count-guarded indexed bridges are exposed as `IReadOnlyList<>` to match the high-level layer's convention (no `Get(i)` indexers). List members are lazily materialized via `LazyList`.

Tests: added `GCCAsmStmtTest` and `GCCAsmGotoTest` to `StmtTest` covering extended asm (outputs/inputs/clobbers/volatile) and asm-goto labels. Build 0 warnings; interop suite green (81 pass).

> [!NOTE]
> Authored with Copilot.
