### PR TITLE
Fix four clang 22 regen regressions (size_t constant macros, __unaligned leak, namespace remap, NativeTypeName namespace)

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -144,6 +144,78 @@ public sealed partial class PInvokeGenerator
         }
     }
 
+    private static string GetNamespaceQualifiedNativeTypeName(Type type, string nativeTypeName)
+    {
+        // Peel pointer/reference/array layers so a stripped namespace is restored even for
+        // `Ns::Point *` and similar, where clang only ever drops the leading `Namespace::`.
+
+        var namedType = type;
+
+        while (true)
+        {
+            if (namedType is PointerType pointerType)
+            {
+                namedType = pointerType.PointeeType;
+            }
+            else if (namedType is ReferenceType referenceType)
+            {
+                namedType = referenceType.PointeeType;
+            }
+            else if (namedType is ArrayType arrayType)
+            {
+                namedType = arrayType.ElementType;
+            }
+            else if (namedType is AttributedType attributedType)
+            {
+                namedType = attributedType.ModifiedType;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        Decl? decl = namedType switch {
+            TagType tagType => tagType.Decl,
+            TypedefType typedefType => typedefType.Decl,
+            _ => null,
+        };
+
+        // A synthesized name for an anonymous decl carries no source namespace to restore.
+        if (decl is null || decl.Handle.IsAnonymous)
+        {
+            return nativeTypeName;
+        }
+
+        return GetNamespaceQualifiedNativeTypeName(decl, nativeTypeName);
+    }
+
+    private static string GetNamespaceQualifiedNativeTypeName(Decl decl, string nativeTypeName)
+    {
+        // clang 22's type printer omits the enclosing C++ namespace from a reference when a
+        // matching `using namespace` is in scope, where-as older releases always spelled it.
+        // Rebuild the dropped `Namespace::` prefix from the decl so the NativeTypeName keeps the
+        // fully qualified source spelling (e.g. `Gdiplus::Status`) and stays stable across versions.
+
+        var qualifierBuilder = new StringBuilder();
+
+        for (var declContext = decl.DeclContext; declContext is Decl parentDecl; declContext = parentDecl.DeclContext)
+        {
+            if (parentDecl is NamespaceDecl namespaceDecl && !string.IsNullOrEmpty(namespaceDecl.Name))
+            {
+                _ = qualifierBuilder.Insert(0, "::").Insert(0, namespaceDecl.Name);
+            }
+        }
+
+        if (qualifierBuilder.Length == 0)
+        {
+            return nativeTypeName;
+        }
+
+        var qualifier = qualifierBuilder.ToString();
+        return nativeTypeName.StartsWith(qualifier, StringComparison.Ordinal) ? nativeTypeName : qualifier + nativeTypeName;
+    }
+
     private string GetCursorQualifiedName(NamedDecl namedDecl, bool truncateParameters = false)
     {
         if (!_cursorQualifiedNames.TryGetValue((namedDecl, truncateParameters), out var qualifiedName))

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -563,40 +563,6 @@ public sealed partial class PInvokeGenerator
         return remappedName;
     }
 
-    private string ApplyTagTypeNameOverrides(TagType tagType, string leafName)
-    {
-        // Keep a `--remap-type` override or a de-clashed nested record name (see
-        // GetRemappedCursorName) consistent between the type declaration and any reference to it,
-        // so both resolve to the same C# type.
-
-        if (_config._remappedTypeNames.Count != 0)
-        {
-            var remappedTypeNamesLookup = _config._remappedTypeNames.GetAlternateLookup<ReadOnlySpan<char>>();
-
-            if (remappedTypeNamesLookup.TryGetValue(leafName, out var remappedTypeName))
-            {
-                return remappedTypeName;
-            }
-        }
-
-        // A `--remap-type` takes precedence over prefix stripping, matching the declaration side.
-        leafName = StripTypePrefix(leafName);
-
-        if ((tagType.Decl is RecordDecl recordDecl) && TryDeclashRecordName(recordDecl, leafName, out var declashedName))
-        {
-            leafName = declashedName;
-        }
-
-        // Mirror the declaration side (see GetRemappedCursorName): a lowercase-only type name is
-        // `@`-escaped so the reference resolves to the same escaped C# type and compiles without CS8981.
-        if (IsLowercaseAsciiOnly(leafName))
-        {
-            leafName = $"@{leafName}";
-        }
-
-        return leafName;
-    }
-
     private bool TryDeclashRecordName(RecordDecl recordDecl, string name, out string declashedName)
     {
         declashedName = name;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Predicates.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Predicates.cs
@@ -907,6 +907,12 @@ public sealed partial class PInvokeGenerator
                 return IsType(cursor, usingType.Desugar, out value);
             }
         }
+        else if (type.IsSugared && (type.Desugar != type))
+        {
+            // A sugar type class we don't specifically handle (e.g. clang 22's
+            // PredefinedSugarType for `size_t`) still desugars to its underlying type.
+            return IsType(cursor, type.Desugar, out value);
+        }
 
         value = default;
         return false;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
@@ -550,6 +550,12 @@ public sealed partial class PInvokeGenerator
             {
                 result.typeName = EscapeName(GetRemappedCursorName(objCInterfaceType.Decl));
             }
+            else if (type.IsSugared && (type.Desugar != type))
+            {
+                // A sugar type class we don't specifically handle (e.g. clang 22's
+                // PredefinedSugarType for `size_t`) still desugars to its underlying type.
+                result.typeName = GetTypeName(cursor, context, rootType, type.Desugar, ignoreTransparentStructsWhereRequired, isTemplate, out _);
+            }
             else
             {
                 AddDiagnostic(DiagnosticLevel.Warning, $"Unsupported type: '{type.TypeClass}'. Falling back '{result.typeName}'.", cursor);

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
@@ -367,33 +367,22 @@ public sealed partial class PInvokeGenerator
                     result.typeName = GetAnonymousName(tagType.Decl, tagType.KindSpelling);
                     result.nativeTypeName = result.typeName;
                 }
-                else if (tagType.Handle.IsConstQualified)
+                else if (tagType.UnqualifiedType != tagType)
                 {
+                    // The type carries a local qualifier (const, volatile, or an MS extension
+                    // such as `__unaligned`) that clang folds into the spelling. Resolve the
+                    // decl's own type so the qualifier keyword doesn't leak into the name.
                     result.typeName = GetTypeName(cursor, context, rootType, tagType.Decl.TypeForDecl, ignoreTransparentStructsWhereRequired, isTemplate, out _);
                 }
                 else
                 {
-                    // The default name should be correct for C++, but C may have a prefix we need to strip
+                    // Resolve the name through the decl so a reference matches its declaration exactly,
+                    // including a `--remap` keyed by the fully qualified name (e.g. `Gdiplus.PointF`).
+                    // clang's type printer may or may not spell the enclosing namespace depending on a
+                    // `using namespace`, so keying off the decl's qualified name rather than the printed
+                    // spelling keeps declarations and references in agreement.
 
-                    if (result.typeName.StartsWith("enum ", StringComparison.Ordinal))
-                    {
-                        result.typeName = result.typeName[5..];
-                    }
-                    else if (result.typeName.StartsWith("struct ", StringComparison.Ordinal))
-                    {
-                        result.typeName = result.typeName[7..];
-                    }
-                    else if (result.typeName.StartsWith("union ", StringComparison.Ordinal))
-                    {
-                        result.typeName = result.typeName[6..];
-                    }
-                }
-
-                if (result.typeName.Contains("::", StringComparison.Ordinal))
-                {
-                    result.typeName = result.typeName.Split(s_doubleColonSeparator, StringSplitOptions.RemoveEmptyEntries).Last();
-                    result.typeName = GetRemappedName(result.typeName, cursor, tryRemapOperatorName: false, out _, skipUsing: true);
-                    result.typeName = ApplyTagTypeNameOverrides(tagType, result.typeName);
+                    result.typeName = GetRemappedCursorName(tagType.Decl, out _, skipUsing: true);
 
                     // A nested type needs to be qualified by its containing type(s) so it resolves
                     // when referenced from another scope (e.g. `A::Inner` -> `A.Inner`). Namespaces
@@ -408,10 +397,6 @@ public sealed partial class PInvokeGenerator
                     }
 
                     result.typeName = qualificationBuilder.Append(result.typeName).ToString();
-                }
-                else
-                {
-                    result.typeName = ApplyTagTypeNameOverrides(tagType, result.typeName);
                 }
             }
             else if (type is TemplateSpecializationType templateSpecializationType)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
@@ -549,6 +549,12 @@ public sealed partial class PInvokeGenerator
             Debug.Assert(!string.IsNullOrWhiteSpace(result.typeName));
             Debug.Assert(!string.IsNullOrWhiteSpace(result.nativeTypeName));
 
+            // clang 22's type printer omits the enclosing C++ namespace from a reference when the
+            // namespace is in scope (a `using namespace` or a reference from within the namespace),
+            // where-as older releases always spelled it. Restore the dropped `Namespace::` prefix from
+            // the referenced decl so the NativeTypeName keeps the fully qualified, version-stable spelling.
+            result.nativeTypeName = GetNamespaceQualifiedNativeTypeName(type, result.nativeTypeName);
+
             if (IsNativeTypeNameEquivalent(result.nativeTypeName, result.typeName))
             {
                 result.nativeTypeName = string.Empty;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -51,7 +51,6 @@ public sealed partial class PInvokeGenerator : IDisposable
 
     private static readonly Encoding s_defaultStreamWriterEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
     private static readonly SearchValues<char> s_lowercaseAsciiLetters = SearchValues.Create("abcdefghijklmnopqrstuvwxyz");
-    private static readonly string[] s_doubleColonSeparator = ["::"];
     private static readonly char[] s_doubleQuoteSeparator = ['"'];
     private static readonly SearchValues<char> s_qualifiedNameSeparatorChars = SearchValues.Create(".:");
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/NamespaceQualifiedNativeTypeNameIsPreservedTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/NamespaceQualifiedNativeTypeNameIsPreservedTest.CSharp.cs
@@ -1,0 +1,32 @@
+namespace ClangSharp.Test
+{
+    public partial struct Point
+    {
+        [NativeTypeName("Ns::Real")]
+        public float X;
+
+        [NativeTypeName("Ns::Real")]
+        public float Y;
+    }
+
+    public enum Status
+    {
+        Err = -1,
+        Ok = 0,
+    }
+
+    public unsafe partial struct Holder
+    {
+        [NativeTypeName("Ns::Point")]
+        public Point point;
+
+        [NativeTypeName("Ns::Point *")]
+        public Point* pointPtr;
+
+        [NativeTypeName("Ns::Real")]
+        public float r;
+
+        [NativeTypeName("Ns::Status")]
+        public Status status;
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/NamespaceQualifiedNativeTypeNameIsPreservedTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/NamespaceQualifiedNativeTypeNameIsPreservedTest.Xml.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="Point" access="public">
+      <field name="X" access="public">
+        <type native="Ns::Real">float</type>
+      </field>
+      <field name="Y" access="public">
+        <type native="Ns::Real">float</type>
+      </field>
+    </struct>
+    <enumeration name="Status" access="public">
+      <type>int</type>
+      <enumerator name="Err" access="public">
+        <type primitive="False">int</type>
+        <value>
+          <code>-1</code>
+        </value>
+      </enumerator>
+      <enumerator name="Ok" access="public">
+        <type primitive="False">int</type>
+        <value>
+          <code>0</code>
+        </value>
+      </enumerator>
+    </enumeration>
+    <struct name="Holder" access="public" unsafe="true">
+      <field name="point" access="public">
+        <type native="Ns::Point">Point</type>
+      </field>
+      <field name="pointPtr" access="public">
+        <type native="Ns::Point *">Point*</type>
+      </field>
+      <field name="r" access="public">
+        <type native="Ns::Real">float</type>
+      </field>
+      <field name="status" access="public">
+        <type native="Ns::Status">Status</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceRemap/NamespaceQualifiedRemapAppliesAtUseSiteTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceRemap/NamespaceQualifiedRemapAppliesAtUseSiteTest.CSharp.cs
@@ -1,0 +1,27 @@
+namespace ClangSharp.Test
+{
+    public partial struct NsPoint
+    {
+        public int X;
+
+        public int Y;
+    }
+
+    public enum NsStatus
+    {
+        Err = -1,
+        Ok = 0,
+    }
+
+    public unsafe partial struct Holder
+    {
+        [NativeTypeName("Ns::Point")]
+        public NsPoint point;
+
+        [NativeTypeName("Ns::Point *")]
+        public NsPoint* pointPtr;
+
+        [NativeTypeName("Ns::Status")]
+        public NsStatus status;
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceRemap/NamespaceQualifiedRemapAppliesAtUseSiteTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceRemap/NamespaceQualifiedRemapAppliesAtUseSiteTest.Xml.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="NsPoint" access="public">
+      <field name="X" access="public">
+        <type>int</type>
+      </field>
+      <field name="Y" access="public">
+        <type>int</type>
+      </field>
+    </struct>
+    <enumeration name="NsStatus" access="public">
+      <type>int</type>
+      <enumerator name="Err" access="public">
+        <type primitive="False">int</type>
+        <value>
+          <code>-1</code>
+        </value>
+      </enumerator>
+      <enumerator name="Ok" access="public">
+        <type primitive="False">int</type>
+        <value>
+          <code>0</code>
+        </value>
+      </enumerator>
+    </enumeration>
+    <struct name="Holder" access="public" unsafe="true">
+      <field name="point" access="public">
+        <type native="Ns::Point">NsPoint</type>
+      </field>
+      <field name="pointPtr" access="public">
+        <type native="Ns::Point *">NsPoint*</type>
+      </field>
+      <field name="status" access="public">
+        <type native="Ns::Status">NsStatus</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/SizeTMacroBinding/SizeTGenerateUnmanagedConstantsMacroTest.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/SizeTMacroBinding/SizeTGenerateUnmanagedConstantsMacroTest.CSharp.Latest.Windows.cs
@@ -1,0 +1,8 @@
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [NativeTypeName("#define MY_INT_SIZE sizeof(int)")]
+        public const ulong MY_INT_SIZE = 4;
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/SizeTMacroBinding/SizeTMacroTest.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/SizeTMacroBinding/SizeTMacroTest.CSharp.Latest.Windows.cs
@@ -1,0 +1,8 @@
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [NativeTypeName("#define MY_INT_SIZE sizeof(int)")]
+        public const ulong MY_INT_SIZE = 4;
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/UnalignedTypeBinding/UnalignedRecordPointerParameterTest.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/UnalignedTypeBinding/UnalignedRecordPointerParameterTest.CSharp.Latest.Windows.cs
@@ -1,0 +1,15 @@
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct tagMETARECORD
+    {
+        public int rdSize;
+    }
+
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?PlayMetaFileRecord@@YAXPEFAUtagMETARECORD@@@Z", ExactSpelling = true)]
+        public static extern void PlayMetaFileRecord([NativeTypeName("LPMETARECORD")] tagMETARECORD* lpMR);
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/NamespaceNativeTypeNameTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/NamespaceNativeTypeNameTest.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests.Baseline;
+
+[TestFixtureSource(nameof(Variants))]
+public sealed class NamespaceNativeTypeNameTest : BaselineTest
+{
+    public NamespaceNativeTypeNameTest(BaselineVariant variant) : base(variant)
+    {
+    }
+
+    protected override string Area => "NamespaceNativeTypeName";
+
+    // clang 22's type printer omits the enclosing C++ namespace from a reference spelled from within that
+    // same namespace, where-as older releases always spelled it. The generator restores the dropped
+    // `Namespace::` prefix from the decl so the emitted `NativeTypeName` keeps the fully qualified source
+    // spelling for typedef, record (including by-pointer), and enum references and stays version-stable.
+    [Test]
+    public Task NamespaceQualifiedNativeTypeNameIsPreservedTest()
+    {
+        var inputContents = @"namespace Ns
+{
+    typedef float Real;
+
+    struct Point
+    {
+        Real X;
+        Real Y;
+    };
+
+    enum Status
+    {
+        Err = -1,
+        Ok = 0,
+    };
+
+    struct Holder
+    {
+        Point point;
+        Point* pointPtr;
+        Real r;
+        Status status;
+    };
+}
+";
+
+        return ValidateAsync(nameof(NamespaceQualifiedNativeTypeNameIsPreservedTest), inputContents);
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/NamespaceRemapTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/NamespaceRemapTest.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests.Baseline;
+
+[TestFixtureSource(nameof(Variants))]
+public sealed class NamespaceRemapTest : BaselineTest
+{
+    public NamespaceRemapTest(BaselineVariant variant) : base(variant)
+    {
+    }
+
+    protected override string Area => "NamespaceRemap";
+
+    // A `--remap` keyed by the fully qualified name of a namespaced C++ type (e.g. `Ns.Point`) must apply to
+    // both the type declaration and every reference to it. The reference resolves through the same decl as the
+    // declaration, so a use-site field must emit the remapped name rather than the unqualified leaf, keeping the
+    // declaration and its references in agreement.
+    [Test]
+    public Task NamespaceQualifiedRemapAppliesAtUseSiteTest()
+    {
+        var inputContents = @"namespace Ns
+{
+    struct Point
+    {
+        int X;
+        int Y;
+    };
+
+    enum Status
+    {
+        Err = -1,
+        Ok = 0,
+    };
+}
+
+struct Holder
+{
+    Ns::Point point;
+    Ns::Point* pointPtr;
+    Ns::Status status;
+};
+";
+
+        var remappedNames = new Dictionary<string, string> {
+            ["Ns.Point"] = "NsPoint",
+            ["Ns.Status"] = "NsStatus",
+        };
+
+        return ValidateAsync(nameof(NamespaceQualifiedRemapAppliesAtUseSiteTest), inputContents, remappedNames: remappedNames);
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/SizeTMacroBindingTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/SizeTMacroBindingTest.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using ClangSharp.UnitTests.Baseline;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>Provides validation that a macro whose value is a <c>size_t</c> expression (clang 22 models this as a
+/// <c>PredefinedSugarType</c> spelled <c>__size_t</c>) resolves to its underlying primitive rather than leaking the
+/// internal type name or emitting a malformed <c>ref readonly</c> getter under <c>unmanaged-constants</c>.</summary>
+[Platform("win")]
+public sealed class SizeTMacroBindingTest : StandaloneBaselineTest
+{
+    protected override string Area => "SizeTMacroBinding";
+
+    [Test]
+    public Task SizeTMacroTest()
+    {
+        var inputContents = @"#define MY_INT_SIZE sizeof(int)";
+
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(inputContents);
+    }
+
+    [Test]
+    public Task SizeTGenerateUnmanagedConstantsMacroTest()
+    {
+        var inputContents = @"#define MY_INT_SIZE sizeof(int)";
+
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(inputContents, PInvokeGeneratorConfigurationOptions.GenerateUnmanagedConstants);
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/UnalignedTypeBindingTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/UnalignedTypeBindingTest.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation and Contributors. All Rights Reserved. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System.Threading.Tasks;
+using ClangSharp.UnitTests.Baseline;
+using NUnit.Framework;
+
+namespace ClangSharp.UnitTests;
+
+/// <summary>Provides validation that a pointer to an <c>__unaligned</c>-qualified record resolves to the record type
+/// rather than leaking the qualifier and elaborated <c>struct</c> keyword (e.g. <c>__unaligned struct tagFoo*</c>),
+/// which is not valid C#.</summary>
+[Platform("win")]
+public sealed class UnalignedTypeBindingTest : StandaloneBaselineTest
+{
+    protected override string Area => "UnalignedTypeBinding";
+
+    [Test]
+    public Task UnalignedRecordPointerParameterTest()
+    {
+        var inputContents = @"typedef struct tagMETARECORD { int rdSize; } METARECORD;
+typedef struct tagMETARECORD __unaligned *LPMETARECORD;
+
+void PlayMetaFileRecord(LPMETARECORD lpMR);";
+
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(inputContents);
+    }
+}


### PR DESCRIPTION
Regenerating terrafx.interop.windows against ClangSharp v22.1.8 (clang 22.1.8) surfaced four issues, all rooted in clang 22's changed type representation (it folds qualifiers into a type's spelling, desugars fewer sugar types on its own, and drops the enclosing namespace from an in-scope reference). Each fix is a focused commit with a golden-file regression test.

----------

**Bug 1 -- `size_t` constant-expression macros emit an uncompilable `ref readonly` getter (blocking)**

An unsigned/`size_t`-typed constant *expression* macro (e.g. `ARRAYSIZE(x) - 1`, `sizeof(...)`) took the experimental `ref readonly` path and emitted a property body that was just the folded expression -- no `return`, no `;` -- so it failed with `CS1002` (and leaked the internal `__size_t` type name). This was the dominant break in the regen (~152 `CS1002` across 26 files). Root cause: clang 22 hands back a sugar type `IsType<T>` no longer recognized, so the macro fell off the constant path. Desugar the unrecognized sugar as a fallback so these import as plain constants again, matching v21.

----------

**Bug 2 -- `__unaligned` + elaborated `struct` specifier leaks into C# (blocking)**

clang 22 folds local qualifiers into a tag type's spelling and no longer emits an `ElaboratedType`, so a `UNALIGNED FAR` pointer typedef leaked `__unaligned struct tagFoo*` -- not valid C#. Resolve the tag name through its decl so the qualifier keywords drop and the elaborated `struct` specifier resolves to the record type.

----------

**Bug 3 -- namespace-qualified (dotted) remap keys stopped applying at use-sites**

A `--remap` keyed by a namespace-qualified name (e.g. `Gdiplus.PointF=@GpPointF`) applied to the type *declaration* but not to *references*, silently renaming `Gp*` back to the unprefixed names the `Gp` prefix existed to avoid. Same root cause as Bug 2 -- the reference was matched by printed string rather than by decl. Resolving through the decl makes the remap apply consistently at declaration and use-site.

----------

**Symptom C -- `NativeTypeName` loses the C++ namespace**

clang 22 omits the enclosing namespace from a reference spelled while that namespace is in scope (a `using namespace` or a reference from within the namespace), where-as older releases always spelled it, so `Gdiplus::Status` degraded to `Status` (~1332 lines in the regen, and it interacts with the Bug 3 remap). Rebuild the dropped `Namespace::` prefix from the referenced decl for typedef, record (including by-pointer), and enum references. The prepend is a no-op when there's no namespace ancestor, the printed name already carries the scope, or the decl is anonymous, so no existing (C-only self-host) baselines change.

----------

Each fix adds a golden-file regression test (`SizeTMacroBinding`, `UnalignedTypeBinding`, `NamespaceRemap`, `NamespaceNativeTypeName`). Full generator suite: 4116 passed / 0 failed, 0 warnings.

> [!NOTE]
> This description was drafted by Copilot.
