### PR TITLE
Surface Objective-C and template-parameter-pack Type predicates

### DIFF
--- a/sources/ClangSharp.Interop/Extensions/CXType.cs
+++ b/sources/ClangSharp.Interop/Extensions/CXType.cs
@@ -89,11 +89,29 @@ public unsafe partial struct CXType : IEquatable<CXType>
 
     public readonly bool IsGNUAutoType => clangsharp.Type_getIsGNUAutoType(this) != 0;
 
+    public readonly bool IsObjCClassType => clangsharp.Type_getIsObjCClassType(this) != 0;
+
+    public readonly bool IsObjCIdType => clangsharp.Type_getIsObjCIdType(this) != 0;
+
     public readonly bool IsObjCInstanceType => (kind != CXType_Invalid) && clangsharp.Type_getIsObjCInstanceType(this) != 0;
+
+    public readonly bool IsObjCKindOfType => clangsharp.Type_getIsObjCKindOfType(this) != 0;
+
+    public readonly bool IsObjCKindOfTypeAsWritten => clangsharp.Type_getIsObjCKindOfTypeAsWritten(this) != 0;
+
+    public readonly bool IsObjCObjectSpecialized => clangsharp.Type_getIsObjCObjectSpecialized(this) != 0;
+
+    public readonly bool IsObjCObjectSpecializedAsWritten => clangsharp.Type_getIsObjCObjectSpecializedAsWritten(this) != 0;
+
+    public readonly bool IsObjCQualifiedClassType => clangsharp.Type_getIsObjCQualifiedClassType(this) != 0;
+
+    public readonly bool IsObjCQualifiedIdType => clangsharp.Type_getIsObjCQualifiedIdType(this) != 0;
 
     public readonly bool IsObjectType => clangsharp.Type_getIsObjectType(this) != 0;
 
     public readonly bool IsPODType => clang.isPODType(this) != 0;
+
+    public readonly bool IsParameterPack => clangsharp.Type_getIsParameterPack(this) != 0;
 
     public readonly bool IsRealFloatingType => clangsharp.Type_getIsRealFloatingType(this) != 0;
 
@@ -144,6 +162,8 @@ public unsafe partial struct CXType : IEquatable<CXType>
     public readonly uint NumObjCProtocolRefs => clang.Type_getNumObjCProtocolRefs(this);
 
     public readonly uint NumObjCTypeArgs => clang.Type_getNumObjCTypeArgs(this);
+
+    public readonly int NumObjCTypeParamProtocols => clangsharp.Type_getNumObjCTypeParamProtocols(this);
 
     public readonly int NumTemplateArguments => clang.Type_getNumTemplateArguments(this);
 
@@ -282,6 +302,8 @@ public unsafe partial struct CXType : IEquatable<CXType>
     public readonly CXCursor GetObjCProtocolDecl(uint i) => clang.Type_getObjCProtocolDecl(this, i);
 
     public readonly CXType GetObjCTypeArg(uint i) => clang.Type_getObjCTypeArg(this, i);
+
+    public readonly CXCursor GetObjCTypeParamProtocol(uint i) => clangsharp.Type_getObjCTypeParamProtocol(this, i);
 
     public readonly long GetOffsetOf(string s)
     {

--- a/sources/ClangSharp/Types/ObjCObjectPointerType.cs
+++ b/sources/ClangSharp/Types/ObjCObjectPointerType.cs
@@ -22,6 +22,12 @@ public sealed class ObjCObjectPointerType : Type
 
     public ObjCInterfaceType InterfaceType => _interfaceType.GetValue(this);
 
+    public bool IsKindOfType => Handle.IsObjCKindOfType;
+
+    public bool IsSpecialized => Handle.IsObjCObjectSpecialized;
+
+    public bool IsSpecializedAsWritten => Handle.IsObjCObjectSpecializedAsWritten;
+
     public ObjCObjectType ObjectType => PointeeType.CastAs<ObjCObjectType>();
 
     public IReadOnlyList<ObjCProtocolDecl> Protocols => ObjectType.Protocols;

--- a/sources/ClangSharp/Types/ObjCObjectType.cs
+++ b/sources/ClangSharp/Types/ObjCObjectType.cs
@@ -32,6 +32,14 @@ public class ObjCObjectType : Type
 
     public ObjCInterfaceDecl Interface => _interface.GetValue(this);
 
+    public bool IsKindOfType => Handle.IsObjCKindOfType;
+
+    public bool IsKindOfTypeAsWritten => Handle.IsObjCKindOfTypeAsWritten;
+
+    public bool IsSpecialized => Handle.IsObjCObjectSpecialized;
+
+    public bool IsSpecializedAsWritten => Handle.IsObjCObjectSpecializedAsWritten;
+
     public IReadOnlyList<ObjCProtocolDecl> Protocols => _protocols;
 
     public Type SuperClassType => _superClassType.GetValue(this);

--- a/sources/ClangSharp/Types/ObjCTypeParamType.cs
+++ b/sources/ClangSharp/Types/ObjCTypeParamType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
 
+using System.Collections.Generic;
 using ClangSharp.Interop;
 using static ClangSharp.Interop.CXTypeKind;
 using static ClangSharp.Interop.CX_TypeClass;
@@ -9,13 +10,23 @@ namespace ClangSharp;
 public sealed class ObjCTypeParamType : Type
 {
     private ValueLazy<ObjCTypeParamType, ObjCTypeParamDecl> _decl;
+    private readonly LazyList<ObjCProtocolDecl> _protocols;
 
     internal unsafe ObjCTypeParamType(CXType handle) : base(handle, CXType_ObjCTypeParam, CX_TypeClass_ObjCTypeParam)
     {
         _decl = new ValueLazy<ObjCTypeParamType, ObjCTypeParamDecl>(&DeclFactory);
+        _protocols = LazyList.Create<ObjCProtocolDecl>(this, Handle.NumObjCTypeParamProtocols, &ProtocolsFactory);
     }
 
     public ObjCTypeParamDecl Decl => _decl.GetValue(this);
 
+    public IReadOnlyList<ObjCProtocolDecl> Protocols => _protocols;
+
     private static unsafe ObjCTypeParamDecl DeclFactory(ObjCTypeParamType self) => self.TranslationUnit.GetOrCreate<ObjCTypeParamDecl>(self.Handle.Declaration);
+
+    private static unsafe ObjCProtocolDecl ProtocolsFactory(object self, int i)
+    {
+        var @this = (ObjCTypeParamType)self;
+        return @this.TranslationUnit.GetOrCreate<ObjCProtocolDecl>(@this.Handle.GetObjCTypeParamProtocol(unchecked((uint)i)));
+    }
 }

--- a/sources/ClangSharp/Types/TemplateTypeParmType.cs
+++ b/sources/ClangSharp/Types/TemplateTypeParmType.cs
@@ -21,5 +21,7 @@ public sealed class TemplateTypeParmType : Type
 
     public uint Index => unchecked((uint)Handle.Index);
 
+    public bool IsParameterPack => Handle.IsParameterPack;
+
     private static unsafe TemplateTypeParmDecl DeclFactory(TemplateTypeParmType self) => self.TranslationUnit.GetOrCreate<TemplateTypeParmDecl>(self.Handle.Declaration);
 }

--- a/sources/ClangSharp/Types/Type.cs
+++ b/sources/ClangSharp/Types/Type.cs
@@ -162,9 +162,17 @@ public unsafe class Type : IEquatable<Type>
 
     public bool IsNullPtrType => (CanonicalType is BuiltinType builtinType) && builtinType.Kind == CXType_NullPtr;
 
+    public bool IsObjCClassType => Handle.IsObjCClassType;
+
+    public bool IsObjCIdType => Handle.IsObjCIdType;
+
     public bool IsObjCInstanceType => Handle.IsObjCInstanceType;
 
     public bool IsObjCObjectPointerType => CanonicalType is ObjCObjectPointerType;
+
+    public bool IsObjCQualifiedClassType => Handle.IsObjCQualifiedClassType;
+
+    public bool IsObjCQualifiedIdType => Handle.IsObjCQualifiedIdType;
 
     public bool IsObjectType => Handle.IsObjectType;
 

--- a/tests/ClangSharp.UnitTests/CursorTests/TypePredicateTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/TypePredicateTest.cs
@@ -1,0 +1,108 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+public sealed class TypePredicateTest : TranslationUnitTest
+{
+    // Objective-C lightweight generics and __kindof require a modern runtime, so an Apple target triple
+    // is pinned to keep the parse deterministic cross-platform.
+    private static readonly string[] s_objCCommandLineArgs =
+    [
+        "-target",
+        "x86_64-apple-macosx10.15.0",
+        "-fobjc-runtime=macosx",
+    ];
+
+    [Test]
+    public void TemplateTypeParmTypeIsParameterPackTest()
+    {
+        var inputContents = """
+template <typename T, typename... Ts>
+struct S
+{
+    T first;
+    void rest(Ts... args);
+};
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents);
+
+        var classTemplate = translationUnit.TranslationUnitDecl.Decls.OfType<ClassTemplateDecl>().Single();
+        var record = (CXXRecordDecl)classTemplate.TemplatedDecl;
+
+        var first = record.Decls.OfType<FieldDecl>().Single();
+        var firstType = (TemplateTypeParmType)first.Type;
+        Assert.That(firstType.IsParameterPack, Is.False);
+
+        var rest = record.Decls.OfType<CXXMethodDecl>().Single((method) => method.Name.Equals("rest", StringComparison.Ordinal));
+        var packExpansion = (PackExpansionType)rest.Parameters.Single().Type;
+        var packParm = (TemplateTypeParmType)packExpansion.Pattern;
+        Assert.That(packParm.IsParameterPack, Is.True);
+    }
+
+    [Test]
+    public void ObjCTypePredicatesTest()
+    {
+        var inputContents = """
+__attribute__((objc_root_class))
+@interface Base
+@end
+
+@protocol Flying
+@end
+
+@interface Bird : Base <Flying>
+@end
+
+@interface Cage<T> : Base
+- (T)occupant;
+@end
+
+@interface Keeper<U> : Base
+- (U<Flying>)charge;
+@end
+
+@interface Api : Base
+- (id)anyObject;
+- (Class)anyClass;
+- (id<Flying>)flyer;
+- (Class<Flying>)flyerClass;
+- (__kindof Bird *)someBird;
+- (Cage<Bird *> *)birdCage;
+@end
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents, "objective-c", s_objCCommandLineArgs);
+
+        var api = translationUnit.TranslationUnitDecl.CursorChildren.OfType<ObjCInterfaceDecl>().Single((decl) => decl.Name.Equals("Api", StringComparison.Ordinal));
+
+        Type Return(string selector)
+        {
+            return api.CursorChildren.OfType<ObjCMethodDecl>().Single((method) => method.Selector.Equals(selector, StringComparison.Ordinal)).ReturnType;
+        }
+
+        Assert.That(Return("anyObject").IsObjCIdType, Is.True);
+        Assert.That(Return("anyClass").IsObjCClassType, Is.True);
+        Assert.That(Return("flyer").IsObjCQualifiedIdType, Is.True);
+        Assert.That(Return("flyerClass").IsObjCQualifiedClassType, Is.True);
+
+        var someBird = (ObjCObjectPointerType)Return("someBird").CanonicalType;
+        Assert.That(someBird.IsKindOfType, Is.True);
+        Assert.That(someBird.ObjectType.IsKindOfType, Is.True);
+        Assert.That(someBird.ObjectType.IsKindOfTypeAsWritten, Is.True);
+
+        var birdCage = (ObjCObjectPointerType)Return("birdCage").CanonicalType;
+        Assert.That(birdCage.IsSpecialized, Is.True);
+        Assert.That(birdCage.ObjectType.IsSpecialized, Is.True);
+        Assert.That(birdCage.ObjectType.IsSpecializedAsWritten, Is.True);
+
+        var keeper = translationUnit.TranslationUnitDecl.CursorChildren.OfType<ObjCInterfaceDecl>().Single((decl) => decl.Name.Equals("Keeper", StringComparison.Ordinal));
+        var charge = (ObjCTypeParamType)keeper.CursorChildren.OfType<ObjCMethodDecl>().Single((method) => method.Selector.Equals("charge", StringComparison.Ordinal)).ReturnType;
+        Assert.That(charge.Protocols, Has.Count.EqualTo(1));
+        Assert.That(charge.Protocols[0].Name, Is.EqualTo("Flying"));
+    }
+}


### PR DESCRIPTION
Surfaces the remaining Type-side predicates newly reachable from the v22 `libClangSharp` port. These are the subclass-dispatched bridges; the base-`Type` dependence predicates (`IsDependentType`, `IsInstantiationDependentType`, `ContainsUnexpandedParameterPack`, `IsVariablyModifiedType`) were already surfaced on `Type` via the `Dependence` flags, so they are intentionally not re-added.

----------

**Objective-C**
- `Type.IsObjCIdType` / `IsObjCClassType` / `IsObjCQualifiedIdType` / `IsObjCQualifiedClassType`
- `ObjCObjectType` / `ObjCObjectPointerType`: `IsKindOfType`, `IsSpecialized`, `IsSpecializedAsWritten` (plus `IsKindOfTypeAsWritten` on `ObjCObjectType`, which is where the native dispatch exposes it)
- `ObjCTypeParamType.Protocols`

**Templates**
- `TemplateTypeParmType.IsParameterPack`

----------

Adds `TypePredicateTest` covering both clusters. Full interop suite green (92/92), 0 warnings.

> [!NOTE]
> Authored with Copilot.
