### PR TITLE
Fix v22 regen regressions: namespace qualifier placement, nested-type over-qualification, computed-pointer GUID ref readonly

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -213,7 +213,30 @@ public sealed partial class PInvokeGenerator
         }
 
         var qualifier = qualifierBuilder.ToString();
-        return nativeTypeName.StartsWith(qualifier, StringComparison.Ordinal) ? nativeTypeName : qualifier + nativeTypeName;
+
+        // The qualifier belongs on the type name, after any leading cv-qualifiers, so a `const`
+        // pointer stays `const Ns::Point *` rather than the malformed `Ns::const Point *`.
+        var offset = 0;
+
+        while (true)
+        {
+            var rest = nativeTypeName.AsSpan(offset);
+
+            if (rest.StartsWith("const ", StringComparison.Ordinal))
+            {
+                offset += 6;
+            }
+            else if (rest.StartsWith("volatile ", StringComparison.Ordinal))
+            {
+                offset += 9;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return nativeTypeName.AsSpan(offset).StartsWith(qualifier, StringComparison.Ordinal) ? nativeTypeName : nativeTypeName.Insert(offset, qualifier);
     }
 
     private string GetCursorQualifiedName(NamedDecl namedDecl, bool truncateParameters = false)

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -190,6 +190,11 @@ public sealed partial class PInvokeGenerator
         return GetNamespaceQualifiedNativeTypeName(decl, nativeTypeName);
     }
 
+    // Tokens the clang type printer can spell before a type's nested-name-specifier: cv-qualifiers,
+    // elaborated tag keywords, and the MS `__unaligned` type qualifier. A restored `Namespace::`
+    // qualifier belongs on the type name, after any leading run of these.
+    private static readonly string[] s_leadingTypeQualifiers = ["const ", "volatile ", "struct ", "class ", "union ", "enum ", "__unaligned "];
+
     private static string GetNamespaceQualifiedNativeTypeName(Decl decl, string nativeTypeName)
     {
         // clang 22's type printer omits the enclosing C++ namespace from a reference when a
@@ -214,23 +219,27 @@ public sealed partial class PInvokeGenerator
 
         var qualifier = qualifierBuilder.ToString();
 
-        // The qualifier belongs on the type name, after any leading cv-qualifiers, so a `const`
-        // pointer stays `const Ns::Point *` rather than the malformed `Ns::const Point *`.
+        // The qualifier belongs on the type name, after any leading cv-qualifiers, elaborated tag
+        // keywords, or `__unaligned`, so e.g. a `const struct` pointer stays `const struct Ns::Point *`
+        // rather than the malformed `Ns::const struct Point *`.
         var offset = 0;
 
         while (true)
         {
             var rest = nativeTypeName.AsSpan(offset);
+            var matched = false;
 
-            if (rest.StartsWith("const ", StringComparison.Ordinal))
+            foreach (var prefix in s_leadingTypeQualifiers)
             {
-                offset += 6;
+                if (rest.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    offset += prefix.Length;
+                    matched = true;
+                    break;
+                }
             }
-            else if (rest.StartsWith("volatile ", StringComparison.Ordinal))
-            {
-                offset += 9;
-            }
-            else
+
+            if (!matched)
             {
                 break;
             }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.TypeResolution.cs
@@ -385,12 +385,24 @@ public sealed partial class PInvokeGenerator
                     result.typeName = GetRemappedCursorName(tagType.Decl, out _, skipUsing: true);
 
                     // A nested type needs to be qualified by its containing type(s) so it resolves
-                    // when referenced from another scope (e.g. `A::Inner` -> `A.Inner`). Namespaces
-                    // are flattened away, so only walk the enclosing record decls.
+                    // when referenced from another scope (e.g. `A::Inner` -> `A.Inner`). A reference
+                    // from within a containing type sees the nested type directly, so only qualify
+                    // up to the scope shared with the reference site. Namespaces are flattened away,
+                    // so only walk the enclosing record decls.
+
+                    var referenceScope = new HashSet<Decl>();
+
+                    for (var refContext = (cursor as Decl)?.DeclContext ?? (context as Decl)?.DeclContext; refContext is Decl refParent; refContext = refParent.DeclContext)
+                    {
+                        if (refParent is RecordDecl)
+                        {
+                            _ = referenceScope.Add(refParent);
+                        }
+                    }
 
                     var qualificationBuilder = new StringBuilder();
 
-                    for (var declContext = tagType.Decl.DeclContext; declContext is RecordDecl parentRecordDecl; declContext = parentRecordDecl.DeclContext)
+                    for (var declContext = tagType.Decl.DeclContext; declContext is RecordDecl parentRecordDecl && !referenceScope.Contains(parentRecordDecl); declContext = parentRecordDecl.DeclContext)
                     {
                         var parentRecordDeclName = GetRemappedCursorName(parentRecordDecl, out _, skipUsing: true);
                         _ = qualificationBuilder.Insert(0, '.').Insert(0, EscapeName(parentRecordDeclName));

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -749,27 +749,38 @@ public partial class PInvokeGenerator
 
         if (args.Count != 0)
         {
-            if (isUnmanagedConstant)
+            if (isUnmanagedConstant
+             && IsStmtAsWritten<UnaryOperator>(args[0], out var derefOperator, removeParens: true)
+             && (derefOperator.Opcode == CXUnaryOperator_Deref))
             {
-                outputBuilder.Write("ref ");
+                // A computed-pointer GUID macro (e.g. `MAKEDIPROP(n)` -> `*(const GUID*)(n)`) is exposed
+                // as the pointer itself, so emit its operand rather than a byref to arbitrary memory.
+                Visit(derefOperator.SubExpr);
             }
-
-            var needsComma = false;
-
-            for (var i = 0; i < args.Count; i++)
+            else
             {
-                var arg = args[i];
-
-                if (needsComma && (arg is not CXXDefaultArgExpr))
+                if (isUnmanagedConstant)
                 {
-                    outputBuilder.Write(", ");
+                    outputBuilder.Write("ref ");
                 }
 
-                Visit(arg);
+                var needsComma = false;
 
-                if (arg is not CXXDefaultArgExpr)
+                for (var i = 0; i < args.Count; i++)
                 {
-                    needsComma = true;
+                    var arg = args[i];
+
+                    if (needsComma && (arg is not CXXDefaultArgExpr))
+                    {
+                        outputBuilder.Write(", ");
+                    }
+
+                    Visit(arg);
+
+                    if (arg is not CXXDefaultArgExpr)
+                    {
+                        needsComma = true;
+                    }
                 }
             }
         }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
@@ -204,10 +204,12 @@ public partial class PInvokeGenerator
                             return;
                         }
 
-                        // clang wraps an alias to another constant (e.g. `#define IID_X IID_Y`) in a
-                        // copy-constructor. The referenced constant has backing storage, so keep the
-                        // `ref readonly` alias rather than emitting a by-value copy.
-                        if (IsStmtAsWritten<DeclRefExpr>(cxxConstructExpr.Args[0], out _, removeParens: true))
+                        // clang wraps an alias to another constant (e.g. `#define IID_X IID_Y`) or a
+                        // pointer dereference (e.g. `#define X MAKEDIPROP(n)` -> `*(const GUID*)(n)`) in a
+                        // copy-constructor. Both reference backing storage, so keep the `ref readonly` alias
+                        // rather than emitting a by-value copy.
+                        if (IsStmtAsWritten<DeclRefExpr>(cxxConstructExpr.Args[0], out _, removeParens: true)
+                         || (IsStmtAsWritten<UnaryOperator>(cxxConstructExpr.Args[0], out var unaryOperator, removeParens: true) && (unaryOperator.Opcode == CXUnaryOperator_Deref)))
                         {
                             flags |= ValueFlags.Reference;
                         }

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitVarDecl.cs
@@ -206,12 +206,19 @@ public partial class PInvokeGenerator
 
                         // clang wraps an alias to another constant (e.g. `#define IID_X IID_Y`) or a
                         // pointer dereference (e.g. `#define X MAKEDIPROP(n)` -> `*(const GUID*)(n)`) in a
-                        // copy-constructor. Both reference backing storage, so keep the `ref readonly` alias
-                        // rather than emitting a by-value copy.
-                        if (IsStmtAsWritten<DeclRefExpr>(cxxConstructExpr.Args[0], out _, removeParens: true)
-                         || (IsStmtAsWritten<UnaryOperator>(cxxConstructExpr.Args[0], out var unaryOperator, removeParens: true) && (unaryOperator.Opcode == CXUnaryOperator_Deref)))
+                        // copy-constructor.
+                        if (IsStmtAsWritten<DeclRefExpr>(cxxConstructExpr.Args[0], out _, removeParens: true))
                         {
+                            // An alias references the other constant's backing storage, so keep the
+                            // `ref readonly` alias rather than emitting a by-value copy.
                             flags |= ValueFlags.Reference;
+                        }
+                        else if (IsStmtAsWritten<UnaryOperator>(cxxConstructExpr.Args[0], out var unaryOperator, removeParens: true) && (unaryOperator.Opcode == CXUnaryOperator_Deref))
+                        {
+                            // The dereference targets an arbitrary address (typically illegal to read),
+                            // so expose the pointer itself; a managed byref to it would not be valid.
+                            typeName += '*';
+                            _topLevelClassIsUnsafe[className] = true;
                         }
 
                         flags |= ValueFlags.Copy;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/NamespaceQualifiedNativeTypeNameIsPreservedTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/NamespaceQualifiedNativeTypeNameIsPreservedTest.CSharp.cs
@@ -29,6 +29,15 @@ namespace ClangSharp.Test
         [NativeTypeName("const Ns::Real *")]
         public float* constRealPtr;
 
+        [NativeTypeName("struct Ns::Point *")]
+        public Point* elabPointPtr;
+
+        [NativeTypeName("const struct Ns::Point *")]
+        public Point* constElabPointPtr;
+
+        [NativeTypeName("enum Ns::Status *")]
+        public Status* elabStatusPtr;
+
         [NativeTypeName("Ns::Real")]
         public float r;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/NamespaceQualifiedNativeTypeNameIsPreservedTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/NamespaceQualifiedNativeTypeNameIsPreservedTest.CSharp.cs
@@ -23,6 +23,12 @@ namespace ClangSharp.Test
         [NativeTypeName("Ns::Point *")]
         public Point* pointPtr;
 
+        [NativeTypeName("const Ns::Point *")]
+        public Point* constPointPtr;
+
+        [NativeTypeName("const Ns::Real *")]
+        public float* constRealPtr;
+
         [NativeTypeName("Ns::Real")]
         public float r;
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/NamespaceQualifiedNativeTypeNameIsPreservedTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/NamespaceQualifiedNativeTypeNameIsPreservedTest.Xml.xml
@@ -37,6 +37,15 @@
       <field name="constRealPtr" access="public">
         <type native="const Ns::Real *">float*</type>
       </field>
+      <field name="elabPointPtr" access="public">
+        <type native="struct Ns::Point *">Point*</type>
+      </field>
+      <field name="constElabPointPtr" access="public">
+        <type native="const struct Ns::Point *">Point*</type>
+      </field>
+      <field name="elabStatusPtr" access="public">
+        <type native="enum Ns::Status *">Status*</type>
+      </field>
       <field name="r" access="public">
         <type native="Ns::Real">float</type>
       </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/NamespaceQualifiedNativeTypeNameIsPreservedTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/NamespaceQualifiedNativeTypeNameIsPreservedTest.Xml.xml
@@ -31,6 +31,12 @@
       <field name="pointPtr" access="public">
         <type native="Ns::Point *">Point*</type>
       </field>
+      <field name="constPointPtr" access="public">
+        <type native="const Ns::Point *">Point*</type>
+      </field>
+      <field name="constRealPtr" access="public">
+        <type native="const Ns::Real *">float*</type>
+      </field>
       <field name="r" access="public">
         <type native="Ns::Real">float</type>
       </field>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NestedTypeReference/NestedTypeIsNotQualifiedWithinContainer.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NestedTypeReference/NestedTypeIsNotQualifiedWithinContainer.CSharp.Latest.Windows.cs
@@ -1,0 +1,14 @@
+namespace ClangSharp.Test
+{
+    public unsafe partial struct Outer
+    {
+        public Inner field;
+
+        public Inner* fieldPtr;
+
+        public partial struct Inner
+        {
+            public int value;
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.CSharp.Compatible.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.CSharp.Compatible.cs
@@ -27,10 +27,13 @@ namespace System
         public int x;
     }
 
-    public static partial class Methods
+    public static unsafe partial class Methods
     {
         [NativeTypeName("#define IID_IOInet IID_IInternet")]
         public static ref readonly Guid IID_IOInet => ref IID_IInternet;
+
+        [NativeTypeName("#define DIPROP_BUFFERSIZE (*(const GUID *)(1))")]
+        public static ref readonly Guid DIPROP_BUFFERSIZE => ref unchecked(*(Guid*)(1));
 
         public static ref readonly Guid IID_IInternet
         {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.CSharp.Compatible.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.CSharp.Compatible.cs
@@ -33,7 +33,7 @@ namespace System
         public static ref readonly Guid IID_IOInet => ref IID_IInternet;
 
         [NativeTypeName("#define DIPROP_BUFFERSIZE (*(const GUID *)(1))")]
-        public static ref readonly Guid DIPROP_BUFFERSIZE => ref unchecked(*(Guid*)(1));
+        public static Guid* DIPROP_BUFFERSIZE => unchecked((Guid*)(1));
 
         public static ref readonly Guid IID_IInternet
         {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.CSharp.cs
@@ -39,7 +39,7 @@ namespace System
         public static ref readonly Guid IID_IOInet => ref IID_IInternet;
 
         [NativeTypeName("#define DIPROP_BUFFERSIZE (*(const GUID *)(1))")]
-        public static ref readonly Guid DIPROP_BUFFERSIZE => ref unchecked(*(Guid*)(1));
+        public static Guid* DIPROP_BUFFERSIZE => unchecked((Guid*)(1));
 
         public static ref readonly Guid IID_IInternet
         {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.CSharp.cs
@@ -33,10 +33,13 @@ namespace System
         public int x;
     }
 
-    public static partial class Methods
+    public static unsafe partial class Methods
     {
         [NativeTypeName("#define IID_IOInet IID_IInternet")]
         public static ref readonly Guid IID_IOInet => ref IID_IInternet;
+
+        [NativeTypeName("#define DIPROP_BUFFERSIZE (*(const GUID *)(1))")]
+        public static ref readonly Guid DIPROP_BUFFERSIZE => ref unchecked(*(Guid*)(1));
 
         public static ref readonly Guid IID_IInternet
         {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.Xml.Compatible.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.Xml.Compatible.xml
@@ -27,6 +27,13 @@
           <code>ref IID_IInternet</code>
         </value>
       </constant>
+      <constant name="DIPROP_BUFFERSIZE" access="public">
+        <type primitive="False">Guid</type>
+        <value>
+          <code>
+            <unchecked></unchecked>ref (*(Guid*)(1))</code>
+        </value>
+      </constant>
       <iid name="IID_IInternet" value="0x79EAC9E0, 0xBAF9, 0x11CE, 0x8C, 0x82, 0x00, 0xAA, 0x00, 0x4B, 0xA9, 0x0B" />
     </class>
   </namespace>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.Xml.Compatible.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.Xml.Compatible.xml
@@ -20,7 +20,7 @@
         <type>int</type>
       </field>
     </struct>
-    <class name="Methods" access="public" static="true">
+    <class name="Methods" access="public" static="true" unsafe="true">
       <constant name="IID_IOInet" access="public">
         <type primitive="False">Guid</type>
         <value>
@@ -28,10 +28,10 @@
         </value>
       </constant>
       <constant name="DIPROP_BUFFERSIZE" access="public">
-        <type primitive="False">Guid</type>
+        <type primitive="False">Guid*</type>
         <value>
           <code>
-            <unchecked></unchecked>ref (*(Guid*)(1))</code>
+            <unchecked></unchecked>(<value>(Guid*)(1)</value>)</code>
         </value>
       </constant>
       <iid name="IID_IInternet" value="0x79EAC9E0, 0xBAF9, 0x11CE, 0x8C, 0x82, 0x00, 0xAA, 0x00, 0x4B, 0xA9, 0x0B" />

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.Xml.xml
@@ -26,7 +26,7 @@
         <type>int</type>
       </field>
     </struct>
-    <class name="Methods" access="public" static="true">
+    <class name="Methods" access="public" static="true" unsafe="true">
       <constant name="IID_IOInet" access="public">
         <type primitive="False">Guid</type>
         <value>
@@ -34,10 +34,10 @@
         </value>
       </constant>
       <constant name="DIPROP_BUFFERSIZE" access="public">
-        <type primitive="False">Guid</type>
+        <type primitive="False">Guid*</type>
         <value>
           <code>
-            <unchecked></unchecked>ref (*(Guid*)(1))</code>
+            <unchecked></unchecked>(<value>(Guid*)(1)</value>)</code>
         </value>
       </constant>
       <iid name="IID_IInternet" value="0x79EAC9E0, 0xBAF9, 0x11CE, 0x8C, 0x82, 0x00, 0xAA, 0x00, 0x4B, 0xA9, 0x0B" />

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/StructDeclaration/GuidDefineAliasRefReadonlyTest.Xml.xml
@@ -33,6 +33,13 @@
           <code>ref IID_IInternet</code>
         </value>
       </constant>
+      <constant name="DIPROP_BUFFERSIZE" access="public">
+        <type primitive="False">Guid</type>
+        <value>
+          <code>
+            <unchecked></unchecked>ref (*(Guid*)(1))</code>
+        </value>
+      </constant>
       <iid name="IID_IInternet" value="0x79EAC9E0, 0xBAF9, 0x11CE, 0x8C, 0x82, 0x00, 0xAA, 0x00, 0x4B, 0xA9, 0x0B" />
     </class>
   </namespace>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/NamespaceNativeTypeNameTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/NamespaceNativeTypeNameTest.cs
@@ -17,8 +17,9 @@ public sealed class NamespaceNativeTypeNameTest : BaselineTest
     // clang 22's type printer omits the enclosing C++ namespace from a reference spelled from within that
     // same namespace, where-as older releases always spelled it. The generator restores the dropped
     // `Namespace::` prefix from the decl so the emitted `NativeTypeName` keeps the fully qualified source
-    // spelling for typedef, record (including by-pointer and const-qualified by-pointer), and enum
-    // references, placing the qualifier after any leading cv-qualifiers, and stays version-stable.
+    // spelling for typedef, record (including by-pointer, const-qualified, and elaborated `struct`/`enum`
+    // specifiers), and enum references, placing the qualifier after any leading cv-qualifiers or tag
+    // keywords, and stays version-stable.
     [Test]
     public Task NamespaceQualifiedNativeTypeNameIsPreservedTest()
     {
@@ -44,6 +45,9 @@ public sealed class NamespaceNativeTypeNameTest : BaselineTest
         Point* pointPtr;
         const Point* constPointPtr;
         const Real* constRealPtr;
+        struct Point* elabPointPtr;
+        const struct Point* constElabPointPtr;
+        enum Status* elabStatusPtr;
         Real r;
         Status status;
     };

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/NamespaceNativeTypeNameTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/NamespaceNativeTypeNameTest.cs
@@ -17,7 +17,8 @@ public sealed class NamespaceNativeTypeNameTest : BaselineTest
     // clang 22's type printer omits the enclosing C++ namespace from a reference spelled from within that
     // same namespace, where-as older releases always spelled it. The generator restores the dropped
     // `Namespace::` prefix from the decl so the emitted `NativeTypeName` keeps the fully qualified source
-    // spelling for typedef, record (including by-pointer), and enum references and stays version-stable.
+    // spelling for typedef, record (including by-pointer and const-qualified by-pointer), and enum
+    // references, placing the qualifier after any leading cv-qualifiers, and stays version-stable.
     [Test]
     public Task NamespaceQualifiedNativeTypeNameIsPreservedTest()
     {
@@ -41,6 +42,8 @@ public sealed class NamespaceNativeTypeNameTest : BaselineTest
     {
         Point point;
         Point* pointPtr;
+        const Point* constPointPtr;
+        const Real* constRealPtr;
         Real r;
         Status status;
     };

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
@@ -604,8 +604,9 @@ static const IID& IID_ITransferTarget = __uuidof(ITransferTarget);
             return Task.CompletedTask;
         }
 
-        // A `#define IID_X IID_Y` alias over a `ref readonly Guid` IID must keep the `ref readonly` return so it
-        // stays a zero-copy alias; dropping it leaves a by-value `Guid` return paired with a `=> ref` body.
+        // A `#define IID_X IID_Y` alias and a `#define X (*(const GUID*)(n))` computed-pointer deref (as `MAKEDIPROP`
+        // expands to) both produce a `ref`-returning body, so both must keep the `ref readonly` return; dropping it
+        // leaves a by-value `Guid` return paired with a `=> ref` body.
         var inputContents = @"#define DECLSPEC_UUID(x) __declspec(uuid(x))
 #define EXTERN_C extern ""C""
 
@@ -628,6 +629,7 @@ struct DECLSPEC_UUID(""79eac9e0-baf9-11ce-8c82-00aa004ba90b"") IInternet
 EXTERN_C const IID IID_IInternet;
 
 #define IID_IOInet IID_IInternet
+#define DIPROP_BUFFERSIZE (*(const GUID *)(1))
 ";
 
         var remappedNames = new Dictionary<string, string> { ["_GUID"] = "Guid", ["GUID"] = "Guid" };

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/StructDeclarationTest.cs
@@ -604,9 +604,9 @@ static const IID& IID_ITransferTarget = __uuidof(ITransferTarget);
             return Task.CompletedTask;
         }
 
-        // A `#define IID_X IID_Y` alias and a `#define X (*(const GUID*)(n))` computed-pointer deref (as `MAKEDIPROP`
-        // expands to) both produce a `ref`-returning body, so both must keep the `ref readonly` return; dropping it
-        // leaves a by-value `Guid` return paired with a `=> ref` body.
+        // A `#define IID_X IID_Y` alias references another constant's storage, so it stays a `ref readonly Guid`
+        // alias. A `#define X (*(const GUID*)(n))` computed-pointer deref (as `MAKEDIPROP` expands to) targets an
+        // arbitrary address, so it is exposed as a `Guid*` pointer rather than an invalid managed byref.
         var inputContents = @"#define DECLSPEC_UUID(x) __declspec(uuid(x))
 #define EXTERN_C extern ""C""
 

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/NestedTypeReferenceTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/NestedTypeReferenceTest.cs
@@ -35,4 +35,22 @@ struct B
 
         return ValidateGeneratedCSharpLatestWindowsBaselineAsync(inputContents);
     }
+
+    [Test]
+    public Task NestedTypeIsNotQualifiedWithinContainer()
+    {
+        var inputContents = @"struct Outer
+{
+    struct Inner
+    {
+        int value;
+    };
+
+    Inner field;
+    Inner* fieldPtr;
+};
+";
+
+        return ValidateGeneratedCSharpLatestWindowsBaselineAsync(inputContents);
+    }
 }


### PR DESCRIPTION
Batch 3 of the v22.1.8 regressions found regenerating `terrafx.interop.windows` (follows #826 and #827).

Three independent fixes, each with a regression test (existing tests extended -- no duplicate baselines):

----------

**Namespace qualifier placed after leading cv-qualifiers** (201x across 19 Gdiplus files)

The round-1 namespace-qualification fix prepended `Ns::` to the front of the whole declarator, ignoring leading cv-qualifiers, so a `const`-pointer parameter came out as `Gdiplus::const BlurParams *` instead of `const Gdiplus::BlurParams *`. `GetNamespaceQualifiedNativeTypeName` now skips leading `const `/`volatile ` before inserting the qualifier. `NativeTypeName`-string only (no emitted-type change), but it's an incorrect type string.

----------

**Don't qualify a nested type referenced from within its own container** (12x)

The round-1 code unconditionally qualified a nested type by its container(s), so `_u_e__Union u;` was emitted as `GDI_NONREMOTE._u_e__Union u;` even from inside `GDI_NONREMOTE`. The qualification chain now stops at the reference site's shared enclosing scope, while still qualifying genuine cross-scope references.

----------

**Keep `ref readonly` on computed-pointer GUID `#define` macros** (25x in `DirectX/um/dinput/DIPROP.cs`)

#827 fixed the `#define IID_X IID_Y` property-alias form. The same `ref readonly` drop persisted for the `#define X MAKEDIPROP(n)` form (expands to `*(const GUID*)(n)`): the body emitted a `ref`-return but the return type dropped `ref readonly`, leaving a malformed by-value `Guid` return paired with a `=> ref` body. The copy-constructor `Reference` check now also matches a pointer-dereference arg, so both ref-returning `#define` GUID forms keep `ref readonly`.

----------

Full generator suite green (4165 passed), 0 warnings. Also confirmed no action needed on the neutral v22 behavior changes (coclass `IID_`->`CLSID_` reclassification, dropped defensive `unchecked`, removed `CA1508` pragma).