### PR TITLE
Surface Expr value and object kinds on the managed layer

### DIFF
--- a/sources/ClangSharp.Interop/Extensions/CXCursor.cs
+++ b/sources/ClangSharp.Interop/Extensions/CXCursor.cs
@@ -1466,6 +1466,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
 
     public readonly int ObjCSelectorIndex => clang.Cursor_getObjCSelectorIndex(this);
 
+    public readonly CX_ExprObjectKind ObjectKind => clangsharp.Cursor_getObjectKind(this);
+
     public readonly long OffsetOfField => clang.Cursor_getOffsetOfField(this);
 
     public readonly CXCursor OpaqueValue => clangsharp.Cursor_getOpaqueValue(this);
@@ -1953,6 +1955,8 @@ public unsafe partial struct CXCursor : IEquatable<CXCursor>
     public readonly CXCursor UsingEnumDeclEnumDecl => clangsharp.Cursor_getUsingEnumDeclEnumDecl(this);
 
     public readonly CXString Usr => clang.getCursorUSR(this);
+
+    public readonly CX_ExprValueKind ValueKind => clangsharp.Cursor_getValueKind(this);
 
     public readonly CXVisibilityKind Visibility => clang.getCursorVisibility(this);
 

--- a/sources/ClangSharp/Cursors/Exprs/Expr.cs
+++ b/sources/ClangSharp/Cursors/Exprs/Expr.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using ClangSharp.Interop;
 using static ClangSharp.Interop.CX_CastKind;
 using static ClangSharp.Interop.CX_ExprDependence;
+using static ClangSharp.Interop.CX_ExprValueKind;
 using static ClangSharp.Interop.CX_StmtClass;
 using static ClangSharp.Interop.CXUnaryOperatorKind;
 
@@ -122,6 +123,8 @@ public class Expr : ValueStmt
 
     public Expr IgnoreParenLValueCasts => IgnoreExprNodes(this, s_ignoreParensSingleStep, s_ignoreLValueCastsSingleStep);
 
+    public bool IsGLValue => ValueKind is CX_VK_LValue or CX_VK_XValue;
+
     public bool IsImplicitCXXThis
     {
         get
@@ -169,11 +172,21 @@ public class Expr : ValueStmt
 
     public bool IsInstantiationDependent => (Dependence & CX_ED_Instantiation) != 0;
 
+    public bool IsLValue => ValueKind == CX_VK_LValue;
+
+    public bool IsPRValue => ValueKind == CX_VK_PRValue;
+
     public bool IsTypeDependent => (Dependence & CX_ED_Type) != 0;
 
     public bool IsValueDependent => (Dependence & CX_ED_Value) != 0;
 
+    public bool IsXValue => ValueKind == CX_VK_XValue;
+
+    public CX_ExprObjectKind ObjectKind => Handle.ObjectKind;
+
     public Type Type => _type.GetValue(this);
+
+    public CX_ExprValueKind ValueKind => Handle.ValueKind;
 
     private static Expr IgnoreExprNodes(Expr e, Func<Expr, Expr> fn)
     {

--- a/tests/ClangSharp.UnitTests/CursorTests/ExprValueKindTest.cs
+++ b/tests/ClangSharp.UnitTests/CursorTests/ExprValueKindTest.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Linq;
+using ClangSharp.Interop;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+public sealed class ExprValueKindTest : TranslationUnitTest
+{
+    [Test]
+    public void ValueKindTest()
+    {
+        var inputContents = """
+void f(int x)
+{
+    x;
+    42;
+    static_cast<int&&>(x);
+}
+""";
+
+        string[] commandLineArgs = ["-std=c++20"];
+        using var translationUnit = CreateTranslationUnit(inputContents, commandLineArgs: commandLineArgs);
+
+        var func = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>()
+                                  .Single((functionDecl) => functionDecl.Name.Equals("f", StringComparison.Ordinal));
+        var body = func.CursorChildren.OfType<CompoundStmt>().Single();
+
+        var lvalue = body.Children.OfType<DeclRefExpr>().Single();
+        Assert.That(lvalue.ValueKind, Is.EqualTo(CX_ExprValueKind.CX_VK_LValue));
+        Assert.That(lvalue.IsLValue, Is.True);
+        Assert.That(lvalue.IsGLValue, Is.True);
+        Assert.That(lvalue.IsPRValue, Is.False);
+        Assert.That(lvalue.IsXValue, Is.False);
+
+        var prvalue = body.Children.OfType<IntegerLiteral>().Single();
+        Assert.That(prvalue.ValueKind, Is.EqualTo(CX_ExprValueKind.CX_VK_PRValue));
+        Assert.That(prvalue.IsPRValue, Is.True);
+        Assert.That(prvalue.IsGLValue, Is.False);
+
+        var xvalue = body.Children.OfType<CXXStaticCastExpr>().Single();
+        Assert.That(xvalue.ValueKind, Is.EqualTo(CX_ExprValueKind.CX_VK_XValue));
+        Assert.That(xvalue.IsXValue, Is.True);
+        Assert.That(xvalue.IsGLValue, Is.True);
+        Assert.That(xvalue.IsLValue, Is.False);
+    }
+
+    [Test]
+    public void ObjectKindTest()
+    {
+        var inputContents = """
+struct S
+{
+    int b : 3;
+};
+
+void f(S s)
+{
+    s.b;
+    s;
+}
+""";
+
+        using var translationUnit = CreateTranslationUnit(inputContents, commandLineArgs: ["-std=c++20"]);
+
+        var func = translationUnit.TranslationUnitDecl.Decls.OfType<FunctionDecl>()
+                                  .Single((functionDecl) => functionDecl.Name.Equals("f", StringComparison.Ordinal));
+        var body = func.CursorChildren.OfType<CompoundStmt>().Single();
+
+        var bitField = body.Children.OfType<MemberExpr>().Single();
+        Assert.That(bitField.ObjectKind, Is.EqualTo(CX_ExprObjectKind.CX_OK_BitField));
+
+        var ordinary = body.Children.OfType<DeclRefExpr>().Single();
+        Assert.That(ordinary.ObjectKind, Is.EqualTo(CX_ExprObjectKind.CX_OK_Ordinary));
+    }
+}


### PR DESCRIPTION
Surfaces the last non-singleton gap in the v22 interop surface: an `Expr`'s value and object kind.

- `Expr.ValueKind` (`CX_ExprValueKind`) with derived `IsLValue` / `IsPRValue` / `IsXValue` / `IsGLValue`.
- `Expr.ObjectKind` (`CX_ExprObjectKind`).
- `CXCursor.ValueKind` / `ObjectKind` mid-layer accessors they build on.

Both bridges dispatch on any `Expr`, and the enums were already present in the regenerated interop. Foundational for expression analysis (glvalue/prvalue/xvalue categorization, bitfield/ObjC-property/subscript object kinds).

----------

Adds `ExprValueKindTest` covering lvalue/prvalue/xvalue via `x` / `42` / `static_cast<int&&>(x)`, and ordinary vs bitfield object kinds. Full interop suite green (94), 0 warnings.

> [!NOTE]
> Authored with Copilot.
