### PR TITLE
Fix zero-length bitfield handling in the P/Invoke generator

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitRecordDecl.cs
@@ -533,7 +533,15 @@ public partial class PInvokeGenerator
             {
                 if (fieldDecl.IsBitField)
                 {
-                    VisitBitfieldDecl(fieldDecl, bitfieldDescs, recordDecl, contextName: "", ref bitfieldIndex, ref bitfieldPreviousSize, ref bitfieldRemainingBits);
+                    if (fieldDecl.IsZeroLengthBitField)
+                    {
+                        bitfieldPreviousSize = 0;
+                        bitfieldRemainingBits = 0;
+                    }
+                    else
+                    {
+                        VisitBitfieldDecl(fieldDecl, bitfieldDescs, recordDecl, contextName: "", ref bitfieldIndex, ref bitfieldPreviousSize, ref bitfieldRemainingBits);
+                    }
                 }
                 else
                 {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -1408,6 +1408,15 @@ public sealed partial class PInvokeGenerator : IDisposable
                 continue;
             }
 
+            if (fieldDecl.IsZeroLengthBitField)
+            {
+                // A zero-length bitfield (`int : 0;`) names no storage and only forces the next
+                // bitfield into a fresh storage unit, so it emits no region and resets the run.
+                previousSize = 0;
+                remainingBits = 0;
+                continue;
+            }
+
             var type = fieldDecl.Type;
             var currentSize = type.Handle.SizeOf;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/ZeroLengthBitfieldTest.CSharp.Compatible.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/ZeroLengthBitfieldTest.CSharp.Compatible.cs
@@ -1,0 +1,39 @@
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        [NativeBitfield("o0_b0_1", offset: 0, length: 1)]
+        public uint _bitfield1;
+
+        [NativeTypeName("unsigned int : 1")]
+        public uint o0_b0_1
+        {
+            get
+            {
+                return _bitfield1 & 0x1u;
+            }
+
+            set
+            {
+                _bitfield1 = (_bitfield1 & ~0x1u) | (value & 0x1u);
+            }
+        }
+
+        [NativeBitfield("o4_b0_1", offset: 0, length: 1)]
+        public uint _bitfield2;
+
+        [NativeTypeName("unsigned int : 1")]
+        public uint o4_b0_1
+        {
+            get
+            {
+                return _bitfield2 & 0x1u;
+            }
+
+            set
+            {
+                _bitfield2 = (_bitfield2 & ~0x1u) | (value & 0x1u);
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/ZeroLengthBitfieldTest.CSharp.Default.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/ZeroLengthBitfieldTest.CSharp.Default.cs
@@ -1,0 +1,39 @@
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        [NativeBitfield("o0_b0_1", offset: 0, length: 1)]
+        public uint _bitfield1;
+
+        [NativeTypeName("unsigned int : 1")]
+        public uint o0_b0_1
+        {
+            readonly get
+            {
+                return _bitfield1 & 0x1u;
+            }
+
+            set
+            {
+                _bitfield1 = (_bitfield1 & ~0x1u) | (value & 0x1u);
+            }
+        }
+
+        [NativeBitfield("o4_b0_1", offset: 0, length: 1)]
+        public uint _bitfield2;
+
+        [NativeTypeName("unsigned int : 1")]
+        public uint o4_b0_1
+        {
+            readonly get
+            {
+                return _bitfield2 & 0x1u;
+            }
+
+            set
+            {
+                _bitfield2 = (_bitfield2 & ~0x1u) | (value & 0x1u);
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/ZeroLengthBitfieldTest.CSharp.Latest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/ZeroLengthBitfieldTest.CSharp.Latest.cs
@@ -1,0 +1,39 @@
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        [NativeBitfield("o0_b0_1", offset: 0, length: 1)]
+        public uint _bitfield1;
+
+        [NativeTypeName("unsigned int : 1")]
+        public uint o0_b0_1
+        {
+            readonly get
+            {
+                return _bitfield1 & 0x1u;
+            }
+
+            set
+            {
+                _bitfield1 = (_bitfield1 & ~0x1u) | (value & 0x1u);
+            }
+        }
+
+        [NativeBitfield("o4_b0_1", offset: 0, length: 1)]
+        public uint _bitfield2;
+
+        [NativeTypeName("unsigned int : 1")]
+        public uint o4_b0_1
+        {
+            readonly get
+            {
+                return _bitfield2 & 0x1u;
+            }
+
+            set
+            {
+                _bitfield2 = (_bitfield2 & ~0x1u) | (value & 0x1u);
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/ZeroLengthBitfieldTest.CSharp.Preview.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/ZeroLengthBitfieldTest.CSharp.Preview.cs
@@ -1,0 +1,39 @@
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        [NativeBitfield("o0_b0_1", offset: 0, length: 1)]
+        public uint _bitfield1;
+
+        [NativeTypeName("unsigned int : 1")]
+        public uint o0_b0_1
+        {
+            readonly get
+            {
+                return _bitfield1 & 0x1u;
+            }
+
+            set
+            {
+                _bitfield1 = (_bitfield1 & ~0x1u) | (value & 0x1u);
+            }
+        }
+
+        [NativeBitfield("o4_b0_1", offset: 0, length: 1)]
+        public uint _bitfield2;
+
+        [NativeTypeName("unsigned int : 1")]
+        public uint o4_b0_1
+        {
+            readonly get
+            {
+                return _bitfield2 & 0x1u;
+            }
+
+            set
+            {
+                _bitfield2 = (_bitfield2 & ~0x1u) | (value & 0x1u);
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/ZeroLengthBitfieldTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/ZeroLengthBitfieldTest.Xml.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="MyStruct" access="public">
+      <field name="_bitfield1" access="public">
+        <attribute>NativeBitfield("o0_b0_1", offset: 0, length: 1)</attribute>
+        <type>uint</type>
+      </field>
+      <field name="o0_b0_1" access="public">
+        <type native="unsigned int : 1">uint</type>
+        <get>
+          <code>return <bitfieldName>_bitfield1</bitfieldName> &amp; 0x<bitwidthHexStringBacking>1u</bitwidthHexStringBacking>;</code>
+        </get>
+        <set>
+          <code>
+            <bitfieldName>_bitfield1</bitfieldName> = (_bitfield1 &amp; ~0x<bitwidthHexStringBacking>1u</bitwidthHexStringBacking>) | (value &amp; 0x<bitwidthHexString>1u</bitwidthHexString>);</code>
+        </set>
+      </field>
+      <field name="_bitfield2" access="public">
+        <attribute>NativeBitfield("o4_b0_1", offset: 0, length: 1)</attribute>
+        <type>uint</type>
+      </field>
+      <field name="o4_b0_1" access="public">
+        <type native="unsigned int : 1">uint</type>
+        <get>
+          <code>return <bitfieldName>_bitfield2</bitfieldName> &amp; 0x<bitwidthHexStringBacking>1u</bitwidthHexStringBacking>;</code>
+        </get>
+        <set>
+          <code>
+            <bitfieldName>_bitfield2</bitfieldName> = (_bitfield2 &amp; ~0x<bitwidthHexStringBacking>1u</bitwidthHexStringBacking>) | (value &amp; 0x<bitwidthHexString>1u</bitwidthHexString>);</code>
+        </set>
+      </field>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
@@ -153,6 +153,20 @@ struct MyStruct3
     }
 
     [Test]
+    public Task ZeroLengthBitfieldTest()
+    {
+        var inputContents = @"struct MyStruct
+{
+    unsigned int o0_b0_1 : 1;
+    unsigned int : 0;
+    unsigned int o4_b0_1 : 1;
+};
+";
+
+        return ValidateAsync(nameof(ZeroLengthBitfieldTest), inputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateNativeBitfieldAttribute);
+    }
+
+    [Test]
     public Task DeclTypeTest()
     {
         var inputContents = @"extern ""C"" void MyFunction();


### PR DESCRIPTION
A zero-length bitfield (`int : 0;`) is a layout-only marker: it names no storage and forces the *next* bitfield into a fresh storage unit. The generator previously ran it through the normal bitfield path, which emitted a bogus 0-length region and packed the following bitfield into the *same* backing field.

`GetBitfieldDescs` and the `VisitRecordDecl` emit loop now skip zero-length bitfields via `FieldDecl.IsZeroLengthBitField` and reset the running size/bit counters, so the next bitfield lands in a new storage unit.

----------

Adds `ZeroLengthBitfieldTest` (with `GenerateNativeBitfieldAttribute`) covering `o0_b0_1` -> `_bitfield1` and `o4_b0_1` -> `_bitfield2` across a `: 0` boundary. Full generator baseline suite green (4085), 0 warnings.

> [!NOTE]
> Authored with Copilot.
