### PR TITLE
Surface macro and inclusion-directive preprocessing API

### DIFF
--- a/sources/ClangSharp.Interop/Extensions/CXCursor.cs
+++ b/sources/ClangSharp.Interop/Extensions/CXCursor.cs
@@ -1077,6 +1077,10 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly CXCursor InClassInitializer => clangsharp.Cursor_getInClassInitializer(this);
 
+    public readonly CX_InclusionDirectiveKind InclusionDirectiveKind => clangsharp.Cursor_getInclusionDirectiveKind(this);
+
+    public readonly bool InclusionDirectiveWasInQuotes => clangsharp.Cursor_getInclusionDirectiveWasInQuotes(this) != 0;
+
     public readonly CXCursor InheritedConstructor => clangsharp.Cursor_getInheritedConstructor(this);
 
     public readonly bool InheritedFromVBase => clangsharp.Cursor_getInheritedFromVBase(this) != 0;
@@ -1205,7 +1209,13 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly bool IsMacroBuiltIn => clang.Cursor_isMacroBuiltin(this) != 0;
 
+    public readonly bool IsMacroC99Varargs => clangsharp.Cursor_getIsMacroC99Varargs(this) != 0;
+
     public readonly bool IsMacroFunctionLike => clang.Cursor_isMacroFunctionLike(this) != 0;
+
+    public readonly bool IsMacroGNUVarargs => clangsharp.Cursor_getIsMacroGNUVarargs(this) != 0;
+
+    public readonly bool IsMacroVariadic => clangsharp.Cursor_getIsMacroVariadic(this) != 0;
 
     public readonly bool IsMemberSpecialization => clangsharp.Cursor_getIsMemberSpecialization(this) != 0;
 
@@ -1378,6 +1388,10 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly uint NumInputs => clangsharp.Cursor_getNumInputs(this);
 
     public readonly uint NumLabels => clangsharp.Cursor_getNumLabels(this);
+
+    public readonly int NumMacroParams => clangsharp.Cursor_getNumMacroParams(this);
+
+    public readonly int NumMacroTokens => clangsharp.Cursor_getNumMacroTokens(this);
 
     public readonly int NumMethods => clangsharp.Cursor_getNumMethods(this);
 
@@ -2020,6 +2034,10 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
             return result != 0;
         }
     }
+
+    public readonly CXString GetMacroParamName(uint index) => clangsharp.Cursor_getMacroParamName(this, index);
+
+    public readonly CXString GetMacroTokenSpelling(uint index) => clangsharp.Cursor_getMacroTokenSpelling(this, index);
 
     public readonly CXCursor GetMethod(uint index) => clangsharp.Cursor_getMethod(this, index);
 

--- a/sources/ClangSharp/Cursors/Preprocessings/InclusionDirective.cs
+++ b/sources/ClangSharp/Cursors/Preprocessings/InclusionDirective.cs
@@ -10,4 +10,8 @@ public sealed class InclusionDirective : PreprocessingDirective
     internal InclusionDirective(CXCursor handle) : base(handle, CXCursor_InclusionDirective)
     {
     }
+
+    public CX_InclusionDirectiveKind Kind => Handle.InclusionDirectiveKind;
+
+    public bool WasInQuotes => Handle.InclusionDirectiveWasInQuotes;
 }

--- a/sources/ClangSharp/Cursors/Preprocessings/MacroDefinitionRecord.cs
+++ b/sources/ClangSharp/Cursors/Preprocessings/MacroDefinitionRecord.cs
@@ -1,5 +1,7 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System;
+using System.Collections.Generic;
 using ClangSharp.Interop;
 using static ClangSharp.Interop.CXCursorKind;
 
@@ -7,13 +9,36 @@ namespace ClangSharp;
 
 public sealed class MacroDefinitionRecord : PreprocessingDirective
 {
-    internal MacroDefinitionRecord(CXCursor handle) : base(handle, CXCursor_MacroDefinition)
-    {
-    }
+    private readonly LazyList<string> _parameterNames;
+    private readonly LazyList<string> _tokens;
 
-    public bool IsFunctionLike => Handle.IsMacroFunctionLike;
+    internal unsafe MacroDefinitionRecord(CXCursor handle) : base(handle, CXCursor_MacroDefinition)
+    {
+        _parameterNames = LazyList.Create<string>(this, Math.Max(0, Handle.NumMacroParams), &ParameterNamesFactory);
+        _tokens = LazyList.Create<string>(this, Math.Max(0, Handle.NumMacroTokens), &TokensFactory);
+    }
 
     public bool IsBuiltinMacro => Handle.IsMacroBuiltIn;
 
+    public bool IsC99Varargs => Handle.IsMacroC99Varargs;
+
+    public bool IsFunctionLike => Handle.IsMacroFunctionLike;
+
+    public bool IsGNUVarargs => Handle.IsMacroGNUVarargs;
+
+    public bool IsVariadic => Handle.IsMacroVariadic;
+
     public string Name => Handle.Spelling.CString;
+
+    public int NumParameters => Handle.NumMacroParams;
+
+    public int NumTokens => Handle.NumMacroTokens;
+
+    public IReadOnlyList<string> ParameterNames => _parameterNames;
+
+    public IReadOnlyList<string> Tokens => _tokens;
+
+    private static string ParameterNamesFactory(object self, int i) => ((MacroDefinitionRecord)self).Handle.GetMacroParamName(unchecked((uint)i)).CString;
+
+    private static string TokensFactory(object self, int i) => ((MacroDefinitionRecord)self).Handle.GetMacroTokenSpelling(unchecked((uint)i)).CString;
 }

--- a/tests/ClangSharp.UnitTests/CursorTests/PreprocessingTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/PreprocessingTest.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Linq;
+using ClangSharp.Interop;
+using NUnit.Framework;
+using static ClangSharp.Interop.CXTranslationUnit_Flags;
+
+namespace ClangSharp.UnitTests;
+
+public sealed class PreprocessingTest : TranslationUnitTest
+{
+    private const CXTranslationUnit_Flags PreprocessingFlags = DefaultTranslationUnitFlags | CXTranslationUnit_DetailedPreprocessingRecord;
+
+    [Test]
+    public void MacroDefinitionRecordTest()
+    {
+        var inputContents = """
+#define OBJECT 1
+#define FUNC(a, b) ((a) + (b))
+#define VARIADIC(fmt, ...) fmt
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents, translationUnitFlags: PreprocessingFlags);
+
+        var macros = translationUnit.TranslationUnitDecl.CursorChildren.OfType<MacroDefinitionRecord>().ToArray();
+
+        var obj = macros.Single((macro) => macro.Name.Equals("OBJECT", StringComparison.Ordinal));
+        Assert.That(obj.IsFunctionLike, Is.False);
+        Assert.That(obj.NumParameters, Is.EqualTo(0));
+        Assert.That(obj.Tokens, Has.Count.EqualTo(1));
+        Assert.That(obj.Tokens[0], Is.EqualTo("1"));
+
+        var func = macros.Single((macro) => macro.Name.Equals("FUNC", StringComparison.Ordinal));
+        Assert.That(func.IsFunctionLike, Is.True);
+        Assert.That(func.IsVariadic, Is.False);
+        Assert.That(func.NumParameters, Is.EqualTo(2));
+        Assert.That(func.ParameterNames, Has.Count.EqualTo(2));
+        Assert.That(func.ParameterNames[0], Is.EqualTo("a"));
+        Assert.That(func.ParameterNames[1], Is.EqualTo("b"));
+
+        var variadic = macros.Single((macro) => macro.Name.Equals("VARIADIC", StringComparison.Ordinal));
+        Assert.That(variadic.IsFunctionLike, Is.True);
+        Assert.That(variadic.IsVariadic, Is.True);
+    }
+
+    [Test]
+    public void InclusionDirectiveTest()
+    {
+        var inputContents = """
+#pragma once
+#include "ClangUnsavedFile.h"
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents, translationUnitFlags: PreprocessingFlags);
+
+        var inclusion = translationUnit.TranslationUnitDecl.CursorChildren.OfType<InclusionDirective>().First();
+
+        Assert.That(inclusion.Kind, Is.EqualTo(CX_InclusionDirectiveKind.CX_IDK_Include));
+        Assert.That(inclusion.WasInQuotes, Is.True);
+    }
+}

--- a/tests/ClangSharp.UnitTests/TranslationUnitTest.cs
+++ b/tests/ClangSharp.UnitTests/TranslationUnitTest.cs
@@ -25,7 +25,7 @@ public abstract class TranslationUnitTest
         "-Wno-pragma-once-outside-header"       // We are processing files which may be header files
     ];
 
-    protected static TranslationUnit CreateTranslationUnit(string inputContents, string language = "c++" /* input files are C++ by default */, string[]? commandLineArgs = null)
+    protected static TranslationUnit CreateTranslationUnit(string inputContents, string language = "c++" /* input files are C++ by default */, string[]? commandLineArgs = null, CXTranslationUnit_Flags translationUnitFlags = DefaultTranslationUnitFlags)
     {
         Assert.That(DefaultInputFileName, Does.Exist);
 
@@ -38,7 +38,7 @@ public abstract class TranslationUnitTest
             "-x",
             language,
         };
-        var errorCode = CXTranslationUnit.TryParse(index, DefaultInputFileName, arguments.ToArray(), unsavedFiles, DefaultTranslationUnitFlags, out var translationUnit);
+        var errorCode = CXTranslationUnit.TryParse(index, DefaultInputFileName, arguments.ToArray(), unsavedFiles, translationUnitFlags, out var translationUnit);
         Assert.That(errorCode, Is.EqualTo(CXErrorCode.CXError_Success), $"Failed to create {nameof(CXTranslationUnit)} (error code: {errorCode})");
 
         if (translationUnit.NumDiagnostics != 0)


### PR DESCRIPTION
Surfaces the v22 macro and inclusion-directive preprocessing bridges through the managed API, continuing the onboarding of the newly-reachable libClangSharp surface.

`MacroDefinitionRecord` now exposes the underlying `MacroInfo`: `IsVariadic`/`IsC99Varargs`/`IsGNUVarargs`, `NumParameters`/`NumTokens`, and the `ParameterNames`/`Tokens` lists.

`InclusionDirective` now exposes `Kind` (`CX_InclusionDirectiveKind`) and `WasInQuotes`.

----------

The shared `CreateTranslationUnit` test harness gained an optional `translationUnitFlags` parameter so preprocessing tests can request `CXTranslationUnit_DetailedPreprocessingRecord` -- without it, macro/inclusion cursors aren't produced.

`MacroTokenKind` is intentionally left unwrapped: it returns clang's internal `tok::TokenKind`, an unstable enum with no managed mapping.

Because `MacroDefinitionRecord` holds only the identifier, the `MacroInfo` route resolves the *current* active definition via the `Preprocessor` -- a `#undef`'d or redefined macro yields its last active definition.

> [!NOTE]
> Authored with Copilot.
