### PR TITLE
Surface coroutine statement API on CoroutineBodyStmt/CoreturnStmt

### DIFF
--- a/sources/ClangSharp.Interop/Extensions/CXCursor.cs
+++ b/sources/ClangSharp.Interop/Extensions/CXCursor.cs
@@ -17,6 +17,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 {
     public static CXCursor Null => clang.getNullCursor();
 
+    public readonly CXCursor Allocate => clangsharp.Cursor_getAllocate(this);
+
     public readonly CXType ArgumentType => clangsharp.Cursor_getArgumentType(this);
 
     public readonly long ArraySize => clangsharp.Cursor_getArraySize(this);
@@ -943,6 +945,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly CXType DefaultArgType => clangsharp.Cursor_getDefaultArgType(this);
 
+    public readonly CXCursor Deallocate => clangsharp.Cursor_getDeallocate(this);
+
     public readonly CXCursor Definition => clangsharp.Cursor_getDefinition(this);
 
     public readonly CXCursor DependentLambdaCallOperator => clangsharp.Cursor_getDependentLambdaCallOperator(this);
@@ -971,11 +975,17 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly CXEvalResult Evaluate => (CXEvalResult)clang.Cursor_Evaluate(this);
 
+    public readonly CXCursor ExceptionHandler => clangsharp.Cursor_getExceptionHandler(this);
+
     public readonly int ExceptionSpecificationType => clang.getCursorExceptionSpecificationType(this);
 
     public readonly CX_ExprDependence ExprDependence => clangsharp.Cursor_getExprDependence(this);
 
     public readonly CXSourceRange Extent => clang.getCursorExtent(this);
+
+    public readonly CXCursor FallthroughHandler => clangsharp.Cursor_getFallthroughHandler(this);
+
+    public readonly CXCursor FinalSuspendStmt => clangsharp.Cursor_getFinalSuspendStmt(this);
 
     public readonly CX_FloatingSemantics FloatingLiteralSemantics => clangsharp.Cursor_getFloatingLiteralSemantics(this);
 
@@ -1006,6 +1016,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly bool HasDefaultArg => clangsharp.Cursor_getHasDefaultArg(this) != 0;
 
     public readonly bool HasDeletedDestructor => clangsharp.Cursor_getHasDeletedDestructor(this) != 0;
+
+    public readonly bool HasDependentPromiseType => clangsharp.Cursor_getHasDependentPromiseType(this) != 0;
 
     public readonly bool HasElseStorage => clangsharp.Cursor_getHasElseStorage(this) != 0;
 
@@ -1082,6 +1094,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly bool InheritedFromVBase => clangsharp.Cursor_getInheritedFromVBase(this) != 0;
 
     public readonly CXCursor InitExpr => clangsharp.Cursor_getInitExpr(this);
+
+    public readonly CXCursor InitSuspendStmt => clangsharp.Cursor_getInitSuspendStmt(this);
 
     public readonly CX_InitializationStyle InitStyle => clangsharp.Cursor_getInitStyle(this);
 
@@ -1413,6 +1427,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly CXCursor OpaqueValue => clangsharp.Cursor_getOpaqueValue(this);
 
+    public readonly CXCursor Operand => clangsharp.Cursor_getOperand(this);
+
     public readonly CXType OriginalType => clangsharp.Cursor_getOriginalType(this);
 
     public readonly CX_OverloadedOperatorKind OverloadedOperatorKind => clangsharp.Cursor_getOverloadedOperatorKind(this);
@@ -1443,6 +1459,10 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly CXPrintingPolicy PrintingPolicy => (kind != default) ? (CXPrintingPolicy)clang.getCursorPrintingPolicy(this) : default;
 
+    public readonly CXCursor PromiseCall => clangsharp.Cursor_getPromiseCall(this);
+
+    public readonly CXCursor PromiseDecl => clangsharp.Cursor_getPromiseDecl(this);
+
     public readonly CXString QualifiedName => clangsharp.Cursor_getQualifiedName(this);
 
     public readonly CXString RawCommentText => clang.Cursor_getRawCommentText(this);
@@ -1455,11 +1475,21 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly bool RequiresZeroInitialization => clangsharp.Cursor_getRequiresZeroInitialization(this) != 0;
 
+    public readonly CXCursor ResultDecl => clangsharp.Cursor_getResultDecl(this);
+
     public readonly int ResultIndex => clangsharp.Cursor_getResultIndex(this);
 
     public readonly CXType ResultType => clang.getCursorResultType(this);
 
+    public readonly CXCursor ReturnStmt => clangsharp.Cursor_getReturnStmt(this);
+
+    public readonly CXCursor ReturnStmtOnAllocFailure => clangsharp.Cursor_getReturnStmtOnAllocFailure(this);
+
     public readonly CXType ReturnType => clangsharp.Cursor_getReturnType(this);
+
+    public readonly CXCursor ReturnValue => clangsharp.Cursor_getReturnValue(this);
+
+    public readonly CXCursor ReturnValueInit => clangsharp.Cursor_getReturnValueInit(this);
 
     public readonly CXCursor RhsExpr => clangsharp.Cursor_getRhsExpr(this);
 

--- a/sources/ClangSharp/Cursors/Stmts/CoreturnStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/CoreturnStmt.cs
@@ -8,7 +8,22 @@ namespace ClangSharp;
 
 public sealed class CoreturnStmt : Stmt
 {
-    internal CoreturnStmt(CXCursor handle) : base(handle, CXCursor_UnexposedStmt, CX_StmtClass_CoreturnStmt)
+    private ValueLazy<CoreturnStmt, Expr> _operand;
+    private ValueLazy<CoreturnStmt, Expr> _promiseCall;
+
+    internal unsafe CoreturnStmt(CXCursor handle) : base(handle, CXCursor_UnexposedStmt, CX_StmtClass_CoreturnStmt)
     {
+        _operand = new ValueLazy<CoreturnStmt, Expr>(&OperandFactory);
+        _promiseCall = new ValueLazy<CoreturnStmt, Expr>(&PromiseCallFactory);
     }
+
+    public bool IsImplicit => Handle.IsImplicit;
+
+    public Expr Operand => _operand.GetValue(this);
+
+    public Expr PromiseCall => _promiseCall.GetValue(this);
+
+    private static Expr OperandFactory(CoreturnStmt self) => self.TranslationUnit.GetOrCreate<Expr>(self.Handle.Operand);
+
+    private static Expr PromiseCallFactory(CoreturnStmt self) => self.TranslationUnit.GetOrCreate<Expr>(self.Handle.PromiseCall);
 }

--- a/sources/ClangSharp/Cursors/Stmts/CoroutineBodyStmt.cs
+++ b/sources/ClangSharp/Cursors/Stmts/CoroutineBodyStmt.cs
@@ -8,7 +8,88 @@ namespace ClangSharp;
 
 public sealed class CoroutineBodyStmt : Stmt
 {
-    internal CoroutineBodyStmt(CXCursor handle) : base(handle, CXCursor_UnexposedStmt, CX_StmtClass_CoroutineBodyStmt)
+    private ValueLazy<CoroutineBodyStmt, Expr> _allocate;
+    private ValueLazy<CoroutineBodyStmt, CompoundStmt> _body;
+    private ValueLazy<CoroutineBodyStmt, Expr> _deallocate;
+    private ValueLazy<CoroutineBodyStmt, Stmt> _exceptionHandler;
+    private ValueLazy<CoroutineBodyStmt, Stmt> _fallthroughHandler;
+    private ValueLazy<CoroutineBodyStmt, Stmt> _finalSuspendStmt;
+    private ValueLazy<CoroutineBodyStmt, Stmt> _initSuspendStmt;
+    private ValueLazy<CoroutineBodyStmt, VarDecl> _promiseDecl;
+    private ValueLazy<CoroutineBodyStmt, Stmt> _resultDecl;
+    private ValueLazy<CoroutineBodyStmt, Stmt> _returnStmt;
+    private ValueLazy<CoroutineBodyStmt, Stmt> _returnStmtOnAllocFailure;
+    private ValueLazy<CoroutineBodyStmt, Expr> _returnValue;
+    private ValueLazy<CoroutineBodyStmt, Expr> _returnValueInit;
+
+    internal unsafe CoroutineBodyStmt(CXCursor handle) : base(handle, CXCursor_UnexposedStmt, CX_StmtClass_CoroutineBodyStmt)
     {
+        _allocate = new ValueLazy<CoroutineBodyStmt, Expr>(&AllocateFactory);
+        _body = new ValueLazy<CoroutineBodyStmt, CompoundStmt>(&BodyFactory);
+        _deallocate = new ValueLazy<CoroutineBodyStmt, Expr>(&DeallocateFactory);
+        _exceptionHandler = new ValueLazy<CoroutineBodyStmt, Stmt>(&ExceptionHandlerFactory);
+        _fallthroughHandler = new ValueLazy<CoroutineBodyStmt, Stmt>(&FallthroughHandlerFactory);
+        _finalSuspendStmt = new ValueLazy<CoroutineBodyStmt, Stmt>(&FinalSuspendStmtFactory);
+        _initSuspendStmt = new ValueLazy<CoroutineBodyStmt, Stmt>(&InitSuspendStmtFactory);
+        _promiseDecl = new ValueLazy<CoroutineBodyStmt, VarDecl>(&PromiseDeclFactory);
+        _resultDecl = new ValueLazy<CoroutineBodyStmt, Stmt>(&ResultDeclFactory);
+        _returnStmt = new ValueLazy<CoroutineBodyStmt, Stmt>(&ReturnStmtFactory);
+        _returnStmtOnAllocFailure = new ValueLazy<CoroutineBodyStmt, Stmt>(&ReturnStmtOnAllocFailureFactory);
+        _returnValue = new ValueLazy<CoroutineBodyStmt, Expr>(&ReturnValueFactory);
+        _returnValueInit = new ValueLazy<CoroutineBodyStmt, Expr>(&ReturnValueInitFactory);
     }
+
+    public Expr Allocate => _allocate.GetValue(this);
+
+    public CompoundStmt Body => _body.GetValue(this);
+
+    public Expr Deallocate => _deallocate.GetValue(this);
+
+    public Stmt ExceptionHandler => _exceptionHandler.GetValue(this);
+
+    public Stmt FallthroughHandler => _fallthroughHandler.GetValue(this);
+
+    public Stmt FinalSuspendStmt => _finalSuspendStmt.GetValue(this);
+
+    public bool HasDependentPromiseType => Handle.HasDependentPromiseType;
+
+    public Stmt InitSuspendStmt => _initSuspendStmt.GetValue(this);
+
+    public VarDecl PromiseDecl => _promiseDecl.GetValue(this);
+
+    public Stmt ResultDecl => _resultDecl.GetValue(this);
+
+    public Stmt ReturnStmt => _returnStmt.GetValue(this);
+
+    public Stmt ReturnStmtOnAllocFailure => _returnStmtOnAllocFailure.GetValue(this);
+
+    public Expr ReturnValue => _returnValue.GetValue(this);
+
+    public Expr ReturnValueInit => _returnValueInit.GetValue(this);
+
+    private static Expr AllocateFactory(CoroutineBodyStmt self) => self.TranslationUnit.GetOrCreate<Expr>(self.Handle.Allocate);
+
+    private static CompoundStmt BodyFactory(CoroutineBodyStmt self) => self.TranslationUnit.GetOrCreate<CompoundStmt>(self.Handle.Body);
+
+    private static Expr DeallocateFactory(CoroutineBodyStmt self) => self.TranslationUnit.GetOrCreate<Expr>(self.Handle.Deallocate);
+
+    private static Stmt ExceptionHandlerFactory(CoroutineBodyStmt self) => self.TranslationUnit.GetOrCreate<Stmt>(self.Handle.ExceptionHandler);
+
+    private static Stmt FallthroughHandlerFactory(CoroutineBodyStmt self) => self.TranslationUnit.GetOrCreate<Stmt>(self.Handle.FallthroughHandler);
+
+    private static Stmt FinalSuspendStmtFactory(CoroutineBodyStmt self) => self.TranslationUnit.GetOrCreate<Stmt>(self.Handle.FinalSuspendStmt);
+
+    private static Stmt InitSuspendStmtFactory(CoroutineBodyStmt self) => self.TranslationUnit.GetOrCreate<Stmt>(self.Handle.InitSuspendStmt);
+
+    private static VarDecl PromiseDeclFactory(CoroutineBodyStmt self) => self.TranslationUnit.GetOrCreate<VarDecl>(self.Handle.PromiseDecl);
+
+    private static Stmt ResultDeclFactory(CoroutineBodyStmt self) => self.TranslationUnit.GetOrCreate<Stmt>(self.Handle.ResultDecl);
+
+    private static Stmt ReturnStmtFactory(CoroutineBodyStmt self) => self.TranslationUnit.GetOrCreate<Stmt>(self.Handle.ReturnStmt);
+
+    private static Stmt ReturnStmtOnAllocFailureFactory(CoroutineBodyStmt self) => self.TranslationUnit.GetOrCreate<Stmt>(self.Handle.ReturnStmtOnAllocFailure);
+
+    private static Expr ReturnValueFactory(CoroutineBodyStmt self) => self.TranslationUnit.GetOrCreate<Expr>(self.Handle.ReturnValue);
+
+    private static Expr ReturnValueInitFactory(CoroutineBodyStmt self) => self.TranslationUnit.GetOrCreate<Expr>(self.Handle.ReturnValueInit);
 }

--- a/tests/ClangSharp.UnitTests/CursorTests/StmtTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/StmtTest.cs
@@ -103,4 +103,73 @@ lbl:
         Assert.That(asmStmt.LabelNames[0], Is.EqualTo("lbl"));
         Assert.That(asmStmt.LabelExprs, Has.Count.EqualTo(1));
     }
+
+    [Test]
+    public void CoroutineBodyStmtTest()
+    {
+        var inputContents = """
+namespace std
+{
+    template <typename R, typename...> struct coroutine_traits { using promise_type = typename R::promise_type; };
+
+    template <typename Promise = void> struct coroutine_handle;
+
+    template <> struct coroutine_handle<void>
+    {
+        static coroutine_handle from_address(void*) noexcept { return {}; }
+        void* address() const noexcept { return nullptr; }
+    };
+
+    template <typename Promise> struct coroutine_handle
+    {
+        operator coroutine_handle<>() const noexcept { return {}; }
+        static coroutine_handle from_address(void*) noexcept { return {}; }
+        static coroutine_handle from_promise(Promise&) noexcept { return {}; }
+        void* address() const noexcept { return nullptr; }
+    };
+}
+
+struct suspend_always
+{
+    bool await_ready() const noexcept { return false; }
+    void await_suspend(std::coroutine_handle<>) const noexcept { }
+    void await_resume() const noexcept { }
+};
+
+struct task
+{
+    struct promise_type
+    {
+        task get_return_object() { return {}; }
+        suspend_always initial_suspend() { return {}; }
+        suspend_always final_suspend() noexcept { return {}; }
+        void return_void() { }
+        void unhandled_exception() { }
+    };
+};
+
+task f()
+{
+    co_return;
+}
+""";
+
+        string[] commandLineArgs = ["-std=c++20", "-Wno-pragma-once-outside-header"];
+        using var translationUnit = CreateTranslationUnit(inputContents, commandLineArgs: commandLineArgs);
+
+        var func = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>()
+                                  .Single((functionDecl) => functionDecl.Name.Equals("f", StringComparison.Ordinal));
+
+        var coroutineBody = (CoroutineBodyStmt)func.Body!;
+
+        Assert.That(coroutineBody.Body, Is.Not.Null);
+        Assert.That(coroutineBody.PromiseDecl, Is.Not.Null);
+        Assert.That(coroutineBody.InitSuspendStmt, Is.Not.Null);
+        Assert.That(coroutineBody.FinalSuspendStmt, Is.Not.Null);
+        Assert.That(coroutineBody.HasDependentPromiseType, Is.False);
+
+        var coreturn = coroutineBody.Body.Children.OfType<CoreturnStmt>().Single();
+
+        Assert.That(coreturn.PromiseCall, Is.Not.Null);
+    }
 }


### PR DESCRIPTION
Surfaces the coroutine statement API now reachable through the v22 raw-interop regen. The `CoroutineBodyStmt` and `CoreturnStmt` managed classes were empty validation shells; this wires them up over the mid-layer `CXCursor` coroutine accessors (also added here) so the high-level layer mirrors the clang C++ AST.

- `CoroutineBodyStmt`: `Body`, `PromiseDecl`, `InitSuspendStmt`, `FinalSuspendStmt`, `ExceptionHandler`, `FallthroughHandler`, `Allocate`, `Deallocate`, `ResultDecl`, `ReturnValueInit`, `ReturnValue`, `ReturnStmt`, `ReturnStmtOnAllocFailure`, and `HasDependentPromiseType`.
- `CoreturnStmt`: `Operand`, `PromiseCall`, `IsImplicit`.

----------

`CoroutineSuspendExpr`/`CoawaitExpr`/`CoyieldExpr` are intentionally left unsurfaced -- there are no dedicated native bridges for their common/ready/suspend/resume sub-expressions, so a clean surface would need new native shims (a separate follow-up).

Sub-statement children are cached via `ValueLazy`, matching the existing single-cursor accessors. Test: added `CoroutineBodyStmtTest` to `StmtTest` (minimal C++20 coroutine shim) covering the body/promise/suspend surface and the nested `co_return`. Build 0 warnings; interop suite green (84 pass).

> [!NOTE]
> Authored with Copilot.
