### PR TITLE
Surface EnumDecl.IsFixed, FieldDecl.IsZeroLengthBitField, and CXXMethodDecl.RefQualifier

### DIFF
--- a/sources/ClangSharp.Interop/Extensions/CXCursor.cs
+++ b/sources/ClangSharp.Interop/Extensions/CXCursor.cs
@@ -1191,6 +1191,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly bool IsFileScope => clangsharp.Cursor_getIsFileScope(this) != 0;
 
+    public readonly bool IsFixed => clangsharp.Cursor_getIsFixed(this) != 0;
+
     public readonly bool IsFunctionInlined => clang.Cursor_isFunctionInlined(this) != 0;
 
     public readonly bool IsGenericLambda => clangsharp.Cursor_getIsGenericLambda(this) != 0;
@@ -1320,6 +1322,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly bool IsVirtualBase => clang.isVirtualBase(this) != 0;
 
     public readonly bool IsVolatile => clangsharp.Cursor_getIsVolatile(this) != 0;
+
+    public readonly bool IsZeroLengthBitField => clangsharp.Cursor_getIsZeroLengthBitField(this) != 0;
 
     public readonly CXCursorKind Kind => clang.getCursorKind(this);
 
@@ -1486,6 +1490,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly CXCursor RedeclContext => clangsharp.Cursor_getRedeclContext(this);
 
     public readonly CXCursor Referenced => clangsharp.Cursor_getReferenced(this);
+
+    public readonly CXRefQualifierKind RefQualifier => clangsharp.Cursor_getRefQualifier(this);
 
     public readonly bool RequiresZeroInitialization => clangsharp.Cursor_getRequiresZeroInitialization(this) != 0;
 

--- a/sources/ClangSharp/Cursors/Decls/CXXMethodDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/CXXMethodDecl.cs
@@ -48,6 +48,8 @@ public class CXXMethodDecl : FunctionDecl
 
     public new CXXRecordDecl? Parent => (CXXRecordDecl?)(base.Parent ?? ThisObjectType.AsCXXRecordDecl);
 
+    public CXRefQualifierKind RefQualifier => Handle.RefQualifier;
+
     public uint SizeOverriddenMethods => unchecked((uint)Handle.NumMethods);
 
     public Type ThisType => _thisType.GetValue(this);

--- a/sources/ClangSharp/Cursors/Decls/EnumDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/EnumDecl.cs
@@ -36,6 +36,8 @@ public sealed class EnumDecl : TagDecl
 
     public bool IsComplete => IsCompleteDefinition || (IntegerType is not null);
 
+    public bool IsFixed => Handle.IsFixed;
+
     public bool IsScoped => Handle.EnumDecl_IsScoped;
 
     public new EnumDecl MostRecentDecl => (EnumDecl)base.MostRecentDecl;

--- a/sources/ClangSharp/Cursors/Decls/FieldDecl.cs
+++ b/sources/ClangSharp/Cursors/Decls/FieldDecl.cs
@@ -50,6 +50,8 @@ public class FieldDecl : DeclaratorDecl, IMergeable<FieldDecl>
 
     public bool IsUnnamedBitfield => Handle.IsUnnamedBitfield;
 
+    public bool IsZeroLengthBitField => Handle.IsZeroLengthBitField;
+
     public long OffsetOfField => Handle.OffsetOfField;
 
     public new RecordDecl? Parent => (DeclContext as RecordDecl) ?? ((SemanticParentCursor is ClassTemplateDecl classTemplateDecl) ? (RecordDecl)classTemplateDecl.TemplatedDecl : null);

--- a/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/DeclTest.cs
@@ -99,6 +99,42 @@ tuple<int, long> SomeFunction();
     }
 
     [Test]
+    public void EnumFieldMethodPredicatesTest()
+    {
+        var inputContents = """
+enum class Scoped : int { A };
+enum Plain { B };
+struct MyStruct
+{
+    int : 0;
+    int named : 3;
+    void lref() &;
+    void rref() &&;
+    void plain();
+};
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var scoped = translationUnit.TranslationUnitDecl.Decls.OfType<EnumDecl>().Single((enumDecl) => enumDecl.Name.Equals("Scoped", StringComparison.Ordinal));
+        Assert.That(scoped.IsFixed, Is.True);
+
+        var plain = translationUnit.TranslationUnitDecl.Decls.OfType<EnumDecl>().Single((enumDecl) => enumDecl.Name.Equals("Plain", StringComparison.Ordinal));
+        Assert.That(plain.IsFixed, Is.False);
+
+        var myStruct = translationUnit.TranslationUnitDecl.Decls.OfType<RecordDecl>().Single((recordDecl) => recordDecl.Name.Equals("MyStruct", StringComparison.Ordinal));
+
+        var fields = myStruct.Decls.OfType<FieldDecl>().ToArray();
+        Assert.That(fields[0].IsZeroLengthBitField, Is.True);
+        Assert.That(fields[1].IsZeroLengthBitField, Is.False);
+
+        var methods = myStruct.Decls.OfType<CXXMethodDecl>().ToArray();
+        Assert.That(methods.Single((method) => method.Name.Equals("lref", StringComparison.Ordinal)).RefQualifier, Is.EqualTo(CXRefQualifierKind.CXRefQualifier_LValue));
+        Assert.That(methods.Single((method) => method.Name.Equals("rref", StringComparison.Ordinal)).RefQualifier, Is.EqualTo(CXRefQualifierKind.CXRefQualifier_RValue));
+        Assert.That(methods.Single((method) => method.Name.Equals("plain", StringComparison.Ordinal)).RefQualifier, Is.EqualTo(CXRefQualifierKind.CXRefQualifier_None));
+    }
+
+    [Test]
     public void FunctionTemplateSpecializationArgsTest()
     {
         SkipUntilNativeRebuild();


### PR DESCRIPTION
Surfaces three long-standing `clangsharp_*` decl predicates that were bridged natively but never exposed on the managed AST:

- `EnumDecl.IsFixed` -- whether the enum has a fixed underlying type (scoped enums, or `enum E : T`).
- `FieldDecl.IsZeroLengthBitField` -- whether the field is a zero-length bit-field (`int : 0;`).
- `CXXMethodDecl.RefQualifier` -- the method's ref-qualifier (`&` / `&&` / none) as a `CXRefQualifierKind`.

Each is threaded through the `CXCursor` mid-layer so the unsafe struct layer stays in step with the managed API. `DeclTest.EnumFieldMethodPredicatesTest` covers all three, including the negative cases.

> [!NOTE]
> Authored with Copilot.
