### PR TITLE
Fix v22 NativeTypeName global-scope churn and inline-array field address-of

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.Naming.cs
@@ -146,6 +146,16 @@ public sealed partial class PInvokeGenerator
 
     private static string GetNamespaceQualifiedNativeTypeName(Type type, string nativeTypeName)
     {
+        // clang 22 can spell a global-scope name with a redundant leading `::` (e.g. `::boolean`)
+        // when the unqualified name is shadowed in an enclosing namespace. Drop the global-scope
+        // qualifier so the NativeTypeName stays consistent with every other unqualified spelling.
+        var globalScopeOffset = SkipLeadingTypeQualifiers(nativeTypeName);
+
+        if (nativeTypeName.AsSpan(globalScopeOffset).StartsWith("::", StringComparison.Ordinal))
+        {
+            nativeTypeName = nativeTypeName.Remove(globalScopeOffset, 2);
+        }
+
         // Peel pointer/reference/array layers so a stripped namespace is restored even for
         // `Ns::Point *` and similar, where clang only ever drops the leading `Namespace::`.
 
@@ -195,6 +205,36 @@ public sealed partial class PInvokeGenerator
     // qualifier belongs on the type name, after any leading run of these.
     private static readonly string[] s_leadingTypeQualifiers = ["const ", "volatile ", "struct ", "class ", "union ", "enum ", "__unaligned "];
 
+    // Advances past any leading run of cv-qualifiers, elaborated tag keywords, or `__unaligned` to
+    // the offset where the type's nested-name-specifier begins.
+    private static int SkipLeadingTypeQualifiers(string nativeTypeName)
+    {
+        var offset = 0;
+
+        while (true)
+        {
+            var rest = nativeTypeName.AsSpan(offset);
+            var matched = false;
+
+            foreach (var prefix in s_leadingTypeQualifiers)
+            {
+                if (rest.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    offset += prefix.Length;
+                    matched = true;
+                    break;
+                }
+            }
+
+            if (!matched)
+            {
+                break;
+            }
+        }
+
+        return offset;
+    }
+
     private static string GetNamespaceQualifiedNativeTypeName(Decl decl, string nativeTypeName)
     {
         // clang 22's type printer omits the enclosing C++ namespace from a reference when a
@@ -220,28 +260,7 @@ public sealed partial class PInvokeGenerator
         // The qualifier belongs on the type name, after any leading cv-qualifiers, elaborated tag
         // keywords, or `__unaligned`, so e.g. a `const struct` pointer stays `const struct Ns::Point *`
         // rather than the malformed `Ns::const struct Point *`.
-        var offset = 0;
-
-        while (true)
-        {
-            var rest = nativeTypeName.AsSpan(offset);
-            var matched = false;
-
-            foreach (var prefix in s_leadingTypeQualifiers)
-            {
-                if (rest.StartsWith(prefix, StringComparison.Ordinal))
-                {
-                    offset += prefix.Length;
-                    matched = true;
-                    break;
-                }
-            }
-
-            if (!matched)
-            {
-                break;
-            }
-        }
+        var offset = SkipLeadingTypeQualifiers(nativeTypeName);
 
         // The source spelling may already carry a trailing run of the namespace (a minimally
         // qualified reference, e.g. `Windows::Foundation::IPropertyValue` written inside

--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -1526,6 +1526,15 @@ public partial class PInvokeGenerator
                 }
                 else
                 {
+                    // A constant-array field decayed to a pointer projects to an `[InlineArray]`
+                    // value type, which has no implicit pointer conversion, so take its address to
+                    // bind it to a pointer. A compatible-mode fixed buffer decays on its own, and
+                    // array locals (managed arrays) or string literals must not be addressed here.
+                    if (!Config.GenerateCompatibleCode && (subExpr is MemberExpr) && (subExpr.Type.CanonicalType is ConstantArrayType) && (implicitCastExpr.Type.CanonicalType is PointerType))
+                    {
+                        outputBuilder.Write('&');
+                    }
+
                     VisitStmt(subExpr);
                 }
                 break;

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Compatible.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Compatible.Unix.cs
@@ -1,0 +1,21 @@
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct MyStruct
+    {
+        [NativeTypeName("unsigned char[16]")]
+        public fixed byte Data[16];
+    }
+
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "_Z15MyOtherFunctionPv", ExactSpelling = true)]
+        public static extern void MyOtherFunction(void* pData);
+
+        public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
+        {
+            MyOtherFunction(pStruct->Data);
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Compatible.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Compatible.Windows.cs
@@ -1,0 +1,21 @@
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public unsafe partial struct MyStruct
+    {
+        [NativeTypeName("unsigned char[16]")]
+        public fixed byte Data[16];
+    }
+
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?MyOtherFunction@@YAXPEAX@Z", ExactSpelling = true)]
+        public static extern void MyOtherFunction(void* pData);
+
+        public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
+        {
+            MyOtherFunction(pStruct->Data);
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Default.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Default.Unix.cs
@@ -1,0 +1,28 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        [NativeTypeName("unsigned char[16]")]
+        public _Data_e__FixedBuffer Data;
+
+        [InlineArray(16)]
+        public partial struct _Data_e__FixedBuffer
+        {
+            public byte e0;
+        }
+    }
+
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "_Z15MyOtherFunctionPv", ExactSpelling = true)]
+        public static extern void MyOtherFunction(void* pData);
+
+        public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
+        {
+            MyOtherFunction(&pStruct->Data);
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Default.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Default.Windows.cs
@@ -1,0 +1,28 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        [NativeTypeName("unsigned char[16]")]
+        public _Data_e__FixedBuffer Data;
+
+        [InlineArray(16)]
+        public partial struct _Data_e__FixedBuffer
+        {
+            public byte e0;
+        }
+    }
+
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?MyOtherFunction@@YAXPEAX@Z", ExactSpelling = true)]
+        public static extern void MyOtherFunction(void* pData);
+
+        public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
+        {
+            MyOtherFunction(&pStruct->Data);
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Latest.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Latest.Unix.cs
@@ -1,0 +1,28 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        [NativeTypeName("unsigned char[16]")]
+        public _Data_e__FixedBuffer Data;
+
+        [InlineArray(16)]
+        public partial struct _Data_e__FixedBuffer
+        {
+            public byte e0;
+        }
+    }
+
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "_Z15MyOtherFunctionPv", ExactSpelling = true)]
+        public static extern void MyOtherFunction(void* pData);
+
+        public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
+        {
+            MyOtherFunction(&pStruct->Data);
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Latest.Windows.cs
@@ -1,0 +1,28 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        [NativeTypeName("unsigned char[16]")]
+        public _Data_e__FixedBuffer Data;
+
+        [InlineArray(16)]
+        public partial struct _Data_e__FixedBuffer
+        {
+            public byte e0;
+        }
+    }
+
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?MyOtherFunction@@YAXPEAX@Z", ExactSpelling = true)]
+        public static extern void MyOtherFunction(void* pData);
+
+        public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
+        {
+            MyOtherFunction(&pStruct->Data);
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Preview.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Preview.Unix.cs
@@ -1,0 +1,28 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        [NativeTypeName("unsigned char[16]")]
+        public _Data_e__FixedBuffer Data;
+
+        [InlineArray(16)]
+        public partial struct _Data_e__FixedBuffer
+        {
+            public byte e0;
+        }
+    }
+
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "_Z15MyOtherFunctionPv", ExactSpelling = true)]
+        public static extern void MyOtherFunction(void* pData);
+
+        public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
+        {
+            MyOtherFunction(&pStruct->Data);
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Preview.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Preview.Windows.cs
@@ -1,0 +1,28 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClangSharp.Test
+{
+    public partial struct MyStruct
+    {
+        [NativeTypeName("unsigned char[16]")]
+        public _Data_e__FixedBuffer Data;
+
+        [InlineArray(16)]
+        public partial struct _Data_e__FixedBuffer
+        {
+            public byte e0;
+        }
+    }
+
+    public static unsafe partial class Methods
+    {
+        [DllImport("ClangSharpPInvokeGenerator", CallingConvention = CallingConvention.Cdecl, EntryPoint = "?MyOtherFunction@@YAXPEAX@Z", ExactSpelling = true)]
+        public static extern void MyOtherFunction(void* pData);
+
+        public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
+        {
+            MyOtherFunction(&pStruct->Data);
+        }
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Compatible.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Compatible.Unix.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="MyStruct" access="public" unsafe="true">
+      <field name="Data" access="public">
+        <type native="unsigned char[16]" count="16" fixed="_Data_e__FixedBuffer">byte</type>
+      </field>
+    </struct>
+    <class name="Methods" access="public" static="true">
+      <function name="MyOtherFunction" access="public" lib="ClangSharpPInvokeGenerator" convention="Cdecl" entrypoint="_Z15MyOtherFunctionPv" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pData">
+          <type>void*</type>
+        </param>
+      </function>
+      <function name="MyFunction" access="public" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pStruct">
+          <type>MyStruct*</type>
+        </param>
+        <code>MyOtherFunction(pStruct-&gt;Data);</code>
+      </function>
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Compatible.Windows.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Compatible.Windows.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="MyStruct" access="public" unsafe="true">
+      <field name="Data" access="public">
+        <type native="unsigned char[16]" count="16" fixed="_Data_e__FixedBuffer">byte</type>
+      </field>
+    </struct>
+    <class name="Methods" access="public" static="true">
+      <function name="MyOtherFunction" access="public" lib="ClangSharpPInvokeGenerator" convention="Cdecl" entrypoint="?MyOtherFunction@@YAXPEAX@Z" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pData">
+          <type>void*</type>
+        </param>
+      </function>
+      <function name="MyFunction" access="public" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pStruct">
+          <type>MyStruct*</type>
+        </param>
+        <code>MyOtherFunction(pStruct-&gt;Data);</code>
+      </function>
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Default.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Default.Unix.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="MyStruct" access="public">
+      <field name="Data" access="public">
+        <type native="unsigned char[16]" count="16" fixed="_Data_e__FixedBuffer">byte</type>
+      </field>
+      <struct name="_Data_e__FixedBuffer" access="public">
+        <attribute>InlineArray(16)</attribute>
+        <field name="e0" access="public">
+          <type>byte</type>
+        </field>
+      </struct>
+    </struct>
+    <class name="Methods" access="public" static="true">
+      <function name="MyOtherFunction" access="public" lib="ClangSharpPInvokeGenerator" convention="Cdecl" entrypoint="_Z15MyOtherFunctionPv" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pData">
+          <type>void*</type>
+        </param>
+      </function>
+      <function name="MyFunction" access="public" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pStruct">
+          <type>MyStruct*</type>
+        </param>
+        <code>MyOtherFunction(&amp;pStruct-&gt;Data);</code>
+      </function>
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Default.Windows.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Default.Windows.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="MyStruct" access="public">
+      <field name="Data" access="public">
+        <type native="unsigned char[16]" count="16" fixed="_Data_e__FixedBuffer">byte</type>
+      </field>
+      <struct name="_Data_e__FixedBuffer" access="public">
+        <attribute>InlineArray(16)</attribute>
+        <field name="e0" access="public">
+          <type>byte</type>
+        </field>
+      </struct>
+    </struct>
+    <class name="Methods" access="public" static="true">
+      <function name="MyOtherFunction" access="public" lib="ClangSharpPInvokeGenerator" convention="Cdecl" entrypoint="?MyOtherFunction@@YAXPEAX@Z" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pData">
+          <type>void*</type>
+        </param>
+      </function>
+      <function name="MyFunction" access="public" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pStruct">
+          <type>MyStruct*</type>
+        </param>
+        <code>MyOtherFunction(&amp;pStruct-&gt;Data);</code>
+      </function>
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Latest.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Latest.Unix.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="MyStruct" access="public">
+      <field name="Data" access="public">
+        <type native="unsigned char[16]" count="16" fixed="_Data_e__FixedBuffer">byte</type>
+      </field>
+      <struct name="_Data_e__FixedBuffer" access="public">
+        <attribute>InlineArray(16)</attribute>
+        <field name="e0" access="public">
+          <type>byte</type>
+        </field>
+      </struct>
+    </struct>
+    <class name="Methods" access="public" static="true">
+      <function name="MyOtherFunction" access="public" lib="ClangSharpPInvokeGenerator" convention="Cdecl" entrypoint="_Z15MyOtherFunctionPv" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pData">
+          <type>void*</type>
+        </param>
+      </function>
+      <function name="MyFunction" access="public" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pStruct">
+          <type>MyStruct*</type>
+        </param>
+        <code>MyOtherFunction(&amp;pStruct-&gt;Data);</code>
+      </function>
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Latest.Windows.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Latest.Windows.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="MyStruct" access="public">
+      <field name="Data" access="public">
+        <type native="unsigned char[16]" count="16" fixed="_Data_e__FixedBuffer">byte</type>
+      </field>
+      <struct name="_Data_e__FixedBuffer" access="public">
+        <attribute>InlineArray(16)</attribute>
+        <field name="e0" access="public">
+          <type>byte</type>
+        </field>
+      </struct>
+    </struct>
+    <class name="Methods" access="public" static="true">
+      <function name="MyOtherFunction" access="public" lib="ClangSharpPInvokeGenerator" convention="Cdecl" entrypoint="?MyOtherFunction@@YAXPEAX@Z" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pData">
+          <type>void*</type>
+        </param>
+      </function>
+      <function name="MyFunction" access="public" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pStruct">
+          <type>MyStruct*</type>
+        </param>
+        <code>MyOtherFunction(&amp;pStruct-&gt;Data);</code>
+      </function>
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Preview.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Preview.Unix.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="MyStruct" access="public">
+      <field name="Data" access="public">
+        <type native="unsigned char[16]" count="16" fixed="_Data_e__FixedBuffer">byte</type>
+      </field>
+      <struct name="_Data_e__FixedBuffer" access="public">
+        <attribute>InlineArray(16)</attribute>
+        <field name="e0" access="public">
+          <type>byte</type>
+        </field>
+      </struct>
+    </struct>
+    <class name="Methods" access="public" static="true">
+      <function name="MyOtherFunction" access="public" lib="ClangSharpPInvokeGenerator" convention="Cdecl" entrypoint="_Z15MyOtherFunctionPv" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pData">
+          <type>void*</type>
+        </param>
+      </function>
+      <function name="MyFunction" access="public" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pStruct">
+          <type>MyStruct*</type>
+        </param>
+        <code>MyOtherFunction(&amp;pStruct-&gt;Data);</code>
+      </function>
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Preview.Windows.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Preview.Windows.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="MyStruct" access="public">
+      <field name="Data" access="public">
+        <type native="unsigned char[16]" count="16" fixed="_Data_e__FixedBuffer">byte</type>
+      </field>
+      <struct name="_Data_e__FixedBuffer" access="public">
+        <attribute>InlineArray(16)</attribute>
+        <field name="e0" access="public">
+          <type>byte</type>
+        </field>
+      </struct>
+    </struct>
+    <class name="Methods" access="public" static="true">
+      <function name="MyOtherFunction" access="public" lib="ClangSharpPInvokeGenerator" convention="Cdecl" entrypoint="?MyOtherFunction@@YAXPEAX@Z" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pData">
+          <type>void*</type>
+        </param>
+      </function>
+      <function name="MyFunction" access="public" static="true" unsafe="true">
+        <type>void</type>
+        <param name="pStruct">
+          <type>MyStruct*</type>
+        </param>
+        <code>MyOtherFunction(&amp;pStruct-&gt;Data);</code>
+      </function>
+    </class>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/GlobalScopeQualifierIsStrippedTest.CSharp.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/GlobalScopeQualifierIsStrippedTest.CSharp.cs
@@ -1,0 +1,13 @@
+namespace ClangSharp.Test
+{
+    public partial struct @boolean
+    {
+        public int x;
+    }
+
+    public unsafe partial struct Holder
+    {
+        [NativeTypeName("boolean *")]
+        public byte* globalPtr;
+    }
+}

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/GlobalScopeQualifierIsStrippedTest.Xml.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/NamespaceNativeTypeName/GlobalScopeQualifierIsStrippedTest.Xml.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<bindings>
+  <namespace name="ClangSharp.Test">
+    <struct name="@boolean" access="public">
+      <field name="x" access="public">
+        <type>int</type>
+      </field>
+    </struct>
+    <struct name="Holder" access="public" unsafe="true">
+      <field name="globalPtr" access="public">
+        <type native="boolean *">byte*</type>
+      </field>
+    </struct>
+  </namespace>
+</bindings>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/FunctionDeclarationBodyImportTest.cs
@@ -44,6 +44,28 @@ void MyFunction()
         return ValidateAsync(nameof(ArraySubscriptTest), inputContents);
     }
 
+    // A constant-array field projects to an `[InlineArray]` value type, which has no implicit
+    // pointer conversion, so a decay to a pointer argument must take its address (`&pStruct->Data`).
+    // A compatible-mode fixed buffer decays to a pointer on its own, so it stays unaddressed.
+    [Test]
+    public Task ArrayFieldToPointerArgumentTest()
+    {
+        var inputContents = @"void MyOtherFunction(void* pData);
+
+struct MyStruct
+{
+    unsigned char Data[16];
+};
+
+void MyFunction(struct MyStruct* pStruct)
+{
+    MyOtherFunction(pStruct->Data);
+}
+";
+
+        return ValidateAsync(nameof(ArrayFieldToPointerArgumentTest), inputContents);
+    }
+
     [Test]
     public Task BasicTest()
     {

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/NamespaceNativeTypeNameTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/NamespaceNativeTypeNameTest.cs
@@ -100,4 +100,30 @@ public sealed class NamespaceNativeTypeNameTest : BaselineTest
 
         return ValidateAsync(nameof(PartiallyQualifiedNamespaceIsNotDuplicatedTest), inputContents);
     }
+
+    // clang 22 can spell a global-scope reference with a redundant leading `::` (e.g. `::boolean`)
+    // when the unqualified name is shadowed by a type in the enclosing namespace. The generator
+    // drops that global-scope qualifier so the `NativeTypeName` stays consistent with every other
+    // unqualified spelling rather than churning to `::boolean`.
+    [Test]
+    public Task GlobalScopeQualifierIsStrippedTest()
+    {
+        var inputContents = @"typedef unsigned char boolean;
+
+namespace Ns
+{
+    struct boolean
+    {
+        int x;
+    };
+
+    struct Holder
+    {
+        ::boolean* globalPtr;
+    };
+}
+";
+
+        return ValidateAsync(nameof(GlobalScopeQualifierIsStrippedTest), inputContents);
+    }
 }


### PR DESCRIPTION
Two independent v22.1.8 regen regressions found regenerating `terrafx.interop.windows`, both fallout from the round-1 namespace-qualifier / address-of work.

----------

**Strip the redundant global-scope qualifier from NativeTypeName**

clang 22 spells a name with a leading `::` when the unqualified name is shadowed by a type in an enclosing namespace, and we passed it through verbatim -- e.g. `[NativeTypeName("::boolean *")]`. The C# type is correctly `byte*`, but the qualifier is spurious churn that is inconsistent with the ~874 other unqualified `boolean` sites. Strip a leading global-scope `::` at the type-name position (after cv/tag qualifiers) so `::boolean *` normalizes to `boolean *`. The refactor also extracts the leading-qualifier skip into a shared `SkipLeadingTypeQualifiers` helper.

----------

**Take the address of an inline-array field decayed to a pointer**

An array-to-pointer decay of an inline-array field was emitted unaddressed, e.g. `NativeMemory.Fill(a->u.Byte, ...)`. That does **not** compile in Default/Latest/Preview because an `[InlineArray]` field has no implicit `void*` conversion (CS1503). Emit the `&` when a `MemberExpr` of `ConstantArrayType` decays to a pointer, except in compatible mode where the `fixed` buffer decays naturally (adding `&` there would be `T**`). Restricting to `MemberExpr` leaves managed-array locals and explicit source `&` untouched -- locals need `fixed`/pinning, not `&`.

----------

Added regression tests `GlobalScopeQualifierIsStrippedTest` and `ArrayFieldToPointerArgumentTest` with unified baselines. Full suite green (4205 passed, 0 failed), zero existing-baseline churn.