### PR TITLE
Don't take the address of a subscripted inline-array field

### DIFF
--- a/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
+++ b/sources/ClangSharp.PInvokeGenerator/PInvokeGenerator.VisitStmt.cs
@@ -1530,7 +1530,9 @@ public partial class PInvokeGenerator
                     // value type, which has no implicit pointer conversion, so take its address to
                     // bind it to a pointer. A compatible-mode fixed buffer decays on its own, and
                     // array locals (managed arrays) or string literals must not be addressed here.
-                    if (!Config.GenerateCompatibleCode && (subExpr is MemberExpr) && (subExpr.Type.CanonicalType is ConstantArrayType) && (implicitCastExpr.Type.CanonicalType is PointerType))
+                    // A subscripted field (`arr[i]`) indexes the inline array in place, so the decay
+                    // there is an lvalue that must not be addressed.
+                    if (!Config.GenerateCompatibleCode && (subExpr is MemberExpr) && (subExpr.Type.CanonicalType is ConstantArrayType) && (implicitCastExpr.Type.CanonicalType is PointerType) && !IsPrevContextStmt<ArraySubscriptExpr>(out _, out _))
                     {
                         outputBuilder.Write('&');
                     }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Compatible.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Compatible.Unix.cs
@@ -16,6 +16,7 @@ namespace ClangSharp.Test
         public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
         {
             MyOtherFunction(pStruct->Data);
+            pStruct->Data[15] = 1;
         }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Compatible.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Compatible.Windows.cs
@@ -16,6 +16,7 @@ namespace ClangSharp.Test
         public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
         {
             MyOtherFunction(pStruct->Data);
+            pStruct->Data[15] = 1;
         }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Default.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Default.Unix.cs
@@ -23,6 +23,7 @@ namespace ClangSharp.Test
         public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
         {
             MyOtherFunction(&pStruct->Data);
+            pStruct->Data[15] = 1;
         }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Default.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Default.Windows.cs
@@ -23,6 +23,7 @@ namespace ClangSharp.Test
         public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
         {
             MyOtherFunction(&pStruct->Data);
+            pStruct->Data[15] = 1;
         }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Latest.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Latest.Unix.cs
@@ -23,6 +23,7 @@ namespace ClangSharp.Test
         public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
         {
             MyOtherFunction(&pStruct->Data);
+            pStruct->Data[15] = 1;
         }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Latest.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Latest.Windows.cs
@@ -23,6 +23,7 @@ namespace ClangSharp.Test
         public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
         {
             MyOtherFunction(&pStruct->Data);
+            pStruct->Data[15] = 1;
         }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Preview.Unix.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Preview.Unix.cs
@@ -23,6 +23,7 @@ namespace ClangSharp.Test
         public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
         {
             MyOtherFunction(&pStruct->Data);
+            pStruct->Data[15] = 1;
         }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Preview.Windows.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.CSharp.Preview.Windows.cs
@@ -23,6 +23,7 @@ namespace ClangSharp.Test
         public static void MyFunction([NativeTypeName("struct MyStruct *")] MyStruct* pStruct)
         {
             MyOtherFunction(&pStruct->Data);
+            pStruct->Data[15] = 1;
         }
     }
 }

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Compatible.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Compatible.Unix.xml
@@ -18,7 +18,8 @@
         <param name="pStruct">
           <type>MyStruct*</type>
         </param>
-        <code>MyOtherFunction(pStruct-&gt;Data);</code>
+        <code>MyOtherFunction(pStruct-&gt;Data);
+      pStruct-&gt;Data[15] = 1;</code>
       </function>
     </class>
   </namespace>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Compatible.Windows.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Compatible.Windows.xml
@@ -18,7 +18,8 @@
         <param name="pStruct">
           <type>MyStruct*</type>
         </param>
-        <code>MyOtherFunction(pStruct-&gt;Data);</code>
+        <code>MyOtherFunction(pStruct-&gt;Data);
+      pStruct-&gt;Data[15] = 1;</code>
       </function>
     </class>
   </namespace>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Default.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Default.Unix.xml
@@ -24,7 +24,8 @@
         <param name="pStruct">
           <type>MyStruct*</type>
         </param>
-        <code>MyOtherFunction(&amp;pStruct-&gt;Data);</code>
+        <code>MyOtherFunction(&amp;pStruct-&gt;Data);
+      pStruct-&gt;Data[15] = 1;</code>
       </function>
     </class>
   </namespace>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Default.Windows.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Default.Windows.xml
@@ -24,7 +24,8 @@
         <param name="pStruct">
           <type>MyStruct*</type>
         </param>
-        <code>MyOtherFunction(&amp;pStruct-&gt;Data);</code>
+        <code>MyOtherFunction(&amp;pStruct-&gt;Data);
+      pStruct-&gt;Data[15] = 1;</code>
       </function>
     </class>
   </namespace>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Latest.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Latest.Unix.xml
@@ -24,7 +24,8 @@
         <param name="pStruct">
           <type>MyStruct*</type>
         </param>
-        <code>MyOtherFunction(&amp;pStruct-&gt;Data);</code>
+        <code>MyOtherFunction(&amp;pStruct-&gt;Data);
+      pStruct-&gt;Data[15] = 1;</code>
       </function>
     </class>
   </namespace>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Latest.Windows.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Latest.Windows.xml
@@ -24,7 +24,8 @@
         <param name="pStruct">
           <type>MyStruct*</type>
         </param>
-        <code>MyOtherFunction(&amp;pStruct-&gt;Data);</code>
+        <code>MyOtherFunction(&amp;pStruct-&gt;Data);
+      pStruct-&gt;Data[15] = 1;</code>
       </function>
     </class>
   </namespace>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Preview.Unix.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Preview.Unix.xml
@@ -24,7 +24,8 @@
         <param name="pStruct">
           <type>MyStruct*</type>
         </param>
-        <code>MyOtherFunction(&amp;pStruct-&gt;Data);</code>
+        <code>MyOtherFunction(&amp;pStruct-&gt;Data);
+      pStruct-&gt;Data[15] = 1;</code>
       </function>
     </class>
   </namespace>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Preview.Windows.xml
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/Baselines/FunctionDeclarationBodyImport/ArrayFieldToPointerArgumentTest.Xml.Preview.Windows.xml
@@ -24,7 +24,8 @@
         <param name="pStruct">
           <type>MyStruct*</type>
         </param>
-        <code>MyOtherFunction(&amp;pStruct-&gt;Data);</code>
+        <code>MyOtherFunction(&amp;pStruct-&gt;Data);
+      pStruct-&gt;Data[15] = 1;</code>
       </function>
     </class>
   </namespace>

--- a/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/FunctionDeclarationBodyImportTest.cs
+++ b/tests/ClangSharp.PInvokeGenerator.UnitTests/Baseline/FunctionDeclarationBodyImportTest.cs
@@ -60,6 +60,7 @@ struct MyStruct
 void MyFunction(struct MyStruct* pStruct)
 {
     MyOtherFunction(pStruct->Data);
+    pStruct->Data[15] = 1;
 }
 ";
 


### PR DESCRIPTION
Follow-up to #830. That PR added the address-of for an inline-array field decayed to a pointer, but the same logic also fired on a subscripted field lvalue.

`IN6_SET_ADDR_LOOPBACK` emitted:
```diff
 NativeMemory.Fill(&a->u.Byte, (uint)(sizeof(IN6_ADDR)), 0); // correct
-a->u.Byte[15] = 1;
+&a->u.Byte[15] = 1; // CS0131
```

A subscript indexes the inline array in place, so the decay feeding it is an lvalue, not a pointer bind. Skip the address-of when the decayed field is the base of an `ArraySubscriptExpr` (via `IsPrevContextStmt<ArraySubscriptExpr>`); the call-argument case still gets `&`, and compatible mode is unaffected.

Verified across all four configs: Default/Latest/Preview keep `&pStruct->Data` on the argument and emit a clean `pStruct->Data[15] = 1`; Compatible has no `&` on either. Extended `ArrayFieldToPointerArgumentTest` with the subscript assignment; full suite green (4205 passed, 0 failed).