### PR TITLE
Surface TemplateName dependence predicates and underlying name

### DIFF
--- a/sources/ClangSharp.Interop/Extensions/CX_TemplateName.cs
+++ b/sources/ClangSharp.Interop/Extensions/CX_TemplateName.cs
@@ -6,4 +6,12 @@ namespace ClangSharp.Interop;
 public unsafe partial struct CX_TemplateName
 {
     public readonly CXCursor AsTemplateDecl => clangsharp.TemplateName_getAsTemplateDecl(this);
+
+    public readonly bool ContainsUnexpandedParameterPack => clangsharp.TemplateName_getContainsUnexpandedParameterPack(this) != 0;
+
+    public readonly bool IsDependent => clangsharp.TemplateName_getIsDependent(this) != 0;
+
+    public readonly bool IsInstantiationDependent => clangsharp.TemplateName_getIsInstantiationDependent(this) != 0;
+
+    public readonly CX_TemplateName Underlying => clangsharp.TemplateName_getUnderlying(this);
 }

--- a/sources/ClangSharp/TemplateName.cs
+++ b/sources/ClangSharp/TemplateName.cs
@@ -8,6 +8,7 @@ namespace ClangSharp;
 public sealed unsafe class TemplateName
 {
     private ValueLazy<TemplateName, TemplateDecl> _asTemplateDecl;
+    private ValueLazy<TemplateName, TemplateName> _underlying;
     private ValueLazy<TemplateName, TranslationUnit> _translationUnit;
 
     internal TemplateName(CX_TemplateName handle)
@@ -16,11 +17,18 @@ public sealed unsafe class TemplateName
 
         _translationUnit = new ValueLazy<TemplateName, TranslationUnit>(&TranslationUnitFactory);
         _asTemplateDecl = new ValueLazy<TemplateName, TemplateDecl>(&AsTemplateDeclFactory);
+        _underlying = new ValueLazy<TemplateName, TemplateName>(&UnderlyingFactory);
     }
 
     public TemplateDecl AsTemplateDecl => _asTemplateDecl.GetValue(this);
 
+    public bool ContainsUnexpandedParameterPack => Handle.ContainsUnexpandedParameterPack;
+
     public CX_TemplateName Handle { get; }
+
+    public bool IsDependent => Handle.IsDependent;
+
+    public bool IsInstantiationDependent => Handle.IsInstantiationDependent;
 
     public bool IsNull => Handle.kind == CX_TNK_Invalid;
 
@@ -28,7 +36,11 @@ public sealed unsafe class TemplateName
 
     public TranslationUnit TranslationUnit => _translationUnit.GetValue(this);
 
+    public TemplateName Underlying => _underlying.GetValue(this);
+
     private static unsafe TemplateDecl AsTemplateDeclFactory(TemplateName self) => self._translationUnit.GetValue(self).GetOrCreate<TemplateDecl>(self.Handle.AsTemplateDecl);
+
+    private static unsafe TemplateName UnderlyingFactory(TemplateName self) => self._translationUnit.GetValue(self).GetOrCreate(self.Handle.Underlying);
 
     private static unsafe TranslationUnit TranslationUnitFactory(TemplateName self) => TranslationUnit.GetOrCreate(self.Handle.tu);
 }

--- a/tests/ClangSharp.UnitTests/TypeTest.cs
+++ b/tests/ClangSharp.UnitTests/TypeTest.cs
@@ -187,6 +187,13 @@ using SpecT = Tmpl<int>;
 
         Assert.That(templateName.IsNull, Is.False);
         Assert.That(templateName.Kind, Is.EqualTo(CX_TemplateNameKind.CX_TNK_QualifiedTemplate));
+        Assert.That(templateName.IsDependent, Is.False);
+        Assert.That(templateName.IsInstantiationDependent, Is.False);
+        Assert.That(templateName.ContainsUnexpandedParameterPack, Is.False);
+
+        var underlying = templateName.Underlying;
+        Assert.That(underlying.IsNull, Is.False);
+        Assert.That(underlying.AsTemplateDecl.Name, Is.EqualTo("Tmpl"));
     }
 
     [Test]


### PR DESCRIPTION
Surfaces the remaining `TemplateName` bridges that the v22 native port unblocked, mirroring how `Expr` and `TemplateArgument` already expose their dependence bits.

Managed `TemplateName` now exposes:

- `IsDependent`
- `IsInstantiationDependent`
- `ContainsUnexpandedParameterPack`
- `Underlying` -- the underlying `TemplateName` (unwrapping sugar; a qualified name resolves to itself)

`Kind`, `IsNull`, and `AsTemplateDecl` were already surfaced, so this is purely additive. The values are threaded through the `CX_TemplateName` mid-layer wrapper so the unsafe struct layer stays in step with the managed API.

`TypeTest.TemplateNameTest` is extended to assert the new predicates and `Underlying` on `Tmpl<int>`.

> [!NOTE]
> Authored with Copilot.
