### PR TITLE
Fix a second batch of v22 regen regressions (CS1750/CS0182/CS0102/CS0535/CS0246 + ref readonly)

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/ValueDesc.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/ValueDesc.cs
@@ -21,6 +21,7 @@ internal struct ValueDesc
     public readonly bool IsArray => (Flags & ValueFlags.Array) != 0;
     public readonly bool IsConstant => (Flags & ValueFlags.Constant) != 0;
     public readonly bool IsCopy => (Flags & ValueFlags.Copy) != 0;
+    public readonly bool IsReference => (Flags & ValueFlags.Reference) != 0;
     public Action<object> WriteCustomAttrs { get; set; }
     public object CustomAttrGeneratorData { get; set; }
 }

--- a/sources/ClangSharp.PInvokeGenerator/Abstractions/ValueModifiers.cs
+++ b/sources/ClangSharp.PInvokeGenerator/Abstractions/ValueModifiers.cs
@@ -12,4 +12,5 @@ internal enum ValueFlags
     Constant = 1 << 1,
     Copy = 1 << 2,
     Array = 1 << 3,
+    Reference = 1 << 4,
 }

--- a/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/CSharp/CSharpOutputBuilder.VisitDecl.cs
@@ -112,7 +112,7 @@ internal partial class CSharpOutputBuilder : IOutputBuilder
             Write(GetAccessSpecifierString(desc.AccessSpecifier, isNested: true));
             Write(" static ");
 
-            if (_generator.Config.GenerateUnmanagedConstants && desc.IsConstant && !desc.IsCopy)
+            if (_generator.Config.GenerateUnmanagedConstants && desc.IsConstant && (!desc.IsCopy || desc.IsReference))
             {
                 if (desc.IsArray)
                 {

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -502,7 +502,13 @@ public sealed partial class PInvokeGenerator
 
         if (IsType<RecordType>(cxxBaseSpecifier, baseType, out var recordType))
         {
-            return (CXXRecordDecl)recordType.Decl;
+            var recordDecl = (CXXRecordDecl)recordType.Decl;
+
+            // The referenced decl can be a redeclaration (e.g. a MIDL forward `typedef interface`)
+            // rather than the definition. A non-definition carries the base list but no members, so
+            // resolving to the definition is required to flatten every inherited method into the
+            // derived vtable.
+            return (CXXRecordDecl?)recordDecl.Definition ?? recordDecl;
         }
 
         // A dependent base (such as `Base<T>` used within a class template) has no resolved

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
@@ -441,7 +441,10 @@ public sealed partial class PInvokeGenerator
                     {
                         case CXTemplateArgumentKind_Type:
                         {
-                            typeName = GetRemappedTypeName(cursor, context: null, arg.AsType, out var nativeAsTypeName, skipUsing: true, isTemplate: true);
+                            // The argument name is emitted as part of the generic type (e.g.
+                            // `IReference<Matrix4x4>`), so its namespace using must be emitted too;
+                            // the enclosing type name is not itself resolved through `--with-namespace`.
+                            typeName = GetRemappedTypeName(cursor, context: null, arg.AsType, out var nativeAsTypeName, skipUsing: false, isTemplate: true);
                             break;
                         }
 

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitDecl.cs
@@ -1360,7 +1360,7 @@ public partial class PInvokeGenerator
                     if (defaultArg is not null)
                     {
                         csharpOutputBuilder.WriteCustomAttribute("Optional, DefaultParameterValue(", () => {
-                            generator.Visit(defaultArg);
+                            generator.VisitTransparentStructDefaultArg(defaultArg);
                             csharpOutputBuilder.Write(')');
                         });
                     }
@@ -1484,6 +1484,24 @@ public partial class PInvokeGenerator
                    (IsStmtAsWritten<CastExpr>(defaultArg, out var castExpr, removeParens: true) && (castExpr.CastKind == CX_CK_NullToPointer)) ||
                    (IsStmtAsWritten<IntegerLiteral>(defaultArg, out var integerLiteral, removeParens: true) && (integerLiteral.Value == 0));
         }
+    }
+
+    private void VisitTransparentStructDefaultArg(Expr defaultArg)
+    {
+        // A default value cast to a transparent struct (e.g. `S_OK` => `(HRESULT)0`) is not a
+        // constant expression, so `DefaultParameterValue` must receive the underlying constant.
+        if (IsStmtAsWritten<ExplicitCastExpr>(defaultArg, out var castExpr, removeParens: true))
+        {
+            var typeName = GetRemappedTypeName(castExpr, context: null, castExpr.Type, out _);
+
+            if (_config.WithTransparentStructs.ContainsKey(typeName))
+            {
+                Visit(castExpr.SubExprAsWritten);
+                return;
+            }
+        }
+
+        Visit(defaultArg);
     }
 
     private void VisitTranslationUnitDecl(TranslationUnitDecl translationUnitDecl)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
@@ -124,6 +124,14 @@ public partial class PInvokeGenerator
                 flags |= ValueFlags.Constant;
             }
 
+            if (varDecl.HasInit && IsStmtAsWritten<CXXUuidofExpr>(varDecl.Init, out _, removeParens: true))
+            {
+                // A `__uuidof` binding (e.g. WinRT `MIDL_CONST_ID IID& IID_X = __uuidof(X)`) is
+                // already emitted as a `ref readonly Guid` via _uuidsToGenerate; skip the redundant
+                // declaration to avoid a duplicate member.
+                return;
+            }
+
             if (IsStmtAsWritten<StringLiteral>(varDecl.Init, out var stringLiteral, removeParens: true))
             {
                 kind = ValueKind.String;

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
@@ -203,6 +203,15 @@ public partial class PInvokeGenerator
                             // It's easiest just to let _uuidsToGenerate handle it
                             return;
                         }
+
+                        // clang wraps an alias to another constant (e.g. `#define IID_X IID_Y`) in a
+                        // copy-constructor. The referenced constant has backing storage, so keep the
+                        // `ref readonly` alias rather than emitting a by-value copy.
+                        if (IsStmtAsWritten<DeclRefExpr>(cxxConstructExpr.Args[0], out _, removeParens: true))
+                        {
+                            flags |= ValueFlags.Reference;
+                        }
+
                         flags |= ValueFlags.Copy;
                     }
                     else if (IsStmtAsWritten<CXXNullPtrLiteralExpr>(varDecl.Init, out _, removeParens: true))

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.cs
@@ -2511,6 +2511,14 @@ public sealed partial class PInvokeGenerator : IDisposable
                 needsCast = true;
             }
 
+            // A signed-negative value does not implicitly convert to an unsigned target in C#
+            // (e.g. `uint x = -1`), so emit the explicit cast to the target type.
+            if (IsPrevContextDecl<VarDecl>(out _, out _) && IsUnsigned(targetTypeName)
+                && !IsStmtAsWritten<CastExpr>(stmt, out _, removeParens: true) && IsNegativeConstant(stmt))
+            {
+                needsCast = true;
+            }
+
             if (needsCast)
             {
                 _outputBuilder.BeginInnerValue();
@@ -2543,6 +2551,13 @@ public sealed partial class PInvokeGenerator : IDisposable
         {
             VisitStmt(stmt);
         }
+    }
+
+    private static bool IsNegativeConstant(Stmt stmt)
+    {
+        var written = (stmt is Expr expr) ? GetExprAsWritten(expr, removeParens: true) : stmt;
+        var evaluation = written.Handle.Evaluate;
+        return (evaluation.Kind == CXEval_Int) && (evaluation.AsLongLong < 0);
     }
 
     private bool EnumConstantInitNeedsCast(string targetTypeName, Stmt stmt)

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationDllImport/OptionalParameterTransparentStructTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationDllImport/OptionalParameterTransparentStructTest.CSharp.cs
@@ -1,0 +1,13 @@
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void MyFunction([Optional, DefaultParameterValue(0)] HRESULT value);
+
+        [NativeTypeName("#define S_OK ((HRESULT)0L)")]
+        public const int S_OK = ((int)(0));
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationDllImport/OptionalParameterTransparentStructTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationDllImport/OptionalParameterTransparentStructTest.Xml.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <class name="Methods" access="public" static="true">
+      <function name="MyFunction" access="public" lib="ClangSharpPInvokeGenerator" convention="Cdecl" static="true">
+        <type>void</type>
+        <param name="value">
+          <type>HRESULT</type>
+          <init>
+            <code>((HRESULT)(<value>0</value>))</code>
+          </init>
+        </param>
+      </function>
+      <constant name="S_OK" access="public">
+        <type primitive="True">int</type>
+        <value>
+          <code>((int)(<value>0</value>))</code>
+        </value>
+      </constant>
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationDllImport/OptionalParameterUnsignedNegativeLiteralTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationDllImport/OptionalParameterUnsignedNegativeLiteralTest.CSharp.cs
@@ -1,0 +1,10 @@
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public static partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void MyFunction([NativeTypeName("unsigned int")] uint value = unchecked((uint)(-1)));
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationDllImport/OptionalParameterUnsignedNegativeLiteralTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationDllImport/OptionalParameterUnsignedNegativeLiteralTest.Xml.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <class name="Methods" access="public" static="true">
+      <function name="MyFunction" access="public" lib="ClangSharpPInvokeGenerator" convention="Cdecl" static="true">
+        <type>void</type>
+        <param name="value">
+          <type>uint</type>
+          <init>
+            <unchecked>
+              <value>
+                <cast>uint</cast>
+                <value>
+                  <code>-1</code>
+                </value>
+              </value>
+            </unchecked>
+          </init>
+        </param>
+      </function>
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.CSharp.Compatible.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.CSharp.Compatible.cs
@@ -1,0 +1,58 @@
+using ClangSharp.Test;
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    public unsafe partial struct Guid
+    {
+        [NativeTypeName("unsigned long")]
+        public uint Data1;
+
+        [NativeTypeName("unsigned short")]
+        public ushort Data2;
+
+        [NativeTypeName("unsigned short")]
+        public ushort Data3;
+
+        [NativeTypeName("unsigned char[8]")]
+        public fixed byte Data4[8];
+    }
+
+    [Guid("79EAC9E0-BAF9-11CE-8C82-00AA004BA90B")]
+    public partial struct IInternet
+    {
+        public int x;
+    }
+
+    public static partial class Methods
+    {
+        [NativeTypeName("#define IID_IOInet IID_IInternet")]
+        public static ref readonly Guid IID_IOInet => ref IID_IInternet;
+
+        public static ref readonly Guid IID_IInternet
+        {
+            get
+            {
+                ReadOnlySpan<byte> data = new byte[] {
+                    0xE0, 0xC9, 0xEA, 0x79,
+                    0xF9, 0xBA,
+                    0xCE, 0x11,
+                    0x8C,
+                    0x82,
+                    0x00,
+                    0xAA,
+                    0x00,
+                    0x4B,
+                    0xA9,
+                    0x0B
+                };
+
+                Debug.Assert(data.Length == Unsafe.SizeOf<Guid>());
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.CSharp.cs
@@ -1,0 +1,64 @@
+using ClangSharp.Test;
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    public partial struct Guid
+    {
+        [NativeTypeName("unsigned long")]
+        public uint Data1;
+
+        [NativeTypeName("unsigned short")]
+        public ushort Data2;
+
+        [NativeTypeName("unsigned short")]
+        public ushort Data3;
+
+        [NativeTypeName("unsigned char[8]")]
+        public _Data4_e__FixedBuffer Data4;
+
+        [InlineArray(8)]
+        public partial struct _Data4_e__FixedBuffer
+        {
+            public byte e0;
+        }
+    }
+
+    [Guid("79EAC9E0-BAF9-11CE-8C82-00AA004BA90B")]
+    public partial struct IInternet
+    {
+        public int x;
+    }
+
+    public static partial class Methods
+    {
+        [NativeTypeName("#define IID_IOInet IID_IInternet")]
+        public static ref readonly Guid IID_IOInet => ref IID_IInternet;
+
+        public static ref readonly Guid IID_IInternet
+        {
+            get
+            {
+                ReadOnlySpan<byte> data = [
+                    0xE0, 0xC9, 0xEA, 0x79,
+                    0xF9, 0xBA,
+                    0xCE, 0x11,
+                    0x8C,
+                    0x82,
+                    0x00,
+                    0xAA,
+                    0x00,
+                    0x4B,
+                    0xA9,
+                    0x0B
+                ];
+
+                Debug.Assert(data.Length == Unsafe.SizeOf<Guid>());
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.Xml.Compatible.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.Xml.Compatible.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="System">
+    <struct name="Guid" access="public" unsafe="true">
+      <field name="Data1" access="public">
+        <type native="unsigned long">uint</type>
+      </field>
+      <field name="Data2" access="public">
+        <type native="unsigned short">ushort</type>
+      </field>
+      <field name="Data3" access="public">
+        <type native="unsigned short">ushort</type>
+      </field>
+      <field name="Data4" access="public">
+        <type native="unsigned char[8]" count="8" fixed="_Data4_e__FixedBuffer">byte</type>
+      </field>
+    </struct>
+    <struct name="IInternet" access="public" uuid="79eac9e0-baf9-11ce-8c82-00aa004ba90b">
+      <field name="x" access="public">
+        <type>int</type>
+      </field>
+    </struct>
+    <class name="Methods" access="public" static="true">
+      <constant name="IID_IOInet" access="public">
+        <type primitive="False">Guid</type>
+        <value>
+          <code>ref IID_IInternet</code>
+        </value>
+      </constant>
+      <iid name="IID_IInternet" value="0x79EAC9E0, 0xBAF9, 0x11CE, 0x8C, 0x82, 0x00, 0xAA, 0x00, 0x4B, 0xA9, 0x0B" />
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.Xml.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="System">
+    <struct name="Guid" access="public">
+      <field name="Data1" access="public">
+        <type native="unsigned long">uint</type>
+      </field>
+      <field name="Data2" access="public">
+        <type native="unsigned short">ushort</type>
+      </field>
+      <field name="Data3" access="public">
+        <type native="unsigned short">ushort</type>
+      </field>
+      <field name="Data4" access="public">
+        <type native="unsigned char[8]" count="8" fixed="_Data4_e__FixedBuffer">byte</type>
+      </field>
+      <struct name="_Data4_e__FixedBuffer" access="public">
+        <attribute>InlineArray(8)</attribute>
+        <field name="e0" access="public">
+          <type>byte</type>
+        </field>
+      </struct>
+    </struct>
+    <struct name="IInternet" access="public" uuid="79eac9e0-baf9-11ce-8c82-00aa004ba90b">
+      <field name="x" access="public">
+        <type>int</type>
+      </field>
+    </struct>
+    <class name="Methods" access="public" static="true">
+      <constant name="IID_IOInet" access="public">
+        <type primitive="False">Guid</type>
+        <value>
+          <code>ref IID_IInternet</code>
+        </value>
+      </constant>
+      <iid name="IID_IInternet" value="0x79EAC9E0, 0xBAF9, 0x11CE, 0x8C, 0x82, 0x00, 0xAA, 0x00, 0x4B, 0xA9, 0x0B" />
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidInterfaceDuplicateIidTest.CSharp.Compatible.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidInterfaceDuplicateIidTest.CSharp.Compatible.cs
@@ -1,0 +1,55 @@
+using ClangSharp.Test;
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    public unsafe partial struct Guid
+    {
+        [NativeTypeName("unsigned long")]
+        public uint Data1;
+
+        [NativeTypeName("unsigned short")]
+        public ushort Data2;
+
+        [NativeTypeName("unsigned short")]
+        public ushort Data3;
+
+        [NativeTypeName("unsigned char[8]")]
+        public fixed byte Data4[8];
+    }
+
+    [Guid("E504A81C-6B01-4A88-8E1E-000000000000")]
+    public partial struct ITransferTarget
+    {
+        public int x;
+    }
+
+    public static unsafe partial class Methods
+    {
+        public static ref readonly Guid IID_ITransferTarget
+        {
+            get
+            {
+                ReadOnlySpan<byte> data = new byte[] {
+                    0x1C, 0xA8, 0x04, 0xE5,
+                    0x01, 0x6B,
+                    0x88, 0x4A,
+                    0x8E,
+                    0x1E,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00
+                };
+
+                Debug.Assert(data.Length == Unsafe.SizeOf<Guid>());
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidInterfaceDuplicateIidTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidInterfaceDuplicateIidTest.CSharp.cs
@@ -1,0 +1,61 @@
+using ClangSharp.Test;
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    public partial struct Guid
+    {
+        [NativeTypeName("unsigned long")]
+        public uint Data1;
+
+        [NativeTypeName("unsigned short")]
+        public ushort Data2;
+
+        [NativeTypeName("unsigned short")]
+        public ushort Data3;
+
+        [NativeTypeName("unsigned char[8]")]
+        public _Data4_e__FixedBuffer Data4;
+
+        [InlineArray(8)]
+        public partial struct _Data4_e__FixedBuffer
+        {
+            public byte e0;
+        }
+    }
+
+    [Guid("E504A81C-6B01-4A88-8E1E-000000000000")]
+    public partial struct ITransferTarget
+    {
+        public int x;
+    }
+
+    public static unsafe partial class Methods
+    {
+        public static ref readonly Guid IID_ITransferTarget
+        {
+            get
+            {
+                ReadOnlySpan<byte> data = [
+                    0x1C, 0xA8, 0x04, 0xE5,
+                    0x01, 0x6B,
+                    0x88, 0x4A,
+                    0x8E,
+                    0x1E,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00
+                ];
+
+                Debug.Assert(data.Length == Unsafe.SizeOf<Guid>());
+                return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidInterfaceDuplicateIidTest.Xml.Compatible.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidInterfaceDuplicateIidTest.Xml.Compatible.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="System">
+    <struct name="Guid" access="public" unsafe="true">
+      <field name="Data1" access="public">
+        <type native="unsigned long">uint</type>
+      </field>
+      <field name="Data2" access="public">
+        <type native="unsigned short">ushort</type>
+      </field>
+      <field name="Data3" access="public">
+        <type native="unsigned short">ushort</type>
+      </field>
+      <field name="Data4" access="public">
+        <type native="unsigned char[8]" count="8" fixed="_Data4_e__FixedBuffer">byte</type>
+      </field>
+    </struct>
+    <struct name="ITransferTarget" access="public" uuid="e504a81c-6b01-4a88-8e1e-000000000000">
+      <field name="x" access="public">
+        <type>int</type>
+      </field>
+    </struct>
+    <class name="Methods" access="public" static="true" unsafe="true">
+      <iid name="IID_ITransferTarget" value="0xE504A81C, 0x6B01, 0x4A88, 0x8E, 0x1E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00" />
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidInterfaceDuplicateIidTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidInterfaceDuplicateIidTest.Xml.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="System">
+    <struct name="Guid" access="public">
+      <field name="Data1" access="public">
+        <type native="unsigned long">uint</type>
+      </field>
+      <field name="Data2" access="public">
+        <type native="unsigned short">ushort</type>
+      </field>
+      <field name="Data3" access="public">
+        <type native="unsigned short">ushort</type>
+      </field>
+      <field name="Data4" access="public">
+        <type native="unsigned char[8]" count="8" fixed="_Data4_e__FixedBuffer">byte</type>
+      </field>
+      <struct name="_Data4_e__FixedBuffer" access="public">
+        <attribute>InlineArray(8)</attribute>
+        <field name="e0" access="public">
+          <type>byte</type>
+        </field>
+      </struct>
+    </struct>
+    <struct name="ITransferTarget" access="public" uuid="e504a81c-6b01-4a88-8e1e-000000000000">
+      <field name="x" access="public">
+        <type>int</type>
+      </field>
+    </struct>
+    <class name="Methods" access="public" static="true" unsafe="true">
+      <iid name="IID_ITransferTarget" value="0xE504A81C, 0x6B01, 0x4A88, 0x8E, 0x1E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00" />
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/MultiLevelComInheritanceTest.CSharp.Compatible.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/MultiLevelComInheritanceTest.CSharp.Compatible.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct IUnknown
+    {
+        public void** lpVtbl;
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _QueryInterface(IUnknown* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        [return: NativeTypeName("unsigned int")]
+        public delegate uint _AddRef(IUnknown* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        [return: NativeTypeName("unsigned int")]
+        public delegate uint _Release(IUnknown* pThis);
+
+        [VtblIndex(0)]
+        public int QueryInterface()
+        {
+            fixed (IUnknown* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_QueryInterface>((IntPtr)(lpVtbl[0]))(pThis);
+            }
+        }
+
+        [VtblIndex(1)]
+        [return: NativeTypeName("unsigned int")]
+        public uint AddRef()
+        {
+            fixed (IUnknown* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_AddRef>((IntPtr)(lpVtbl[1]))(pThis);
+            }
+        }
+
+        [VtblIndex(2)]
+        [return: NativeTypeName("unsigned int")]
+        public uint Release()
+        {
+            fixed (IUnknown* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Release>((IntPtr)(lpVtbl[2]))(pThis);
+            }
+        }
+    }
+
+    [NativeTypeName("struct ISequentialStream : IUnknown")]
+    public unsafe partial struct ISequentialStream
+    {
+        public void** lpVtbl;
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _QueryInterface(ISequentialStream* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        [return: NativeTypeName("unsigned int")]
+        public delegate uint _AddRef(ISequentialStream* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        [return: NativeTypeName("unsigned int")]
+        public delegate uint _Release(ISequentialStream* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _Read(ISequentialStream* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _Write(ISequentialStream* pThis);
+
+        [VtblIndex(0)]
+        public int QueryInterface()
+        {
+            fixed (ISequentialStream* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_QueryInterface>((IntPtr)(lpVtbl[0]))(pThis);
+            }
+        }
+
+        [VtblIndex(1)]
+        [return: NativeTypeName("unsigned int")]
+        public uint AddRef()
+        {
+            fixed (ISequentialStream* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_AddRef>((IntPtr)(lpVtbl[1]))(pThis);
+            }
+        }
+
+        [VtblIndex(2)]
+        [return: NativeTypeName("unsigned int")]
+        public uint Release()
+        {
+            fixed (ISequentialStream* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Release>((IntPtr)(lpVtbl[2]))(pThis);
+            }
+        }
+
+        [VtblIndex(3)]
+        public int Read()
+        {
+            fixed (ISequentialStream* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Read>((IntPtr)(lpVtbl[3]))(pThis);
+            }
+        }
+
+        [VtblIndex(4)]
+        public int Write()
+        {
+            fixed (ISequentialStream* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Write>((IntPtr)(lpVtbl[4]))(pThis);
+            }
+        }
+    }
+
+    [NativeTypeName("struct IStream : ISequentialStream")]
+    public unsafe partial struct IStream
+    {
+        public void** lpVtbl;
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _QueryInterface(IStream* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        [return: NativeTypeName("unsigned int")]
+        public delegate uint _AddRef(IStream* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        [return: NativeTypeName("unsigned int")]
+        public delegate uint _Release(IStream* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _Read(IStream* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _Write(IStream* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _Seek(IStream* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _Clone(IStream* pThis);
+
+        [VtblIndex(0)]
+        public int QueryInterface()
+        {
+            fixed (IStream* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_QueryInterface>((IntPtr)(lpVtbl[0]))(pThis);
+            }
+        }
+
+        [VtblIndex(1)]
+        [return: NativeTypeName("unsigned int")]
+        public uint AddRef()
+        {
+            fixed (IStream* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_AddRef>((IntPtr)(lpVtbl[1]))(pThis);
+            }
+        }
+
+        [VtblIndex(2)]
+        [return: NativeTypeName("unsigned int")]
+        public uint Release()
+        {
+            fixed (IStream* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Release>((IntPtr)(lpVtbl[2]))(pThis);
+            }
+        }
+
+        [VtblIndex(3)]
+        public int Read()
+        {
+            fixed (IStream* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Read>((IntPtr)(lpVtbl[3]))(pThis);
+            }
+        }
+
+        [VtblIndex(4)]
+        public int Write()
+        {
+            fixed (IStream* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Write>((IntPtr)(lpVtbl[4]))(pThis);
+            }
+        }
+
+        [VtblIndex(5)]
+        public int Seek()
+        {
+            fixed (IStream* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Seek>((IntPtr)(lpVtbl[5]))(pThis);
+            }
+        }
+
+        [VtblIndex(6)]
+        public int Clone()
+        {
+            fixed (IStream* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Clone>((IntPtr)(lpVtbl[6]))(pThis);
+            }
+        }
+    }
+
+    [NativeTypeName("struct IStreamAsync : IStream")]
+    public unsafe partial struct IStreamAsync
+    {
+        public void** lpVtbl;
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _QueryInterface(IStreamAsync* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        [return: NativeTypeName("unsigned int")]
+        public delegate uint _AddRef(IStreamAsync* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        [return: NativeTypeName("unsigned int")]
+        public delegate uint _Release(IStreamAsync* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _Read(IStreamAsync* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _Write(IStreamAsync* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _Seek(IStreamAsync* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _Clone(IStreamAsync* pThis);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        public delegate int _ReadAsync(IStreamAsync* pThis);
+
+        [VtblIndex(0)]
+        public int QueryInterface()
+        {
+            fixed (IStreamAsync* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_QueryInterface>((IntPtr)(lpVtbl[0]))(pThis);
+            }
+        }
+
+        [VtblIndex(1)]
+        [return: NativeTypeName("unsigned int")]
+        public uint AddRef()
+        {
+            fixed (IStreamAsync* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_AddRef>((IntPtr)(lpVtbl[1]))(pThis);
+            }
+        }
+
+        [VtblIndex(2)]
+        [return: NativeTypeName("unsigned int")]
+        public uint Release()
+        {
+            fixed (IStreamAsync* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Release>((IntPtr)(lpVtbl[2]))(pThis);
+            }
+        }
+
+        [VtblIndex(3)]
+        public int Read()
+        {
+            fixed (IStreamAsync* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Read>((IntPtr)(lpVtbl[3]))(pThis);
+            }
+        }
+
+        [VtblIndex(4)]
+        public int Write()
+        {
+            fixed (IStreamAsync* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Write>((IntPtr)(lpVtbl[4]))(pThis);
+            }
+        }
+
+        [VtblIndex(5)]
+        public int Seek()
+        {
+            fixed (IStreamAsync* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Seek>((IntPtr)(lpVtbl[5]))(pThis);
+            }
+        }
+
+        [VtblIndex(6)]
+        public int Clone()
+        {
+            fixed (IStreamAsync* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_Clone>((IntPtr)(lpVtbl[6]))(pThis);
+            }
+        }
+
+        [VtblIndex(7)]
+        public int ReadAsync()
+        {
+            fixed (IStreamAsync* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_ReadAsync>((IntPtr)(lpVtbl[7]))(pThis);
+            }
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/MultiLevelComInheritanceTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/MultiLevelComInheritanceTest.CSharp.cs
@@ -1,0 +1,173 @@
+using System.Runtime.CompilerServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct IUnknown
+    {
+        public void** lpVtbl;
+
+        [VtblIndex(0)]
+        public int QueryInterface()
+        {
+            return ((delegate* unmanaged[Thiscall]<IUnknown*, int>)(lpVtbl[0]))((IUnknown*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(1)]
+        [return: NativeTypeName("unsigned int")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged[Thiscall]<IUnknown*, uint>)(lpVtbl[1]))((IUnknown*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(2)]
+        [return: NativeTypeName("unsigned int")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged[Thiscall]<IUnknown*, uint>)(lpVtbl[2]))((IUnknown*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName("struct ISequentialStream : IUnknown")]
+    public unsafe partial struct ISequentialStream
+    {
+        public void** lpVtbl;
+
+        [VtblIndex(0)]
+        public int QueryInterface()
+        {
+            return ((delegate* unmanaged[Thiscall]<ISequentialStream*, int>)(lpVtbl[0]))((ISequentialStream*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(1)]
+        [return: NativeTypeName("unsigned int")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged[Thiscall]<ISequentialStream*, uint>)(lpVtbl[1]))((ISequentialStream*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(2)]
+        [return: NativeTypeName("unsigned int")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged[Thiscall]<ISequentialStream*, uint>)(lpVtbl[2]))((ISequentialStream*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(3)]
+        public int Read()
+        {
+            return ((delegate* unmanaged[Thiscall]<ISequentialStream*, int>)(lpVtbl[3]))((ISequentialStream*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(4)]
+        public int Write()
+        {
+            return ((delegate* unmanaged[Thiscall]<ISequentialStream*, int>)(lpVtbl[4]))((ISequentialStream*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName("struct IStream : ISequentialStream")]
+    public unsafe partial struct IStream
+    {
+        public void** lpVtbl;
+
+        [VtblIndex(0)]
+        public int QueryInterface()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStream*, int>)(lpVtbl[0]))((IStream*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(1)]
+        [return: NativeTypeName("unsigned int")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStream*, uint>)(lpVtbl[1]))((IStream*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(2)]
+        [return: NativeTypeName("unsigned int")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStream*, uint>)(lpVtbl[2]))((IStream*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(3)]
+        public int Read()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStream*, int>)(lpVtbl[3]))((IStream*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(4)]
+        public int Write()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStream*, int>)(lpVtbl[4]))((IStream*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(5)]
+        public int Seek()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStream*, int>)(lpVtbl[5]))((IStream*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(6)]
+        public int Clone()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStream*, int>)(lpVtbl[6]))((IStream*)Unsafe.AsPointer(ref this));
+        }
+    }
+
+    [NativeTypeName("struct IStreamAsync : IStream")]
+    public unsafe partial struct IStreamAsync
+    {
+        public void** lpVtbl;
+
+        [VtblIndex(0)]
+        public int QueryInterface()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStreamAsync*, int>)(lpVtbl[0]))((IStreamAsync*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(1)]
+        [return: NativeTypeName("unsigned int")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStreamAsync*, uint>)(lpVtbl[1]))((IStreamAsync*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(2)]
+        [return: NativeTypeName("unsigned int")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStreamAsync*, uint>)(lpVtbl[2]))((IStreamAsync*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(3)]
+        public int Read()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStreamAsync*, int>)(lpVtbl[3]))((IStreamAsync*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(4)]
+        public int Write()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStreamAsync*, int>)(lpVtbl[4]))((IStreamAsync*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(5)]
+        public int Seek()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStreamAsync*, int>)(lpVtbl[5]))((IStreamAsync*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(6)]
+        public int Clone()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStreamAsync*, int>)(lpVtbl[6]))((IStreamAsync*)Unsafe.AsPointer(ref this));
+        }
+
+        [VtblIndex(7)]
+        public int ReadAsync()
+        {
+            return ((delegate* unmanaged[Thiscall]<IStreamAsync*, int>)(lpVtbl[7]))((IStreamAsync*)Unsafe.AsPointer(ref this));
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/MultiLevelComInheritanceTest.Xml.Compatible.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/MultiLevelComInheritanceTest.Xml.Compatible.xml
@@ -1,0 +1,370 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="IUnknown" access="public" vtbl="true" unsafe="true">
+      <field name="lpVtbl" access="public">
+        <type>void**</type>
+      </field>
+      <delegate name="_QueryInterface" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>IUnknown*</type>
+        </param>
+      </delegate>
+      <delegate name="_AddRef" access="public" convention="ThisCall">
+        <type native="unsigned int">uint</type>
+        <param name="pThis">
+          <type>IUnknown*</type>
+        </param>
+      </delegate>
+      <delegate name="_Release" access="public" convention="ThisCall">
+        <type native="unsigned int">uint</type>
+        <param name="pThis">
+          <type>IUnknown*</type>
+        </param>
+      </delegate>
+      <function name="QueryInterface" access="public" unsafe="true" vtblindex="0">
+        <type>int</type>
+        <body>
+          <code>fixed (IUnknown* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_QueryInterface</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">0</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="AddRef" access="public" unsafe="true" vtblindex="1">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>fixed (IUnknown* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_AddRef</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">1</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Release" access="public" unsafe="true" vtblindex="2">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>fixed (IUnknown* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Release</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">2</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+    </struct>
+    <struct name="ISequentialStream" access="public" native="struct ISequentialStream : IUnknown" vtbl="true" unsafe="true">
+      <field name="lpVtbl" access="public">
+        <type>void**</type>
+      </field>
+      <delegate name="_QueryInterface" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>ISequentialStream*</type>
+        </param>
+      </delegate>
+      <delegate name="_AddRef" access="public" convention="ThisCall">
+        <type native="unsigned int">uint</type>
+        <param name="pThis">
+          <type>ISequentialStream*</type>
+        </param>
+      </delegate>
+      <delegate name="_Release" access="public" convention="ThisCall">
+        <type native="unsigned int">uint</type>
+        <param name="pThis">
+          <type>ISequentialStream*</type>
+        </param>
+      </delegate>
+      <delegate name="_Read" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>ISequentialStream*</type>
+        </param>
+      </delegate>
+      <delegate name="_Write" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>ISequentialStream*</type>
+        </param>
+      </delegate>
+      <function name="QueryInterface" access="public" unsafe="true" vtblindex="0">
+        <type>int</type>
+        <body>
+          <code>fixed (ISequentialStream* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_QueryInterface</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">0</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="AddRef" access="public" unsafe="true" vtblindex="1">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>fixed (ISequentialStream* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_AddRef</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">1</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Release" access="public" unsafe="true" vtblindex="2">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>fixed (ISequentialStream* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Release</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">2</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Read" access="public" unsafe="true" vtblindex="3">
+        <type>int</type>
+        <body>
+          <code>fixed (ISequentialStream* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Read</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">3</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Write" access="public" unsafe="true" vtblindex="4">
+        <type>int</type>
+        <body>
+          <code>fixed (ISequentialStream* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Write</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">4</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+    </struct>
+    <struct name="IStream" access="public" native="struct IStream : ISequentialStream" vtbl="true" unsafe="true">
+      <field name="lpVtbl" access="public">
+        <type>void**</type>
+      </field>
+      <delegate name="_QueryInterface" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>IStream*</type>
+        </param>
+      </delegate>
+      <delegate name="_AddRef" access="public" convention="ThisCall">
+        <type native="unsigned int">uint</type>
+        <param name="pThis">
+          <type>IStream*</type>
+        </param>
+      </delegate>
+      <delegate name="_Release" access="public" convention="ThisCall">
+        <type native="unsigned int">uint</type>
+        <param name="pThis">
+          <type>IStream*</type>
+        </param>
+      </delegate>
+      <delegate name="_Read" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>IStream*</type>
+        </param>
+      </delegate>
+      <delegate name="_Write" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>IStream*</type>
+        </param>
+      </delegate>
+      <delegate name="_Seek" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>IStream*</type>
+        </param>
+      </delegate>
+      <delegate name="_Clone" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>IStream*</type>
+        </param>
+      </delegate>
+      <function name="QueryInterface" access="public" unsafe="true" vtblindex="0">
+        <type>int</type>
+        <body>
+          <code>fixed (IStream* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_QueryInterface</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">0</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="AddRef" access="public" unsafe="true" vtblindex="1">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>fixed (IStream* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_AddRef</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">1</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Release" access="public" unsafe="true" vtblindex="2">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>fixed (IStream* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Release</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">2</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Read" access="public" unsafe="true" vtblindex="3">
+        <type>int</type>
+        <body>
+          <code>fixed (IStream* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Read</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">3</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Write" access="public" unsafe="true" vtblindex="4">
+        <type>int</type>
+        <body>
+          <code>fixed (IStream* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Write</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">4</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Seek" access="public" unsafe="true" vtblindex="5">
+        <type>int</type>
+        <body>
+          <code>fixed (IStream* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Seek</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">5</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Clone" access="public" unsafe="true" vtblindex="6">
+        <type>int</type>
+        <body>
+          <code>fixed (IStream* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Clone</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">6</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+    </struct>
+    <struct name="IStreamAsync" access="public" native="struct IStreamAsync : IStream" vtbl="true" unsafe="true">
+      <field name="lpVtbl" access="public">
+        <type>void**</type>
+      </field>
+      <delegate name="_QueryInterface" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>IStreamAsync*</type>
+        </param>
+      </delegate>
+      <delegate name="_AddRef" access="public" convention="ThisCall">
+        <type native="unsigned int">uint</type>
+        <param name="pThis">
+          <type>IStreamAsync*</type>
+        </param>
+      </delegate>
+      <delegate name="_Release" access="public" convention="ThisCall">
+        <type native="unsigned int">uint</type>
+        <param name="pThis">
+          <type>IStreamAsync*</type>
+        </param>
+      </delegate>
+      <delegate name="_Read" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>IStreamAsync*</type>
+        </param>
+      </delegate>
+      <delegate name="_Write" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>IStreamAsync*</type>
+        </param>
+      </delegate>
+      <delegate name="_Seek" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>IStreamAsync*</type>
+        </param>
+      </delegate>
+      <delegate name="_Clone" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>IStreamAsync*</type>
+        </param>
+      </delegate>
+      <delegate name="_ReadAsync" access="public" convention="ThisCall">
+        <type>int</type>
+        <param name="pThis">
+          <type>IStreamAsync*</type>
+        </param>
+      </delegate>
+      <function name="QueryInterface" access="public" unsafe="true" vtblindex="0">
+        <type>int</type>
+        <body>
+          <code>fixed (IStreamAsync* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_QueryInterface</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">0</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="AddRef" access="public" unsafe="true" vtblindex="1">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>fixed (IStreamAsync* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_AddRef</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">1</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Release" access="public" unsafe="true" vtblindex="2">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>fixed (IStreamAsync* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Release</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">2</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Read" access="public" unsafe="true" vtblindex="3">
+        <type>int</type>
+        <body>
+          <code>fixed (IStreamAsync* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Read</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">3</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Write" access="public" unsafe="true" vtblindex="4">
+        <type>int</type>
+        <body>
+          <code>fixed (IStreamAsync* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Write</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">4</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Seek" access="public" unsafe="true" vtblindex="5">
+        <type>int</type>
+        <body>
+          <code>fixed (IStreamAsync* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Seek</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">5</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="Clone" access="public" unsafe="true" vtblindex="6">
+        <type>int</type>
+        <body>
+          <code>fixed (IStreamAsync* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_Clone</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">6</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <function name="ReadAsync" access="public" unsafe="true" vtblindex="7">
+        <type>int</type>
+        <body>
+          <code>fixed (IStreamAsync* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_ReadAsync</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">7</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/MultiLevelComInheritanceTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/MultiLevelComInheritanceTest.Xml.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="IUnknown" access="public" vtbl="true" unsafe="true">
+      <field name="lpVtbl" access="public">
+        <type>void**</type>
+      </field>
+      <function name="QueryInterface" access="public" unsafe="true" vtblindex="0">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IUnknown*, int&gt;)(lpVtbl[<vtbl explicit="False">0</vtbl>]))(<param special="thisPtr">(IUnknown*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="AddRef" access="public" unsafe="true" vtblindex="1">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IUnknown*, uint&gt;)(lpVtbl[<vtbl explicit="False">1</vtbl>]))(<param special="thisPtr">(IUnknown*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Release" access="public" unsafe="true" vtblindex="2">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IUnknown*, uint&gt;)(lpVtbl[<vtbl explicit="False">2</vtbl>]))(<param special="thisPtr">(IUnknown*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+    </struct>
+    <struct name="ISequentialStream" access="public" native="struct ISequentialStream : IUnknown" vtbl="true" unsafe="true">
+      <field name="lpVtbl" access="public">
+        <type>void**</type>
+      </field>
+      <function name="QueryInterface" access="public" unsafe="true" vtblindex="0">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;ISequentialStream*, int&gt;)(lpVtbl[<vtbl explicit="False">0</vtbl>]))(<param special="thisPtr">(ISequentialStream*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="AddRef" access="public" unsafe="true" vtblindex="1">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;ISequentialStream*, uint&gt;)(lpVtbl[<vtbl explicit="False">1</vtbl>]))(<param special="thisPtr">(ISequentialStream*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Release" access="public" unsafe="true" vtblindex="2">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;ISequentialStream*, uint&gt;)(lpVtbl[<vtbl explicit="False">2</vtbl>]))(<param special="thisPtr">(ISequentialStream*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Read" access="public" unsafe="true" vtblindex="3">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;ISequentialStream*, int&gt;)(lpVtbl[<vtbl explicit="False">3</vtbl>]))(<param special="thisPtr">(ISequentialStream*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Write" access="public" unsafe="true" vtblindex="4">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;ISequentialStream*, int&gt;)(lpVtbl[<vtbl explicit="False">4</vtbl>]))(<param special="thisPtr">(ISequentialStream*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+    </struct>
+    <struct name="IStream" access="public" native="struct IStream : ISequentialStream" vtbl="true" unsafe="true">
+      <field name="lpVtbl" access="public">
+        <type>void**</type>
+      </field>
+      <function name="QueryInterface" access="public" unsafe="true" vtblindex="0">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStream*, int&gt;)(lpVtbl[<vtbl explicit="False">0</vtbl>]))(<param special="thisPtr">(IStream*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="AddRef" access="public" unsafe="true" vtblindex="1">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStream*, uint&gt;)(lpVtbl[<vtbl explicit="False">1</vtbl>]))(<param special="thisPtr">(IStream*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Release" access="public" unsafe="true" vtblindex="2">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStream*, uint&gt;)(lpVtbl[<vtbl explicit="False">2</vtbl>]))(<param special="thisPtr">(IStream*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Read" access="public" unsafe="true" vtblindex="3">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStream*, int&gt;)(lpVtbl[<vtbl explicit="False">3</vtbl>]))(<param special="thisPtr">(IStream*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Write" access="public" unsafe="true" vtblindex="4">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStream*, int&gt;)(lpVtbl[<vtbl explicit="False">4</vtbl>]))(<param special="thisPtr">(IStream*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Seek" access="public" unsafe="true" vtblindex="5">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStream*, int&gt;)(lpVtbl[<vtbl explicit="False">5</vtbl>]))(<param special="thisPtr">(IStream*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Clone" access="public" unsafe="true" vtblindex="6">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStream*, int&gt;)(lpVtbl[<vtbl explicit="False">6</vtbl>]))(<param special="thisPtr">(IStream*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+    </struct>
+    <struct name="IStreamAsync" access="public" native="struct IStreamAsync : IStream" vtbl="true" unsafe="true">
+      <field name="lpVtbl" access="public">
+        <type>void**</type>
+      </field>
+      <function name="QueryInterface" access="public" unsafe="true" vtblindex="0">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStreamAsync*, int&gt;)(lpVtbl[<vtbl explicit="False">0</vtbl>]))(<param special="thisPtr">(IStreamAsync*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="AddRef" access="public" unsafe="true" vtblindex="1">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStreamAsync*, uint&gt;)(lpVtbl[<vtbl explicit="False">1</vtbl>]))(<param special="thisPtr">(IStreamAsync*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Release" access="public" unsafe="true" vtblindex="2">
+        <type native="unsigned int">uint</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStreamAsync*, uint&gt;)(lpVtbl[<vtbl explicit="False">2</vtbl>]))(<param special="thisPtr">(IStreamAsync*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Read" access="public" unsafe="true" vtblindex="3">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStreamAsync*, int&gt;)(lpVtbl[<vtbl explicit="False">3</vtbl>]))(<param special="thisPtr">(IStreamAsync*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Write" access="public" unsafe="true" vtblindex="4">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStreamAsync*, int&gt;)(lpVtbl[<vtbl explicit="False">4</vtbl>]))(<param special="thisPtr">(IStreamAsync*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Seek" access="public" unsafe="true" vtblindex="5">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStreamAsync*, int&gt;)(lpVtbl[<vtbl explicit="False">5</vtbl>]))(<param special="thisPtr">(IStreamAsync*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="Clone" access="public" unsafe="true" vtblindex="6">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStreamAsync*, int&gt;)(lpVtbl[<vtbl explicit="False">6</vtbl>]))(<param special="thisPtr">(IStreamAsync*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <function name="ReadAsync" access="public" unsafe="true" vtblindex="7">
+        <type>int</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;IStreamAsync*, int&gt;)(lpVtbl[<vtbl explicit="False">7</vtbl>]))(<param special="thisPtr">(IStreamAsync*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/TemplateArgumentNamespaceUsingTest.CSharp.Compatible.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/TemplateArgumentNamespaceUsingTest.CSharp.Compatible.cs
@@ -1,0 +1,37 @@
+using ClangSharp.Test;
+using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+namespace System.Numerics
+{
+    public unsafe partial struct Matrix4x4
+    {
+        [NativeTypeName("float[16]")]
+        public fixed float m[16];
+    }
+
+    public unsafe partial struct ISpatial : ISpatial.Interface
+    {
+        public void** lpVtbl;
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        [return: NativeTypeName("ABI::Windows::Foundation::IReference<ABI::Windows::Foundation::Numerics::Matrix4x4> *")]
+        public delegate IReference<Matrix4x4>* _GetTransform(ISpatial* pThis);
+
+        [return: NativeTypeName("ABI::Windows::Foundation::IReference<ABI::Windows::Foundation::Numerics::Matrix4x4> *")]
+        public IReference<Matrix4x4>* GetTransform()
+        {
+            fixed (ISpatial* pThis = &this)
+            {
+                return Marshal.GetDelegateForFunctionPointer<_GetTransform>((IntPtr)(lpVtbl[0]))(pThis);
+            }
+        }
+
+        public interface Interface
+        {
+            [return: NativeTypeName("ABI::Windows::Foundation::IReference<ABI::Windows::Foundation::Numerics::Matrix4x4> *")]
+            IReference<Matrix4x4>* GetTransform();
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/TemplateArgumentNamespaceUsingTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/TemplateArgumentNamespaceUsingTest.CSharp.cs
@@ -1,0 +1,35 @@
+using ClangSharp.Test;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace System.Numerics
+{
+    public partial struct Matrix4x4
+    {
+        [NativeTypeName("float[16]")]
+        public _m_e__FixedBuffer m;
+
+        [InlineArray(16)]
+        public partial struct _m_e__FixedBuffer
+        {
+            public float e0;
+        }
+    }
+
+    public unsafe partial struct ISpatial : ISpatial.Interface
+    {
+        public void** lpVtbl;
+
+        [return: NativeTypeName("ABI::Windows::Foundation::IReference<ABI::Windows::Foundation::Numerics::Matrix4x4> *")]
+        public IReference<Matrix4x4>* GetTransform()
+        {
+            return ((delegate* unmanaged[Thiscall]<ISpatial*, IReference<Matrix4x4>*>)(lpVtbl[0]))((ISpatial*)Unsafe.AsPointer(ref this));
+        }
+
+        public interface Interface
+        {
+            [return: NativeTypeName("ABI::Windows::Foundation::IReference<ABI::Windows::Foundation::Numerics::Matrix4x4> *")]
+            IReference<Matrix4x4>* GetTransform();
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/TemplateArgumentNamespaceUsingTest.Xml.Compatible.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/TemplateArgumentNamespaceUsingTest.Xml.Compatible.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="System.Numerics">
+    <struct name="Matrix4x4" access="public" unsafe="true">
+      <field name="m" access="public">
+        <type native="float[16]" count="16" fixed="_m_e__FixedBuffer">float</type>
+      </field>
+    </struct>
+    <struct name="ISpatial" access="public" vtbl="true" unsafe="true">
+      <field name="lpVtbl" access="public">
+        <type>void**</type>
+      </field>
+      <delegate name="_GetTransform" access="public" convention="ThisCall" unsafe="true">
+        <type native="ABI::Windows::Foundation::IReference&lt;ABI::Windows::Foundation::Numerics::Matrix4x4&gt; *">IReference&lt;Matrix4x4&gt;*</type>
+        <param name="pThis">
+          <type>ISpatial*</type>
+        </param>
+      </delegate>
+      <function name="GetTransform" access="public" unsafe="true">
+        <type native="ABI::Windows::Foundation::IReference&lt;ABI::Windows::Foundation::Numerics::Matrix4x4&gt; *">IReference&lt;Matrix4x4&gt;*</type>
+        <body>
+          <code>fixed (ISpatial* pThis = &amp;this)
+    {
+        return Marshal.GetDelegateForFunctionPointer&lt;<delegate>_GetTransform</delegate>&gt;((IntPtr)(lpVtbl[<vtbl explicit="False">0</vtbl>]))(<param special="thisPtr">pThis</param>);
+    }</code>
+        </body>
+      </function>
+      <interface>
+        <function name="GetTransform" access="public" unsafe="true">
+          <type native="ABI::Windows::Foundation::IReference&lt;ABI::Windows::Foundation::Numerics::Matrix4x4&gt; *">IReference&lt;Matrix4x4&gt;*</type>
+        </function>
+      </interface>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/TemplateArgumentNamespaceUsingTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/TemplateArgumentNamespaceUsingTest.Xml.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="System.Numerics">
+    <struct name="Matrix4x4" access="public">
+      <field name="m" access="public">
+        <type native="float[16]" count="16" fixed="_m_e__FixedBuffer">float</type>
+      </field>
+      <struct name="_m_e__FixedBuffer" access="public">
+        <attribute>InlineArray(16)</attribute>
+        <field name="e0" access="public">
+          <type>float</type>
+        </field>
+      </struct>
+    </struct>
+    <struct name="ISpatial" access="public" vtbl="true" unsafe="true">
+      <field name="lpVtbl" access="public">
+        <type>void**</type>
+      </field>
+      <function name="GetTransform" access="public" unsafe="true">
+        <type native="ABI::Windows::Foundation::IReference&lt;ABI::Windows::Foundation::Numerics::Matrix4x4&gt; *">IReference&lt;Matrix4x4&gt;*</type>
+        <body>
+          <code>return ((delegate* unmanaged[Thiscall]&lt;ISpatial*, IReference&lt;Matrix4x4&gt;*&gt;)(lpVtbl[<vtbl explicit="False">0</vtbl>]))(<param special="thisPtr">(ISpatial*)Unsafe.AsPointer(ref this)</param>);</code>
+        </body>
+      </function>
+      <interface>
+        <function name="GetTransform" access="public" unsafe="true">
+          <type native="ABI::Windows::Foundation::IReference&lt;ABI::Windows::Foundation::Numerics::Matrix4x4&gt; *">IReference&lt;Matrix4x4&gt;*</type>
+        </function>
+      </interface>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/FunctionDeclarationDllImportTest.cs
@@ -141,6 +141,16 @@ struct MyStruct
     }
 
     [Test]
+    public Task OptionalParameterUnsignedNegativeLiteralTest()
+    {
+        // A bare negative literal default on an unsigned parameter must keep the explicit `(uint)` cast; otherwise
+        // `unchecked(-1)` stays `int` and fails to bind to the `uint` parameter (CS1750).
+        var inputContents = @"extern ""C"" void MyFunction(unsigned int value = -1);";
+
+        return ValidateAsync(nameof(OptionalParameterUnsignedNegativeLiteralTest), inputContents);
+    }
+
+    [Test]
     public Task WithCallConvTest()
     {
         var inputContents = @"extern ""C"" void MyFunction1(int value); extern ""C"" void MyFunction2(int value);";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/FunctionDeclarationDllImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/FunctionDeclarationDllImportTest.cs
@@ -151,6 +151,24 @@ struct MyStruct
     }
 
     [Test]
+    public Task OptionalParameterTransparentStructTest()
+    {
+        // A transparent-struct-typed parameter default must emit the bare constant. Wrapping it in a cast to the
+        // struct (`((HRESULT)(0))`) is not a constant expression and fails inside `DefaultParameterValue` (CS0182).
+        var inputContents = @"typedef long HRESULT;
+#define S_OK ((HRESULT)0L)
+
+extern ""C"" void MyFunction(HRESULT value = S_OK);";
+
+        var withTransparentStructs = new Dictionary<string, (string, PInvokeGeneratorTransparentStructKind)>
+        {
+            ["HRESULT"] = ("int", PInvokeGeneratorTransparentStructKind.Unknown)
+        };
+        var remappedNames = new Dictionary<string, string> { ["HRESULT"] = "HRESULT" };
+        return ValidateAsync(nameof(OptionalParameterTransparentStructTest), inputContents, remappedNames: remappedNames, withTransparentStructs: withTransparentStructs);
+    }
+
+    [Test]
     public Task WithCallConvTest()
     {
         var inputContents = @"extern ""C"" void MyFunction1(int value); extern ""C"" void MyFunction2(int value);";

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
@@ -722,6 +722,27 @@ struct IStreamAsync : public IStream
         return ValidateAsync(nameof(MultiLevelComInheritanceTest), inputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateVtblIndexAttribute);
     }
 
+    [Test]
+    public Task TemplateArgumentNamespaceUsingTest()
+    {
+        // A namespaced type (System.Numerics.Matrix4x4) used only as a generic-pointer-wrapper template argument
+        // must still emit its `using`; dropping it leaves the `Matrix4x4` reference unresolved (CS0246).
+        var inputContents = @"namespace ABI { namespace Windows { namespace Foundation {
+    template<typename T> struct IReference { T value; };
+    namespace Numerics { struct Matrix4x4 { float m[16]; }; }
+}}}
+
+struct ISpatial
+{
+    virtual ABI::Windows::Foundation::IReference<ABI::Windows::Foundation::Numerics::Matrix4x4>* GetTransform() = 0;
+};
+";
+
+        var remappedNames = new Dictionary<string, string> { ["ABI.Windows.Foundation.Numerics.Matrix4x4"] = "Matrix4x4" };
+        var withNamespaces = new Dictionary<string, string> { ["Matrix4x4"] = "System.Numerics" };
+        return ValidateAsync(nameof(TemplateArgumentNamespaceUsingTest), inputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateGenericPointerWrapper | PInvokeGeneratorConfigurationOptions.GenerateMarkerInterfaces, remappedNames: remappedNames, withNamespaces: withNamespaces);
+    }
+
     [TestCase("double", "double", 10, 5)]
     [TestCase("short", "short", 10, 5)]
     [TestCase("int", "int", 10, 5)]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
@@ -14,6 +14,7 @@ public sealed class StructDeclarationTest : BaselineTest
     private static readonly string[] ExcludeWildcardTestExcludedNames = ["Foo*", "*Legacy", "B?r"];
     private static readonly string[] GuidTestExcludedNames = ["DECLSPEC_UUID"];
     private static readonly string[] GuidConstTestExcludedNames = ["DECLSPEC_UUID", "GUID"];
+    private static readonly string[] GuidDefineAliasTestExcludedNames = ["DECLSPEC_UUID", "EXTERN_C"];
 
     public StructDeclarationTest(BaselineVariant variant) : base(variant)
     {
@@ -592,6 +593,48 @@ static const IID& IID_ITransferTarget = __uuidof(ITransferTarget);
 
         var remappedNames = new Dictionary<string, string> { ["_GUID"] = "Guid", ["GUID"] = "Guid" };
         return ValidateAsync(nameof(GuidInterfaceDuplicateIidTest), inputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateUnmanagedConstants, excludedNames: GuidTestExcludedNames, remappedNames: remappedNames);
+    }
+
+    [Test]
+    public Task GuidDefineAliasRefReadonlyTest()
+    {
+        if (Variant.Os != BaselineOs.Windows)
+        {
+            // Non-Windows doesn't support __declspec(uuid(""))
+            return Task.CompletedTask;
+        }
+
+        // A `#define IID_X IID_Y` alias over a `ref readonly Guid` IID must keep the `ref readonly` return so it
+        // stays a zero-copy alias; dropping it leaves a by-value `Guid` return paired with a `=> ref` body.
+        var inputContents = @"#define DECLSPEC_UUID(x) __declspec(uuid(x))
+#define EXTERN_C extern ""C""
+
+struct _GUID
+{
+    unsigned long  Data1;
+    unsigned short Data2;
+    unsigned short Data3;
+    unsigned char  Data4[8];
+};
+
+typedef struct _GUID GUID;
+typedef GUID IID;
+
+struct DECLSPEC_UUID(""79eac9e0-baf9-11ce-8c82-00aa004ba90b"") IInternet
+{
+    int x;
+};
+
+EXTERN_C const IID IID_IInternet;
+
+#define IID_IOInet IID_IInternet
+";
+
+        var remappedNames = new Dictionary<string, string> { ["_GUID"] = "Guid", ["GUID"] = "Guid" };
+        return ValidateAsync(nameof(GuidDefineAliasRefReadonlyTest), inputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateUnmanagedConstants | PInvokeGeneratorConfigurationOptions.GenerateMacroBindings, excludedNames: GuidDefineAliasTestExcludedNames, remappedNames: remappedNames);
+    }
+
+    [Test]
     public Task InheritanceTest()
     {
         var inputContents = @"struct MyStruct1A

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
@@ -684,6 +684,44 @@ struct MyStruct2 : MyStruct1A, MyStruct1B
         return ValidateAsync(nameof(InheritanceWithNativeInheritanceAttributeTest), inputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateNativeInheritanceAttribute);
     }
 
+    [Test]
+    public Task MultiLevelComInheritanceTest()
+    {
+        // When an intermediate base is reached through a forward `typedef struct X X;` (as MIDL interfaces are
+        // declared), clang binds the base to a non-definition redeclaration whose own members would otherwise be
+        // dropped. All inherited vtbl slots must still flatten in order (CS0535 when they don't).
+        var inputContents = @"struct IUnknown
+{
+    virtual int QueryInterface() = 0;
+    virtual unsigned int AddRef() = 0;
+    virtual unsigned int Release() = 0;
+};
+
+struct ISequentialStream : public IUnknown
+{
+    virtual int Read() = 0;
+    virtual int Write() = 0;
+};
+
+typedef struct IStream IStream;
+
+struct IStream : public ISequentialStream
+{
+    virtual int Seek() = 0;
+    virtual int Clone() = 0;
+};
+
+struct IStream;
+
+struct IStreamAsync : public IStream
+{
+    virtual int ReadAsync() = 0;
+};
+";
+
+        return ValidateAsync(nameof(MultiLevelComInheritanceTest), inputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateVtblIndexAttribute);
+    }
+
     [TestCase("double", "double", 10, 5)]
     [TestCase("short", "short", 10, 5)]
     [TestCase("int", "int", 10, 5)]

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
@@ -559,6 +559,39 @@ EXTERN_C const IID IID_ITextHost;
     }
 
     [Test]
+    public Task GuidInterfaceDuplicateIidTest()
+    {
+        if (Variant.Os != BaselineOs.Windows)
+        {
+            // Non-Windows doesn't support __declspec(uuid(""))
+            return Task.CompletedTask;
+        }
+
+        // A `static const IID&` alias initialized from `__uuidof` names the same `IID_` symbol the interface's uuid
+        // already emits. Only one definition may be generated; the alias var must not add a second (CS0102).
+        var inputContents = @"#define DECLSPEC_UUID(x) __declspec(uuid(x))
+
+struct _GUID
+{
+    unsigned long  Data1;
+    unsigned short Data2;
+    unsigned short Data3;
+    unsigned char  Data4[8];
+};
+
+typedef struct _GUID GUID;
+typedef GUID IID;
+
+struct DECLSPEC_UUID(""e504a81c-6b01-4a88-8e1e-000000000000"") ITransferTarget
+{
+    int x;
+};
+
+static const IID& IID_ITransferTarget = __uuidof(ITransferTarget);
+";
+
+        var remappedNames = new Dictionary<string, string> { ["_GUID"] = "Guid", ["GUID"] = "Guid" };
+        return ValidateAsync(nameof(GuidInterfaceDuplicateIidTest), inputContents, additionalConfigOptions: PInvokeGeneratorConfigurationOptions.GenerateUnmanagedConstants, excludedNames: GuidTestExcludedNames, remappedNames: remappedNames);
     public Task InheritanceTest()
     {
         var inputContents = @"struct MyStruct1A


### PR DESCRIPTION
Fixes a second batch of v22.1.8 (clang 22.1.8) regressions found regenerating `terrafx.interop.windows`. Each is an independent codegen bug with a focused commit carrying its fix, a regression test, and unified baselines. All six were verified against faithful synthetic repros with the release generator, and the full generator suite is green (4164 passed, 0 warnings).

| Bug | Code | Symptom |
|-----|------|---------|
| B1 | CS1750 | unsigned default parameter drops the `(uint)` cast |
| B2 | CS0182 | transparent-struct default wrapped in a non-const cast |
| A | CS0102 | `__uuidof` constant alias emits a duplicate IID |
| E | *(silent)* | `ref readonly` dropped from GUID `#define` aliases |
| C | CS0535 | multi-level COM inheritance drops the immediate base's members |
| D | CS0246 | dropped `using System.Numerics;` while still using `Matrix4x4` |

----------

**B1 — unsigned default parameter drops the `(uint)` cast (CS1750)**

A bare negative literal default on an unsigned parameter emitted `unchecked(-1)`, which is `int` and won't bind to the `uint` parameter. An explicit `UINT(-1)` default was unaffected; only a bare `-1` lost the cast.

```cpp
extern "C" void MyFunction(unsigned int value = -1);
```
Now emits `uint value = unchecked((uint)(-1))`.

----------

**B2 — transparent-struct default wrapped in a non-const cast (CS0182)**

A transparent-struct-typed default was wrapped in `((HRESULT)(0))`, which isn't a constant expression and fails inside `DefaultParameterValue`. Emit the bare constant (`DefaultParameterValue(0)`), matching v21.

----------

**A — `__uuidof` constant alias emits a duplicate IID (CS0102)**

A `static const IID&` alias initialized from `__uuidof` names the same `IID_` symbol the interface's uuid already emits via `_uuidsToGenerate`, so a second definition was generated (same member name twice, plus a `Guid*`-typed field assigned a `Guid`). Skip the redundant declaration.

----------

**E — `ref readonly` dropped from GUID `#define` aliases**

For `#define IID_X IID_Y` aliases the generator kept a `=> ref IID_Y` body but lost the `ref readonly` on the return type, leaving a by-value `Guid` return paired with a `ref` body — semantically a copy, and `CS8149` in isolation. Preserve the reference so the alias stays zero-copy.

```diff
-public static Guid IID_IOInet => ref IID_IInternet;
+public static ref readonly Guid IID_IOInet => ref IID_IInternet;
```

----------

**C — multi-level COM inheritance drops the immediate base's members (CS0535)**

`IStreamAsync : IStream : ISequentialStream : IUnknown`. When the intermediate base is reached through a forward `typedef struct IStream IStream;` (as MIDL interfaces are declared), clang binds it to a non-definition redeclaration whose members were dropped — so `IStreamAsync` flattened IUnknown/ISequentialStream then jumped straight to its own member, skipping IStream's `Seek`…`Clone`. Resolve the record to its definition so every inherited vtbl slot flattens in order.

----------

**D — dropped `using System.Numerics;` while still using `Matrix4x4` (CS0246)**

A namespaced type (`System.Numerics.Matrix4x4`) used only as a generic-pointer-wrapper template argument dropped its `using`, leaving the `Matrix4x4` reference unresolved. Keep the using.

----------

Baselines are unified to the repo convention: B1/B2 collapse to a single `{Mode}` file (identical across all 16 variants); A/E/C/D collapse to `{Mode}` + `{Mode}.Compatible` (the `Compatible` config differs only by down-level codegen — collection expressions vs `new byte[]`, `InlineArray` vs `fixed`).
